### PR TITLE
sid: Move to an always available interface

### DIFF
--- a/module/sid/include/mod_sid.h
+++ b/module/sid/include/mod_sid.h
@@ -28,20 +28,6 @@
  */
 
 /*!
- * \brief Module API indicies.
- */
-enum mod_sid_api_idx {
-    MOD_SID_API_IDX_INFO, /*!< Index of the info api. */
-    MOD_SID_API_COUNT,    /*!< Number of apis. */
-};
-
-/*!
- * \brief Info API id.
- */
-static const fwk_id_t mod_sid_api_id_info =
-    FWK_ID_API_INIT(FWK_MODULE_IDX_SID, MOD_SID_API_IDX_INFO);
-
-/*!
  * \brief System information
  */
 struct mod_sid_info {
@@ -103,14 +89,16 @@ struct mod_sid_subsystem_config {
 /*!
  * \brief Module interface.
  */
-struct mod_sid_api_info {
-    /*!
-     * \brief Get a pointer to the structure holding the system information.
-     *
-     * \return Pointer to system information structure.
-     */
-    const struct mod_sid_info * (*get_system_info)(void);
-};
+
+/*!
+ * \brief Get a pointer to the structure holding the system information.
+ *
+ * \param[out] system_info Pointer to the system information data.
+ *
+ * \retval FWK_SUCCESS The pointer was returned successfully.
+ * \retval FWK_E_INIT The system information is not initialized.
+ */
+int mod_sid_get_system_info(const struct mod_sid_info **system_info);
 
 /*!
  * @}

--- a/module/sid/src/mod_sid.c
+++ b/module/sid/src/mod_sid.c
@@ -14,16 +14,19 @@
 #include <mod_sid.h>
 #include <sid_reg.h>
 
+static bool initialized;
 static struct mod_sid_info info;
 
-static const struct mod_sid_info* get_system_info(void)
+int mod_sid_get_system_info(const struct mod_sid_info **system_info)
 {
-    return &info;
-}
+    if (initialized) {
+        *system_info = &info;
 
-static const struct mod_sid_api_info info_api = {
-    .get_system_info = get_system_info,
-};
+        return FWK_SUCCESS;
+    }
+
+    return FWK_E_INIT;
+}
 
 static int sid_init(
     fwk_id_t module_id,
@@ -91,26 +94,16 @@ static int sid_subsystem_init(
         info.system_idx = fwk_id_get_element_idx(subsystem_id);
         info.name = fwk_module_get_name(
             FWK_ID_ELEMENT(FWK_MODULE_IDX_SID, info.system_idx));
+
+        initialized = true;
     }
 
-    return FWK_SUCCESS;
-}
-
-static int sid_proc_bind_req(
-    fwk_id_t requester_id,
-    fwk_id_t id,
-    fwk_id_t api_id,
-    const void **api)
-{
-    *api = &info_api;
     return FWK_SUCCESS;
 }
 
 const struct fwk_module module_sid = {
     .name = "SID",
     .type = FWK_MODULE_TYPE_DRIVER,
-    .api_count = MOD_SID_API_COUNT,
     .init = sid_init,
     .element_init = sid_subsystem_init,
-    .process_bind_request = sid_proc_bind_req,
 };


### PR DESCRIPTION
Remove the need to bind to the sid module interface. This enables access
to the system information data during the initialization stage of the
pre-runtime phase. This way, configuration data can be tuned according
to system information data.

Change-Id: I2e9e37d562af0d7f6a8ba844a79a78f823f6a64a
Signed-off-by: Ronald Cron <ronald.cron@arm.com>