### PR TITLE
scmi: Remove unused declarations

### DIFF
--- a/module/scmi/include/internal/scmi_base.h
+++ b/module/scmi/include/internal/scmi_base.h
@@ -85,6 +85,4 @@ struct __attribute((packed)) scmi_base_discover_agent_p2a {
     char name[16];
 };
 
-extern struct scp_scmi_protocol scmi_base_protocol;
-
 #endif /* SCMI_BASE_H */

--- a/module/scmi_perf/include/internal/scmi_perf.h
+++ b/module/scmi_perf/include/internal/scmi_perf.h
@@ -243,6 +243,4 @@ struct __attribute((packed)) scmi_perf_notify_level_p2a {
     int32_t status;
 };
 
-extern struct scp_scmi_protocol scmi_perf_protocol;
-
 #endif /* SCMI_PERF_H */


### PR DESCRIPTION
Reemove unnecessary externs from SCMI module internal header files.

Change-Id: I6a74ba18db214b401fb8705606c46b32ead99003
Signed-off-by: Souvik Chakravarty <souvik.chakravarty@arm.com>