### PR TITLE
Opening SCP-firmware to external contributions

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,82 @@
 Contributing to SCP-firmware
 ============================
 
-This project has not put in place a process for contributions currently. If you
-would like to contribute, please contact the maintainers
-(see [maintainers.md](./maintainers.md)).
+Getting Started
+---------------
+
+- Make sure you have a [GitHub account](https://github.com/signup/free).
+- [Fork](https://help.github.com/articles/fork-a-repo)
+  [SCP-firmware](https://github.com/ARM-software/SCP-firmware) on Github.
+- Clone the fork to your own machine.
+- Create a local topic branch based on the
+  [SCP-firmware](https://github.com/ARM-software/SCP-firmware) `master` branch.
+
+Making Changes
+--------------
+
+- Make commits of logical units. See these general
+  [Git guidelines](http://git-scm.com/book/ch5-2.html) for contributing to a
+  project.
+- Follow the [SCP coding style](./doc/code_style.md).
+- Keep the commits on topic. If you need to fix another bug or make another
+  enhancement, please address it on a separate topic branch.
+- Avoid long commit series. If you do have a long series, consider whether
+  some commits should be squashed together or addressed in a separate topic.
+- Make sure your commit messages are in the proper format.
+- Where appropriate, please update the documentation.
+- Ensure that each changed file has the correct copyright and license
+  information.
+    - Files that entirely consist of contributions to this project should have a
+      copyright notice and BSD-3-Clause SPDX license identifier of the form as
+      shown in [license.md](./license.md)
+    - Files that contain changes to imported Third Party IP files should retain
+      their original copyright and license notices.
+- If you are submitting new files that you intend to be the technical
+  sub-maintainer for (for example, a new platform port), then also update the
+  [maintainers](./maintainers.md) file.
+- For topics with multiple commits, it is recommended that you make all the
+  documentation changes (and nothing else) in the last commit of the series.
+- Please test your changes. As a minimum, ensure you can do an AP boot.
+
+Submitting Changes
+------------------
+
+- Ensure that each commit in the series has at least one `Signed-off-by:` line,
+  using your real name and email address. The names in the `Signed-off-by:`
+  and `Author:` lines must match. If anyone else contributes to the commit,
+  they must also add their own `Signed-off-by:` line. By adding this line the
+  contributor certifies the contribution is made under the terms of the
+  [Developer Certificate of Origin (DCO)](./dco.txt).
+- Push your local changes to your fork of the repository.
+- Submit a [pull request](https://help.github.com/articles/using-pull-requests)
+  to the [SCP-firmware](https://github.com/ARM-software/SCP-firmware) `master`
+  branch.
+    - The changes in the
+      [pull request](https://help.github.com/articles/using-pull-requests) will
+      then undergo further review and testing by the
+      [maintainers](./maintainers.md). Any review comments will be made as
+      comments on the [pull request](https://help.github.com/articles/using-pull-requests).
+      This may require you to do some rework.
+- When the changes are accepted, the [maintainers](./maintainers.md) will
+  integrate them.
+
+    - Typically, the [maintainers](./maintainers.md) will merge the
+      [pull request](https://help.github.com/articles/using-pull-requests) into
+      the 'master' branch within the Github UI by rebasing and then merging.
+    - Please avoid creating merge commits in the
+      [pull request](https://help.github.com/articles/using-pull-requests)
+      itself.
+    - If the [pull request](https://help.github.com/articles/using-pull-requests)
+      is not based on a recent commit, the [maintainers](./maintainers.md) may
+      rebase it onto the `master` branch first, or ask you to do this.
+    - If the [pull request](https://help.github.com/articles/using-pull-requests)
+      cannot be automatically merged, the [maintainers](./maintainers.md) will
+      ask you to rebase it onto the `master` branch.
+    - If after merging the [maintainers](./maintainers.md) find any issues, they
+      may remove the commits and ask you to create a new pull request to resolve
+      the problem.
+   -  Please do not delete your topic branch until it is safely merged into
+      the `master` branch.
+
+--------------
+*Copyright (c) 2018-2019, Arm Limited and Contributors. All rights reserved.*

--- a/dco.txt
+++ b/dco.txt
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/license.md
+++ b/license.md
@@ -1,7 +1,7 @@
 License
 =======
 
-Copyright (c) 2011-2019, Arm Limited. All rights reserved.
+Copyright (c) 2011-2019, Arm Limited and Contributors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:


### PR DESCRIPTION
With this patch, the SCP-firmware will accept contributions to the project
from non-Arm contributors. Contributions must be made under Developer
Certificate of Origin (DCO).

This patch updates the contributing guidelines to describe how contributions
can be made, and additionally adds a copy of the DCO terms.

Change-Id: I1cb23b1785c4fb074ae0c344556319a2d7a0254e
Signed-off-by: David Cunado <david.cunado@arm.com>