### PR TITLE
Ensure system PLLs on Juno are locked within MCC timeout

### DIFF
--- a/arch/src/Makefile
+++ b/arch/src/Makefile
@@ -11,6 +11,7 @@ include $(BS_DIR)/toolchain.mk
 BS_LIB_NAME = arch
 
 BS_LIB_SOURCES_armv7-m += armv7-m/exceptions.c
+BS_LIB_SOURCES_armv7-m += armv7-m/handlers.c
 BS_LIB_SOURCES_armv7-m += arm_nvic.c
 BS_LIB_SOURCES_armv7-m += arm_main.c
 BS_LIB_SOURCES_armv7-m += arm_mm.c

--- a/arch/src/armv7-m/exceptions.h
+++ b/arch/src/armv7-m/exceptions.h
@@ -1,0 +1,23 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <fwk_noreturn.h>
+
+/*!
+ * \brief Arm reset exception handler.
+ *
+ * \details This is the first function that executes when the core comes online.
+ */
+noreturn void arm_exception_reset(void);
+
+/*!
+ * \brief Invalid exception handler.
+ *
+ * \details This handler is used as the default in order to catch exceptions
+ *      that have not been configured with a handler of their own.
+ */
+noreturn void arm_exception_invalid(void);

--- a/arch/src/armv7-m/handlers.c
+++ b/arch/src/armv7-m/handlers.c
@@ -1,0 +1,45 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *      ARMv7-M exception handlers.
+ */
+
+#include <stdbool.h>
+#include <cmsis_compiler.h>
+#include <fwk_noreturn.h>
+
+noreturn void arm_exception_reset(void)
+{
+    /*
+     * When entering the firmware, before the framework is entered the following
+     * things happen:
+     *  1. The toolchain-specific C runtime is initialized
+     *     For Arm Compiler:
+     *       1. Zero-initialized data is zeroed
+     *       2. Initialized data is decompressed and copied
+     *     For GCC/Newlib:
+     *       1. Zero-initialized data is zeroed
+     *       2. Initialized data is copied by software_init_hook()
+     * 2. The main() function is called by the C runtime
+     */
+
+#ifdef __ARMCC_VERSION
+    extern noreturn void __main(void);
+
+    __main();
+#else
+    extern noreturn void _start(void);
+
+    _start();
+#endif
+}
+
+noreturn void arm_exception_invalid(void)
+{
+    while (true)
+        __WFI();
+}

--- a/product/juno/module/juno_soc_clock/src/mod_juno_soc_clock.c
+++ b/product/juno/module/juno_soc_clock/src/mod_juno_soc_clock.c
@@ -59,22 +59,6 @@
 #define HDLCDCLK_CLOCK              (400 * FWK_MHZ)
 
 /*
- * This function is executed before the C main() function.
- * This needs to happen as the PLLs must be released from reset very shortly
- * after the SCP is released from reset, otherwise the motherboard
- * microcontroller will kill the SCP and error out.
- */
-
-static void __attribute((constructor, used)) init_pll_early(void)
-{
-    unsigned int pll_idx;
-
-    /* Release All system PLLs from reset */
-    for (pll_idx = 0; pll_idx < PLL_IDX_COUNT; pll_idx++)
-        SCC->PLL[pll_idx].REG0 &= ~PLL_REG0_PLL_RESET;
-}
-
-/*
  * Static helper functions
  */
 

--- a/product/juno/scp_romfw_bypass/firmware.mk
+++ b/product/juno/scp_romfw_bypass/firmware.mk
@@ -41,6 +41,9 @@ BS_FIRMWARE_SOURCES := \
     config_log.c \
     config_timer.c \
     config_sds.c \
-    config_bootloader.c
+    config_bootloader.c \
+    juno_pll_workaround.c
+
+LDFLAGS_GCC += -Wl,--wrap=arm_exception_reset
 
 include $(BS_DIR)/firmware.mk

--- a/product/juno/scp_romfw_bypass/juno_pll_workaround.c
+++ b/product/juno/scp_romfw_bypass/juno_pll_workaround.c
@@ -1,0 +1,39 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *      Workaround for the PLL lock error emitted by the motherboard, seen if
+ *      the SCP fails to lock the system PLLs within a certain (very short)
+ *      timeframe.
+ */
+
+#include <fwk_noreturn.h>
+#include <fwk_module.h>
+#include <juno_scc.h>
+
+#ifdef __ARMCC_VERSION
+#   define __wrap_arm_exception_reset $Sub$$arm_exception_reset
+#   define __real_arm_exception_reset $Super$$arm_exception_reset
+#endif
+
+/*
+ * These PLLs must be released from reset very shortly after the SCP is released
+ * from reset, otherwise the motherboard microcontroller will kill the SCP and
+ * error out. We do this at the earliest possible point in time in order to
+ * ensure nothing delays it from happening.
+ */
+noreturn void __wrap_arm_exception_reset(void)
+{
+    extern noreturn void __real_arm_exception_reset(void);
+
+    unsigned int pll_idx;
+
+    /* Release All system PLLs from reset */
+    for (pll_idx = 0; pll_idx < PLL_IDX_COUNT; pll_idx++)
+        SCC->PLL[pll_idx].REG0 &= ~PLL_REG0_PLL_RESET;
+
+    __real_arm_exception_reset();
+}

--- a/tools/build_system/rules.mk
+++ b/tools/build_system/rules.mk
@@ -129,7 +129,8 @@ ARFLAGS_GCC = -rc
 
 LDFLAGS_GCC += -Wl,--cref
 
-LDFLAGS_ARM += -Wl,--undefined=arm_exception_reset
+LDFLAGS_GCC += -Wl,--undefined=arm_exceptions
+LDFLAGS_ARM += -Wl,--undefined=arm_exceptions
 
 BUILTIN_LIBS_GCC := -lc -lgcc
 


### PR DESCRIPTION
The current approach to resetting the PLLs, which is to use a pre-main
constructor function, is not infallible - if we statically allocate
enough data, eventually the time it takes for the C runtime to
initialize exceeds the amount of time that the motherboard
microcontroller gives us to ensure the system PLLs are locked.

The workaround for this is to instead wrap the core's reset handler.
This way we ensure that the PLLs have been reset before we do any time-
consuming work.