### PR TITLE
system_power: Fix extended PPU support

### DIFF
--- a/module/system_power/src/mod_system_power.c
+++ b/module/system_power/src/mod_system_power.c
@@ -32,7 +32,7 @@ struct system_power_ctx {
     const struct mod_pd_driver_api *sys1_api;
 
     /* Pointer to array of extended PPU power domain driver APIs */
-    const struct mod_pd_driver_api *ext_ppu_apis;
+    const struct mod_pd_driver_api **ext_ppu_apis;
 
     /* Power domain module restricted API pointer */
     const struct mod_pd_restricted_api *mod_pd_restricted_api;
@@ -65,7 +65,7 @@ static void ext_ppus_set_state(enum mod_pd_state state)
     unsigned int i;
 
     for (i = 0; i < system_power_ctx.config->ext_ppus_count; i++) {
-        system_power_ctx.ext_ppu_apis[i].set_state(
+        system_power_ctx.ext_ppu_apis[i]->set_state(
             system_power_ctx.config->ext_ppus[i].ppu_id,
             state);
     }


### PR DESCRIPTION
This patch fixes an issue in the support for extended PPU handling in
system_power, where the ext_ppu_apis field represented a pointer to an
API structure, whilst being initialised like a pointer to an array of
pointers to API structures.

This manifested itself in a crash whenever the module tried to iterate
over the array to perform power management tasks.

Change-Id: I81d071d82f8ed0f677f585a83670ed519cdb8d26
Signed-off-by: Chris Kay <chris.kay@arm.com>