### PR TITLE
fwk: Replace base alignment reference type with max_align_t

### DIFF
--- a/framework/include/fwk_event.h
+++ b/framework/include/fwk_event.h
@@ -12,6 +12,7 @@
 #define FWK_EVENT_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <fwk_align.h>
 #include <fwk_id.h>
@@ -91,7 +92,7 @@ struct fwk_event {
     fwk_id_t id;
 
     /*! Table of event parameters */
-    alignas(uintmax_t) uint8_t params[FWK_EVENT_PARAMETERS_SIZE];
+    alignas(max_align_t) uint8_t params[FWK_EVENT_PARAMETERS_SIZE];
 };
 
 /*!

--- a/framework/include/fwk_mm.h
+++ b/framework/include/fwk_mm.h
@@ -25,10 +25,10 @@
  */
 
 /*!
- * \brief Default allocation alignment based on the alignment of uintmax_t
+ * \brief Default allocation alignment based on the alignment of max_align_t
  *      on the platform the software is built for.
  */
-#define FWK_MM_DEFAULT_ALIGNMENT (alignof(uintmax_t))
+#define FWK_MM_DEFAULT_ALIGNMENT (alignof(max_align_t))
 
 /*!
  * \brief Allocate a block of memory.

--- a/framework/test/test_fwk_mm.c
+++ b/framework/test/test_fwk_mm.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 #include <fwk_assert.h>
@@ -18,7 +19,7 @@
 #define ALLOC_NUM           5
 #define ALLOC_SIZE          64
 #define ALLOC_ODD_SIZE      3
-#define ALLOC_ALIGN         16
+#define ALLOC_ALIGN         (alignof(max_align_t) * 2)
 #define ALLOC_BAD_ALIGN     12
 #define ALLOC_TOTAL_SIZE    (ALLOC_NUM * ALLOC_SIZE)
 #define MEM_PATTERN         0x0A
@@ -114,7 +115,7 @@ static void test_fwk_mm_alloc(void)
     /* Allocate a memory block with an odd size */
     result = fwk_mm_alloc(ALLOC_NUM, ALLOC_ODD_SIZE);
     assert(result != NULL);
-    assert(((uintptr_t)result & FWK_MM_DEFAULT_ALIGNMENT) == 0);
+    assert(((uintptr_t)result % FWK_MM_DEFAULT_ALIGNMENT) == 0);
 
     /*
      * The start address of the last-allocated block should be 64-bit aligned,
@@ -123,7 +124,7 @@ static void test_fwk_mm_alloc(void)
      */
     result = fwk_mm_alloc(ALLOC_NUM, ALLOC_SIZE);
     assert(result != NULL);
-    assert(((uintptr_t)result & FWK_MM_DEFAULT_ALIGNMENT) == 0);
+    assert(((uintptr_t)result % FWK_MM_DEFAULT_ALIGNMENT) == 0);
     assert((uintptr_t)result + ALLOC_TOTAL_SIZE <=
         (uintptr_t)start + SIZE_MEM);
 
@@ -209,7 +210,7 @@ static void test_fwk_mm_calloc(void)
     /* Allocate a memory block with an odd size */
     result = fwk_mm_calloc(ALLOC_NUM, ALLOC_ODD_SIZE);
     assert(result != NULL);
-    assert(((uintptr_t)result & FWK_MM_DEFAULT_ALIGNMENT) == 0);
+    assert(((uintptr_t)result % FWK_MM_DEFAULT_ALIGNMENT) == 0);
 
     /*
      * The start address of the last-allocated block should be 64-bit aligned,
@@ -218,7 +219,7 @@ static void test_fwk_mm_calloc(void)
      */
     result = fwk_mm_calloc(ALLOC_NUM, ALLOC_SIZE);
     assert(result != NULL);
-    assert(((uintptr_t)result & FWK_MM_DEFAULT_ALIGNMENT) == 0);
+    assert(((uintptr_t)result % FWK_MM_DEFAULT_ALIGNMENT) == 0);
     assert((uintptr_t)result + ALLOC_TOTAL_SIZE <=
            (uintptr_t)start + SIZE_MEM);
 


### PR DESCRIPTION
This commit replaces uses of uintmax_t with max_align_t where the
purpose is to identify the largest possible alignment of any type.

Change-Id: I3be23f36f45a6c9f767314debfe81251abefc78e
Signed-off-by: Chris Kay <chris.kay@arm.com>