### PR TITLE
pik_clock: fix compiler warning when building with GCC-7 compiler

### DIFF
--- a/module/pik_clock/src/mod_pik_clock.c
+++ b/module/pik_clock/src/mod_pik_clock.c
@@ -554,6 +554,7 @@ static const struct mod_clock_drv_api api_clock = {
  * Direct driver API functions
  */
 
+#if BUILD_HAS_MOD_CSS_CLOCK
 static int pik_clock_direct_set_div(fwk_id_t clock_id, uint32_t divider_type,
                                     uint32_t divider)
 {
@@ -656,6 +657,7 @@ static const struct mod_css_clock_direct_api api_direct = {
     .set_mod = pik_clock_direct_set_mod,
     .process_power_transition = pik_clock_direct_power_state_change,
 };
+#endif
 
 /*
  * Framework handler functions


### PR DESCRIPTION
This patch fixes compiler warning that arises when building firmware
without css_clock module and with GCC 7 compiler.

Change-Id: I5b55a51ac4de827a2ae7332043efa92edf4853da
Signed-off-by: Manoj Kumar <manoj.kumar3@arm.com>