### PR TITLE
n1sdp: Fix armclang compilation issues

### DIFF
--- a/product/n1sdp/module/n1sdp_flash/include/internal/n1sdp_flash_layout.h
+++ b/product/n1sdp/module/n1sdp_flash/include/internal/n1sdp_flash_layout.h
@@ -32,7 +32,7 @@ struct n1sdp_flash_toc_entry {
     uint32_t size;
     uint32_t flags:16;
     uint32_t checksum:16;
-} __packed;
+} __attribute__((packed));
 
 /* Flash Table of contents (TOC) */
 struct n1sdp_flash_memory_toc {
@@ -45,7 +45,7 @@ struct n1sdp_flash_memory_toc {
     uint32_t entry_count:16;
     uint32_t checksum:16;
     struct n1sdp_flash_toc_entry entry[];
-} __packed;
+} __attribute__((packed));
 
 
 /*
@@ -77,7 +77,7 @@ struct n1sdp_fip_toc_entry {
     uint32_t flags;
     uint32_t image_checksum:16;
     uint32_t checksum:16;
-} __packed;
+} __attribute__((packed));
 
 /* NFIP Table of contents (TOC) */
 struct n1sdp_fip_memory_toc {
@@ -90,6 +90,6 @@ struct n1sdp_fip_memory_toc {
     uint32_t entry_count:16;
     uint32_t checksum:16;
     struct n1sdp_fip_toc_entry entry[];
-} __packed;
+} __attribute__((packed));
 
 #endif /* N1SDP_FLASH_LAYOUT_H */

--- a/product/n1sdp/scp_ramfw/config_sds.c
+++ b/product/n1sdp/scp_ramfw/config_sds.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <assert.h>
 #include <stdbool.h>
+#include <fwk_assert.h>
 #include <fwk_element.h>
 #include <fwk_macros.h>
 #include <fwk_module.h>

--- a/tools/check_style.py
+++ b/tools/check_style.py
@@ -60,6 +60,7 @@ IGNORED_TYPES = [
     'LINE_SPACING',  # We don't require a blank line after declarations
     'SPLIT_STRING',  # We allow strings to be split across lines
     'FILE_PATH_CHANGES',  # Specific to the kernel development process
+    'PREFER_PACKED',  # __packed is not available in Arm Compiler 6
 ]
 
 error_count = 0

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -164,11 +164,36 @@ def main():
     banner('Test building n1sdp product')
 
     cmd = \
-        'CC=arm-none-eabi-gcc CROSS_COMPILE=arm-none-eabi- ' \
+        'CC=arm-none-eabi-gcc ' \
         'PRODUCT=n1sdp ' \
+        'MODE=debug ' \
         'make clean all'
     result = subprocess.call(cmd, shell=True)
-    results.append(('Product n1sdp build (GCC)', result))
+    results.append(('Product n1sdp debug build (GCC)', result))
+
+    cmd = \
+        'CC=armclang ' \
+        'PRODUCT=n1sdp ' \
+        'MODE=debug ' \
+        'make clean all'
+    result = subprocess.call(cmd, shell=True)
+    results.append(('Product n1sdp debug build (ARM)', result))
+
+    cmd = \
+        'CC=arm-none-eabi-gcc ' \
+        'PRODUCT=n1sdp ' \
+        'MODE=release ' \
+        'make clean all'
+    result = subprocess.call(cmd, shell=True)
+    results.append(('Product n1sdp release build (GCC)', result))
+
+    cmd = \
+        'CC=armclang ' \
+        'PRODUCT=n1sdp ' \
+        'MODE=release ' \
+        'make clean all'
+    result = subprocess.call(cmd, shell=True)
+    results.append(('Product n1sdp release build (ARM)', result))
 
     banner('Test building clark product')
 


### PR DESCRIPTION
Some of the syntax used in N1SDP is incompatible with Arm Compiler 6, including __packed and static_assert (without <fwk_assert.h>).

This commit also adds the relevant missing CI build tests.