### PR TITLE
n1sdp: increase link training timeout to 100ms

### DIFF
--- a/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.h
+++ b/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.h
@@ -66,7 +66,7 @@
  */
 #define PCIE_PHY_PLL_LOCK_TIMEOUT      UINT32_C(100)
 #define PCIE_CTRL_RC_RESET_TIMEOUT     UINT32_C(100)
-#define PCIE_LINK_TRAINING_TIMEOUT     UINT32_C(50000)
+#define PCIE_LINK_TRAINING_TIMEOUT     UINT32_C(100000)
 
 /* PCIe controller power on timeout (in microseconds) */
 #define PCIE_POWER_ON_TIMEOUT          UINT32_C(10)


### PR DESCRIPTION
This patch increases the link training timeout to 100ms such that
PCIe GEN4 cards connected to CCIX slot have sufficient time to
auto negotiate to GEN3 speed.

Change-Id: Ie9ecaed8f754fb664d6e26534fe204fd475d8621
Signed-off-by: Manoj Kumar <manoj.kumar3@arm.com>