### PR TITLE
doc: Update user guide

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -3,7 +3,7 @@ SCP-firmware Change Log
 
 Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
 
-SCP-firmware - version 2.4.0
+SCP-firmware - version 2.5.0
 ============================
 
 New features

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-SCP-firmware - version 2.4
+SCP-firmware - version 2.5
 ==========================
 
 Copyright (c) 2011-2019, Arm Limited. All rights reserved.


### PR DESCRIPTION
This commit updates the user guide to bring it in-line with the latest
v2.5.0 release. It changes the Markdown header syntax in order to
represent deeper header levels, replaces old links and attempts to clear
up areas of potential confusion with instructions.

Change-Id: I99b464a4bc94f4618779fbe09b1aa77bed0c318e
Signed-off-by: Chris Kay <chris.kay@arm.com>