### PR TITLE
N1sdp/bl33 copy by atf

### DIFF
--- a/product/n1sdp/include/n1sdp_sds.h
+++ b/product/n1sdp/include/n1sdp_sds.h
@@ -21,6 +21,8 @@ enum n1sdp_sds_struct_id {
     N1SDP_SDS_FEATURE_AVAILABILITY = 5 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
     N1SDP_SDS_CPU_BOOTCTR =          6 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
     N1SDP_SDS_CPU_FLAGS =            7 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
+    N1SDP_SDS_DDR_MEM_INFO =         8 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
+    N1SDP_SDS_BL33_INFO =            9 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
 };
 
 /*
@@ -33,6 +35,8 @@ enum n1sdp_sds_struct_id {
 #define N1SDP_SDS_FEATURE_AVAILABILITY_SIZE  4
 #define N1SDP_SDS_CPU_BOOTCTR_SIZE           256
 #define N1SDP_SDS_CPU_FLAGS_SIZE             256
+#define N1SDP_SDS_DDR_MEM_INFO_SIZE          4
+#define N1SDP_SDS_BL33_INFO_SIZE             12
 
 /*
  * Field masks and offsets for the N1SDP_SDS_AP_CPU_INFO structure.
@@ -60,5 +64,12 @@ struct n1sdp_sds_platid {
 #define N1SDP_SDS_FEATURE_FIRMWARE_POS    0
 #define N1SDP_SDS_FEATURE_DMC_POS         1
 #define N1SDP_SDS_FEATURE_MESSAGING_POS   2
+
+/*
+ * Element identifiers for SDS structures
+ */
+#define SDS_ELEMENT_IDX_FEATURE_AVAILABILITY  3
+#define SDS_ELEMENT_IDX_DDR_MEM_INFO          4
+#define SDS_ELEMENT_IDX_BL33_INFO             5
 
 #endif /* N1SDP_SDS_H */

--- a/product/n1sdp/module/n1sdp_dmc620/include/mod_n1sdp_dmc620.h
+++ b/product/n1sdp/module/n1sdp_dmc620/include/mod_n1sdp_dmc620.h
@@ -709,6 +709,31 @@ struct mod_dmc_ddr_phy_api {
 };
 
 /*!
+ * \brief API to expose DDR memory size.
+ */
+struct mod_dmc620_mem_info_api {
+    /*!
+     * \brief Pointer to function that sets DDR memory size in GB.
+     *
+     * \param size Pointer where memory size will be stored.
+     *
+     * \retval void.
+     */
+    void (*get_mem_size_gb)(uint32_t *size);
+};
+
+/*!
+ * \brief API indices.
+ */
+enum mod_dmc620_api_idx {
+    /*! API index for getting memory information */
+    MOD_DMC620_API_IDX_MEM_INFO,
+
+    /*! Number of exposed interfaces */
+    MOD_DMC620_API_COUNT,
+};
+
+/*!
  * \brief DMC-620 module configuration.
  */
 struct mod_dmc620_module_config {

--- a/product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c
+++ b/product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c
@@ -36,6 +36,18 @@ static void direct_ddr_cmd(struct mod_dmc620_reg *dmc);
 static int enable_dimm_refresh(struct mod_dmc620_reg *dmc);
 static int dmc620_config_interrupt(fwk_id_t ddr_id);
 
+/* Memory Information API */
+
+static void dmc620_get_mem_size_gb(uint32_t *size)
+{
+    fwk_assert(size != NULL);
+    *size = 16;
+}
+
+struct mod_dmc620_mem_info_api ddr_mem_info_api = {
+    .get_mem_size_gb = dmc620_get_mem_size_gb,
+};
+
 /* Framework API */
 static int mod_dmc620_init(fwk_id_t module_id, unsigned int element_count,
                            const void *config)
@@ -82,6 +94,20 @@ static int mod_dmc620_bind(fwk_id_t id, unsigned int round)
         &timer_api);
     if (status != FWK_SUCCESS)
         return status;
