### PR TITLE
bs: Add justification of compiler warning flags

### DIFF
--- a/tools/build_system/rules.mk
+++ b/tools/build_system/rules.mk
@@ -81,6 +81,10 @@ endif
 # Warning flags
 #
 
+# The following flags are enforced to minimise unwitting uses of undefined
+# behaviour in the code base, which can open security holes. Each flag applies a
+# set of warnings, and any warnings that do occur are upgraded to errors to
+# prevent the firmware from building.
 CFLAGS_GCC += -Werror
 CFLAGS_GCC += -Wall
 CFLAGS_GCC += -Wextra


### PR DESCRIPTION
This commit adds a basic security justification to the Makefile rules,
explaining the reasons for increasing the compiler warnings used.

Change-Id: Id867f90fc88014a1801ca341e6d1c0c75faa0f35
Signed-off-by: Chris Kay <chris.kay@arm.com>