### PR TITLE
bs: Rename MODE_DEBUG to BUILD_MODE_DEBUG

### DIFF
--- a/framework/src/fwk_assert.c
+++ b/framework/src/fwk_assert.c
@@ -11,7 +11,7 @@
 
 void fwk_trap(void)
 {
-    #ifdef MODE_DEBUG
+    #ifdef BUILD_MODE_DEBUG
         /*
          * Disable interrupts to ensure the program state cannot be disturbed by
          * interrupt handlers.
@@ -27,7 +27,7 @@ void fwk_trap(void)
 
 void fwk_unreachable(void)
 {
-    #ifdef MODE_DEBUG
+    #ifdef BUILD_MODE_DEBUG
         fwk_trap();
     #else
         /*
@@ -40,7 +40,7 @@ void fwk_unreachable(void)
 bool fwk_expect(bool condition)
 {
     /* Failed expectations are potentially recoverable */
-    #if defined(MODE_DEBUG) && !defined(BUILD_TESTS)
+    #if defined(BUILD_MODE_DEBUG) && !defined(BUILD_TESTS)
         if (!condition)
             fwk_trap();
     #endif

--- a/framework/src/fwk_dlist.c
+++ b/framework/src/fwk_dlist.c
@@ -56,7 +56,7 @@ struct fwk_dlist_node *__fwk_dlist_pop_head(struct fwk_dlist *list)
     popped = (struct fwk_dlist_node *)__fwk_slist_pop_head(
         (struct fwk_slist *)list);
 
-#ifdef MODE_DEBUG
+#ifdef BUILD_MODE_DEBUG
     if (popped != NULL)
         popped->prev = NULL;
 #endif
@@ -81,7 +81,7 @@ void __fwk_dlist_remove(
     node->prev->next = node->next;
     node->next->prev = node->prev;
 
-#ifdef MODE_DEBUG
+#ifdef BUILD_MODE_DEBUG
     node->prev = NULL;
     node->next = NULL;
 #endif

--- a/framework/src/fwk_slist.c
+++ b/framework/src/fwk_slist.c
@@ -90,7 +90,7 @@ struct fwk_slist_node *__fwk_slist_pop_head(struct fwk_slist *list)
 
     list->head = popped->next;
 
-#ifdef MODE_DEBUG
+#ifdef BUILD_MODE_DEBUG
     popped->next = NULL;
 #endif
 
@@ -124,7 +124,7 @@ void __fwk_slist_remove(
             node_iter->next = node->next;
             if (node->next == (struct fwk_slist_node *)list)
                 list->tail = (struct fwk_slist_node *)node_iter;
-        #ifdef MODE_DEBUG
+        #ifdef BUILD_MODE_DEBUG
             node->next = NULL;
         #endif
             return;

--- a/product/sgm775/scp_romfw/config_sds.c
+++ b/product/sgm775/scp_romfw/config_sds.c
@@ -81,7 +81,7 @@ static const struct fwk_element sds_element_table[] = {
             .finalize = true,
         }),
     },
-#ifdef MODE_DEBUG
+#ifdef BUILD_MODE_DEBUG
     {
         .name = "Boot Counters",
         .data = &((struct mod_sds_structure_desc) {

--- a/tools/build_system/doc.md
+++ b/tools/build_system/doc.md
@@ -189,7 +189,7 @@ and assembly units:
 * __BUILD_STRING__ - A string containing build information (date, time and git
   commit). The string is assembled using the tool build_string.py.
 * __BUILD_TESTS__ - Set when building the framework unit tests.
-* __MODE_DEBUG__ - Set when building in debug mode.
+* __BUILD_MODE_DEBUG__ - Set when building in debug mode.
 * __NDEBUG__ - Set when building in release mode. This definition is used by the
   standard C library to disable the assert() support.
 * __BUILD_VERSION_MAJOR__ - Major version number.

--- a/tools/build_system/rules.mk
+++ b/tools/build_system/rules.mk
@@ -104,7 +104,7 @@ ifeq ($(MODE),release)
 else
     O ?= $(DEFAULT_OPT_GCC_DEBUG)
 
-    DEFINES += MODE_DEBUG
+    DEFINES += BUILD_MODE_DEBUG
 endif
 
 #

--- a/tools/build_system/test.mk
+++ b/tools/build_system/test.mk
@@ -23,7 +23,7 @@ CFLAGS += -Wno-strict-aliasing
 CFLAGS += -std=c11
 CFLAGS += $(addprefix -I,$(INCLUDES))
 
-DEFINES += MODE_DEBUG
+DEFINES += BUILD_MODE_DEBUG
 DEFINES += BUILD_TESTS
 
 # Search path for C sources


### PR DESCRIPTION
Renamed as all symbols/define exposed by the build system should
have the prefix BUILD_ in their names.

Change-Id: I8893121b32c31584a163a991547925cc028ee1c9
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>