### PR TITLE
build: Name firmware bin and elf file by the name of the firmware

### DIFF
--- a/tools/build_system/firmware.mk
+++ b/tools/build_system/firmware.mk
@@ -80,7 +80,7 @@ OBJ_DIR := $(BUILD_FIRMWARE_DIR)/$(MODE)/obj
 PRODUCT_MODULES_DIR := $(PRODUCT_DIR)/module
 FIRMWARE_DIR := $(PRODUCT_DIR)/$(FIRMWARE)
 
-TARGET := $(BIN_DIR)/firmware
+TARGET := $(BIN_DIR)/$(FIRMWARE)
 TARGET_BIN := $(TARGET).bin
 TARGET_ELF := $(TARGET).elf
 
@@ -297,5 +297,5 @@ $(SCATTER_PP): $(SCATTER_SRC) | $$(@D)/
 $(TARGET_BIN): $(TARGET_ELF) | $$(@D)/
 	$(call show-action,BIN,$@)
 	$(OBJCOPY) $< $(OCFLAGS) $@
-
+	cp $@ $(BIN_DIR)/firmware.bin
 endif


### PR DESCRIPTION
Having different file names makes it easier to differentiate
the firmware binaries. It also removes the need for renaming
them when they are placed in a common directory.

The firmware.bin binary file is still generated by the build
system. A subsequent patch will remove its generation giving
time to remove any dependency on it.

Change-Id: Id38c20d667f802f18abf090b0c331b796c2ce23d
Signed-off-by: Ronald Cron <ronald.cron@arm.com>