### PR TITLE
dlist: fix pop_head to work for any size dlist

### DIFF
--- a/framework/src/fwk_dlist.c
+++ b/framework/src/fwk_dlist.c
@@ -49,11 +49,10 @@ struct fwk_dlist_node *__fwk_dlist_pop_head(struct fwk_dlist *list)
 
     assert(list != NULL);
 
-    if (list->tail == list->head->next)
-        list->head->next->prev = (struct fwk_dlist_node *)list;
-
     popped = (struct fwk_dlist_node *)__fwk_slist_pop_head(
         (struct fwk_slist *)list);
+
+    list->head->prev = (struct fwk_dlist_node *)list;
 
 #ifdef BUILD_MODE_DEBUG
     if (popped != NULL)

--- a/framework/test/test_fwk_list_pop.c
+++ b/framework/test/test_fwk_list_pop.c
@@ -14,8 +14,8 @@
 static struct fwk_slist slist;
 static struct fwk_dlist dlist;
 
-static struct fwk_slist_node snodes[2];
-static struct fwk_dlist_node dnodes[2];
+static struct fwk_slist_node snodes[3];
+static struct fwk_dlist_node dnodes[3];
 
 static void test_case_setup(void)
 {
@@ -59,7 +59,7 @@ static void test_dlist_pop_head_on_one(void)
     assert(dlist.tail == (struct fwk_dlist_node *)&dlist);
 }
 
-static void test_slist_pop_head_on_many(void)
+static void test_slist_pop_head_on_two(void)
 {
     fwk_list_push_tail(&slist, &snodes[0]);
     fwk_list_push_tail(&slist, &snodes[1]);
@@ -72,7 +72,7 @@ static void test_slist_pop_head_on_many(void)
     assert(snodes[1].next == (struct fwk_slist_node *)&slist);
 }
 
-static void test_dlist_pop_head_on_many(void)
+static void test_dlist_pop_head_on_two(void)
 {
     fwk_list_push_tail(&dlist, &dnodes[0]);
     fwk_list_push_tail(&dlist, &dnodes[1]);
@@ -82,8 +82,40 @@ static void test_dlist_pop_head_on_many(void)
     assert(dlist.head == &dnodes[1]);
     assert(dlist.tail == &dnodes[1]);
 
-    assert(dnodes[1].next == (struct fwk_dlist_node *)&dlist);
     assert(dnodes[1].prev == (struct fwk_dlist_node *)&dlist);
+    assert(dnodes[1].next == (struct fwk_dlist_node *)&dlist);
+}
+
+static void test_slist_pop_head_on_many(void)
+{
+    fwk_list_push_tail(&slist, &snodes[0]);
+    fwk_list_push_tail(&slist, &snodes[1]);
+    fwk_list_push_tail(&slist, &snodes[2]);
+
+    assert(fwk_list_pop_head(&slist) == &snodes[0]);
+
+    assert(slist.head == &snodes[1]);
+    assert(slist.tail == &snodes[2]);
+
+    assert(snodes[1].next == &snodes[2]);
+    assert(snodes[2].next == (struct fwk_slist_node *)&slist);
+}
+
+static void test_dlist_pop_head_on_many(void)
+{
+    fwk_list_push_tail(&dlist, &dnodes[0]);
+    fwk_list_push_tail(&dlist, &dnodes[1]);
+    fwk_list_push_tail(&dlist, &dnodes[2]);
+
+    assert(fwk_list_pop_head(&dlist) == &dnodes[0]);
+
+    assert(dlist.head == &dnodes[1]);
+    assert(dlist.tail == &dnodes[2]);
+
+    assert(dnodes[1].prev == (struct fwk_dlist_node *)&dlist);
+    assert(dnodes[1].next == &dnodes[2]);
+    assert(dnodes[2].next == (struct fwk_dlist_node *)&dlist);
+    assert(dnodes[2].prev == &dnodes[1]);
 }
 
 static const struct fwk_test_case_desc test_case_table[] = {
@@ -91,6 +123,8 @@ static const struct fwk_test_case_desc test_case_table[] = {
     FWK_TEST_CASE(test_dlist_pop_head_on_empty),
     FWK_TEST_CASE(test_slist_pop_head_on_one),
     FWK_TEST_CASE(test_dlist_pop_head_on_one),
+    FWK_TEST_CASE(test_slist_pop_head_on_two),
+    FWK_TEST_CASE(test_dlist_pop_head_on_two),
     FWK_TEST_CASE(test_slist_pop_head_on_many),
     FWK_TEST_CASE(test_dlist_pop_head_on_many),
 };


### PR DESCRIPTION
If a dlist contained more than two nodes, the previous link
of the new list head was not updated and pointed still to the
popped head.

Change-Id: I19507a6910d714f441290db8de5481113847370d
Signed-off-by: Elieva Pignat <Elieva.Pignat@arm.com>