### PR TITLE
build: Disable generation of unaligned accesses

### DIFF
--- a/tools/build_system/cpu.mk
+++ b/tools/build_system/cpu.mk
@@ -21,6 +21,7 @@ ifneq ($(findstring $(BS_FIRMWARE_CPU),$(ARMV7M_CPUS)),)
     $(call add_once,CFLAGS_CLANG,--target=arm-arm-none-eabi)
 
     CFLAGS += -mfloat-abi=soft # No hardware floating point support
+    CFLAGS += -mno-unaligned-access # Disable unaligned access code generation
 else ifeq ($(BS_FIRMWARE_CPU),host)
     BS_ARCH_ARCH := host
 


### PR DESCRIPTION
CCR.UNALIGN_TRP is enabled, and will trap any unaligned access. We need
to ensure the compiler does not generate them.

Change-Id: Ia0166578c00fa53399aa9823eec8f166b70b0762
Signed-off-by: Chris Kay <chris.kay@arm.com>