### PR TITLE
n1sdp: add frequency lookup table for n1sdp_pll

### DIFF
--- a/product/n1sdp/module/n1sdp_pll/include/internal/n1sdp_pll.h
+++ b/product/n1sdp/module/n1sdp_pll/include/internal/n1sdp_pll.h
@@ -39,4 +39,19 @@
 /*! Step size for the PLL. */
 #define MOD_N1SDP_PLL_STEP_SIZE      UINT64_C(1000)
 
+/*! The minimum feedback divider value */
+#define MOD_N1SDP_PLL_FBDIV_MIN      16
+/*! The maximum feedback divider value */
+#define MOD_N1SDP_PLL_FBDIV_MAX      1600
+
+/*! The minimum reference clock divider value */
+#define MOD_N1SDP_PLL_REFDIV_MIN     1
+/*! The maximum reference clock divider value */
+#define MOD_N1SDP_PLL_REFDIV_MAX     63
+
+/*! The minimum post divider value */
+#define MOD_N1SDP_PLL_POSTDIV_MIN    1
+/*! The maximum post divider value */
+#define MOD_N1SDP_PLL_POSTDIV_MAX    7
+
 #endif /* N1SDP_PLL_H */

--- a/product/n1sdp/module/n1sdp_pll/include/mod_n1sdp_pll.h
+++ b/product/n1sdp/module/n1sdp_pll/include/mod_n1sdp_pll.h
@@ -66,6 +66,34 @@ struct mod_n1sdp_pll_dev_config {
 };
 
 /*!
+ * \brief PLL parameter values for non-absolute frequencies.
+ */
+struct n1sdp_pll_custom_freq_param_entry {
+    /*! Required output frequency value in MHz */
+    uint16_t freq_value_mhz;
+
+    /*! Feedback divider value for this frequency */
+    uint16_t fbdiv;
+
+    /*! Reference clock divider value for this frequency */
+    uint8_t refdiv;
+
+    /*! Post divider 1 value for this frequency */
+    uint8_t postdiv;
+};
+
+/*!
+ * \brief N1SDP PLL module configuration.
+ */
+struct n1sdp_pll_module_config {
+    /*! Pointer to custom frequency table */
+    struct n1sdp_pll_custom_freq_param_entry *custom_freq_table;
+
+    /*! Size of custom frequency table */
+    size_t custom_freq_table_size;
+};
+
+/*!
  * @}
  */
 

--- a/product/n1sdp/scp_ramfw/config_n1sdp_pll.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_pll.c
@@ -14,6 +14,15 @@
 #include <config_clock.h>
 #include <n1sdp_system_clock.h>
 
+static struct n1sdp_pll_custom_freq_param_entry freq_table[] = {
+    {
+        .freq_value_mhz = 1333,
+        .fbdiv = 160,
+        .refdiv = 3,
+        .postdiv = 2,
+    },
+};
+
 static const struct fwk_element n1sdp_pll_element_table[] = {
     [CLOCK_PLL_IDX_CPU0] = {
         .name = "CPU_PLL_0",
@@ -80,4 +89,8 @@ static const struct fwk_element *n1sdp_pll_get_element_table
 
 const struct fwk_module_config config_n1sdp_pll = {
     .get_element_table = n1sdp_pll_get_element_table,
+    .data = &((struct n1sdp_pll_module_config) {
+        .custom_freq_table = freq_table,
+        .custom_freq_table_size = FWK_ARRAY_SIZE(freq_table),
+    }),
 };


### PR DESCRIPTION
This patch adds lookup table for frequencies that are not an
integer multiplication of the reference clock.
In such case, n1sdp_pll module sees if a matching frequency is
available in lookup table and uses PLL parameters from the table.

Change-Id: Ic737b3bed17190425064a37a05de5cf35f84dffb
Signed-off-by: Manoj Kumar <manoj.kumar3@arm.com>