+
+    return FWK_SUCCESS;
+}
+
+static int mod_dmc620_process_bind_request(fwk_id_t requester_id,
+    fwk_id_t id, fwk_id_t api_id, const void **api)
+{
+    switch (fwk_id_get_api_idx(api_id)) {
+    case MOD_DMC620_API_IDX_MEM_INFO:
+        *api = &ddr_mem_info_api;
+        break;
+    default:
+        return FWK_E_PARAM;
+    }
 
     return FWK_SUCCESS;
 }
@@ -142,7 +168,8 @@ const struct fwk_module module_n1sdp_dmc620 = {
     .bind = mod_dmc620_bind,
     .start = mod_dmc620_start,
     .process_notification = mod_dmc620_process_notification,
-    .api_count = 0,
+    .process_bind_request = mod_dmc620_process_bind_request,
+    .api_count = MOD_DMC620_API_COUNT,
     .event_count = 0,
 };
 

--- a/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
+++ b/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
@@ -322,6 +322,13 @@ static int n1sdp_pcie_setup(struct n1sdp_pcie_dev_ctx *dev_ctx)
     else
         pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
+    /*
+     * Wait until devices connected in downstream ports
+     * finish link training before doing bus enumeration
+     */
+    pcie_ctx.timer_api->delay(FWK_ID_ELEMENT(FWK_MODULE_IDX_TIMER, 0),
+                                 PCIE_LINK_TRAINING_TIMEOUT);
+
     return FWK_SUCCESS;
 }
 

--- a/product/n1sdp/module/n1sdp_system/include/mod_n1sdp_system.h
+++ b/product/n1sdp/module/n1sdp_system/include/mod_n1sdp_system.h
@@ -41,17 +41,8 @@
 /*! AP Cores Reset Address in SCP Address Space */
 #define AP_CORE_RESET_ADDR            UINT64_C(0xA4040000)
 
-/*! DDR Base address where AP BL33 (UEFI) will be copied to. */
-#define AP_BL33_BASE_ADDR             UINT64_C(0xE0000000)
-
 /*! Address translation enable bit */
 #define ADDR_TRANS_EN                 UINT32_C(0x1)
-
-/*!
- * Number of bits to shift in AP's memory map address to map to SCP's
- * 1MB window.
- */
-#define SCP_AP_1MB_WINDOW_ADDR_SHIFT 20
 
 /*!
  * \brief API indices.

--- a/product/n1sdp/module/n1sdp_system/include/mod_n1sdp_system.h
+++ b/product/n1sdp/module/n1sdp_system/include/mod_n1sdp_system.h
@@ -44,6 +44,15 @@
 /*! Address translation enable bit */
 #define ADDR_TRANS_EN                 UINT32_C(0x1)
 
+/*! Source address of BL33 image to be used by BL31 */
+#define BL33_SRC_BASE_ADDR            UINT32_C(0x14200000)
+
+/*! Destination address of BL33 image to be used by BL31 */
+#define BL33_DST_BASE_ADDR            UINT32_C(0xE0000000)
+
+/*! Size of BL33 image to be used by BL31 */
+#define BL33_SIZE                     UINT32_C(0x00200000)
+
 /*!
  * \brief API indices.
  */

--- a/product/n1sdp/scp_ramfw/config_sds.c
+++ b/product/n1sdp/scp_ramfw/config_sds.c
@@ -64,6 +64,22 @@ static struct fwk_element sds_element_table[] = {
             .finalize = true,
         }),
     },
+    {
+        .name = "DDR Memory Info",
+        .data = &((struct mod_sds_structure_desc) {
+            .id = N1SDP_SDS_DDR_MEM_INFO,
+            .size = N1SDP_SDS_DDR_MEM_INFO_SIZE,
+            .finalize = true,
+        }),
+    },
+    {
+        .name = "BL33 Image Info",
+        .data = &((struct mod_sds_structure_desc) {
+            .id = N1SDP_SDS_BL33_INFO,
+            .size = N1SDP_SDS_BL33_INFO_SIZE,
+            .finalize = true,
+        }),
+    },
 #ifdef BUILD_HAS_MOD_TEST
     {
         .name = "Boot Counters",


### PR DESCRIPTION
In this patch set:
1. Add delay between link training completion and bus enumeration in PCIe to let devices connected in downstream ports finish its link training.
2. Remove BL33 copy by SCP and it is now moved to ARM-TF.
3. Create SDS structures to share DDR memory size information and BL33 image information to ARM-TF.