### PR TITLE
pik_clock: make divider value check limit as configurable parameter

### DIFF
--- a/module/pik_clock/include/mod_pik_clock.h
+++ b/module/pik_clock/include/mod_pik_clock.h
@@ -195,6 +195,25 @@ enum mod_pik_clock_dmcclk_source {
 };
 
 /*!
+ * \brief Divider bitfield width.
+ */
+enum mod_pik_clock_divider_bitfield_width {
+    /*! PIK clock with 4-bit divider. */
+    MOD_PIK_CLOCK_DIVIDER_BITFIELD_WIDTH_4BITS = 4,
+    /*! PIK clock with 5-bit divider. */
+    MOD_PIK_CLOCK_DIVIDER_BITFIELD_WIDTH_5BITS = 5,
+};
+
+/*!
+ * \brief PIK clock module configuration.
+ */
+struct mod_pik_clock_module_config {
+    /*! The maximum divider value. */
+    unsigned int divider_max;
+};
+
+
+/*!
  * \brief Rate lookup entry.
  */
 struct mod_pik_clock_rate {


### PR DESCRIPTION
PIK clock divider value limit checking is hardcoded to 16 with
4-bit assumption. However many mobile & infra platforms has
5-bit divider.

This patch fixes the issue by adding a configurable module parameter
so that the platform's config file can set the divider bitfield size
based on platform.

Additionally, if platform does not provide module configuration data,
then the divider limit is set to a default value of 5-bits.

Change-Id: I70103ec84eacc2d26be999ca6524878bff51dd9d
Signed-off-by: Manoj Kumar <manoj.kumar3@arm.com>