### PR TITLE
build: enhance entry guards in internal header files

### DIFF
--- a/module/cmn600/include/internal/cmn600_ccix.h
+++ b/module/cmn600/include/internal/cmn600_ccix.h
@@ -9,8 +9,8 @@
  *      CMN600 CCIX Configuration Interface
  */
 
-#ifndef CMN600_CCIX_H
-#define CMN600_CCIX_H
+#ifndef INTERNAL_CMN600_CCIX_H
+#define INTERNAL_CMN600_CCIX_H
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -222,4 +222,4 @@ struct cxg_wait_condition_data {
 #define CTL_NUM_SNPCRDS_MASK                      (0xF << 4)
 #define CCIX_VENDER_ID                            (0x2692)
 
-#endif /* CMN600_CCIX_H */
+#endif /* INTERNAL_CMN600_CCIX_H */

--- a/module/cmn600/include/internal/cmn600_ctx.h
+++ b/module/cmn600/include/internal/cmn600_ctx.h
@@ -9,8 +9,8 @@
  *      CMN600 Context structure Interface
  */
 
-#ifndef CMN600_CTX_H
-#define CMN600_CTX_H
+#ifndef INTERNAL_CMN600_CTX_H
+#define INTERNAL_CMN600_CTX_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -95,4 +95,4 @@ struct cmn600_ctx {
 
 int cmn600_setup_sam(struct cmn600_rnsam_reg *rnsam);
 
-#endif /* CMN600_CTX_H */
+#endif /* INTERNAL_CMN600_CTX_H */

--- a/module/mhu/include/internal/mhu.h
+++ b/module/mhu/include/internal/mhu.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef MHU_H
-#define MHU_H
+#ifndef INTERNAL_MHU_H
+#define INTERNAL_MHU_H
 
 #include <stdint.h>
 #include <fwk_macros.h>
@@ -26,4 +26,4 @@ struct mhu_reg {
     FWK_W  uint32_t CLEAR;
 };
 
-#endif /* MHU_H */
+#endif /* INTERNAL_MHU_H */

--- a/module/scmi/include/internal/scmi.h
+++ b/module/scmi/include/internal/scmi.h
@@ -9,8 +9,8 @@
  *      definitions.
  */
 
-#ifndef SCMI_H
-#define SCMI_H
+#ifndef INTERNAL_SCMI_H
+#define INTERNAL_SCMI_H
 
 #include <stdint.h>
 
@@ -168,4 +168,4 @@ struct __attribute((packed)) scmi_protocol_message_attributes_p2a {
  * @}
  */
 
-#endif /* SCMI_H */
+#endif /* INTERNAL_SCMI_H */

--- a/module/scmi/include/internal/scmi_base.h
+++ b/module/scmi/include/internal/scmi_base.h
@@ -8,8 +8,8 @@
  *      SCMI base protocol definitions.
  */
 
-#ifndef SCMI_BASE_H
-#define SCMI_BASE_H
+#ifndef INTERNAL_SCMI_BASE_H
+#define INTERNAL_SCMI_BASE_H
 
 #define SCMI_PROTOCOL_ID_BASE      UINT32_C(0x10)
 #define SCMI_PROTOCOL_VERSION_BASE UINT32_C(0x10000)
@@ -85,4 +85,4 @@ struct __attribute((packed)) scmi_base_discover_agent_p2a {
     char name[16];
 };
 
-#endif /* SCMI_BASE_H */
+#endif /* INTERNAL_SCMI_BASE_H */

--- a/module/scmi_apcore/include/internal/scmi_apcore.h
+++ b/module/scmi_apcore/include/internal/scmi_apcore.h
@@ -8,8 +8,8 @@
  *      SCMI Core Configuration Protocol Support
  */
 
-#ifndef SCMI_APCORE_H
-#define SCMI_APCORE_H
+#ifndef INTERNAL_SCMI_APCORE_H
+#define INTERNAL_SCMI_APCORE_H
 
 #include <stdint.h>
 
@@ -68,4 +68,4 @@ struct __attribute((packed)) scmi_apcore_reset_address_get_p2a {
     uint32_t attributes;
 };
 
-#endif /* SCMI_APCORE_H */
+#endif /* INTERNAL_SCMI_APCORE_H */

--- a/module/scmi_clock/include/internal/scmi_clock.h
+++ b/module/scmi_clock/include/internal/scmi_clock.h
@@ -8,8 +8,8 @@
  *      SCMI Clock Management Protocol Support
  */
 
-#ifndef SCMI_CLOCK_H
-#define SCMI_CLOCK_H
+#ifndef INTERNAL_SCMI_CLOCK_H
+#define INTERNAL_SCMI_CLOCK_H
 
 #define SCMI_PROTOCOL_ID_CLOCK      UINT32_C(0x14)
 #define SCMI_PROTOCOL_VERSION_CLOCK UINT32_C(0x10000)
@@ -188,4 +188,4 @@ struct __attribute((packed)) scmi_clock_describe_rates_p2a {
     struct scmi_clock_rate rates[];
 };
 
-#endif /* SCMI_CLOCK_H */
+#endif /* INTERNAL_SCMI_CLOCK_H */

--- a/module/scmi_perf/include/internal/scmi_perf.h
+++ b/module/scmi_perf/include/internal/scmi_perf.h
@@ -8,8 +8,8 @@
  *      SCMI performance domain management protocol support.
  */
 
-#ifndef SCMI_PERF_H
-#define SCMI_PERF_H
+#ifndef INTERNAL_SCMI_PERF_H
+#define INTERNAL_SCMI_PERF_H
 
 #define SCMI_PROTOCOL_ID_PERF      UINT32_C(0x13)
 #define SCMI_PROTOCOL_VERSION_PERF UINT32_C(0x10000)
@@ -243,4 +243,4 @@ struct __attribute((packed)) scmi_perf_notify_level_p2a {
     int32_t status;
 };
 
-#endif /* SCMI_PERF_H */
+#endif /* INTERNAL_SCMI_PERF_H */

--- a/module/scmi_power_domain/include/internal/scmi_power_domain.h
+++ b/module/scmi_power_domain/include/internal/scmi_power_domain.h
@@ -8,8 +8,8 @@
  *      System Control and Management Interface (SCMI) support.
  */
 
-#ifndef SCMI_POWER_H
-#define SCMI_POWER_H
+#ifndef INTERNAL_SCMI_POWER_H
+#define INTERNAL_SCMI_POWER_H
 
 /*!
  * \addtogroup GroupModules Modules
@@ -118,4 +118,4 @@ struct __attribute((packed)) scmi_pd_power_state_notify_p2a {
  * @}
  */
 
-#endif /* SCMI_POWER_DOMAIN_H */
+#endif /* INTERNAL_SCMI_POWER_DOMAIN_H */

--- a/module/scmi_sensor/include/internal/scmi_sensor.h
+++ b/module/scmi_sensor/include/internal/scmi_sensor.h
@@ -8,8 +8,8 @@
  *      System Control and Management Interface (SCMI) support.
  */
 
-#ifndef SCMI_SENSOR_H
-#define SCMI_SENSOR_H
+#ifndef INTERNAL_SCMI_SENSOR_H
+#define INTERNAL_SCMI_SENSOR_H
 
 /*!
  * \addtogroup GroupModules Modules
@@ -161,4 +161,4 @@ struct __attribute((packed)) scmi_sensor_protocol_description_get_p2a {
  * @}
  */
 
-#endif /* SCMI_SENSOR_H */
+#endif /* INTERNAL_SCMI_SENSOR_H */

--- a/module/scmi_system_power/include/internal/scmi_system_power.h
+++ b/module/scmi_system_power/include/internal/scmi_system_power.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SCMI_SYSTEM_POWER_H
-#define SCMI_SYSTEM_POWER_H
+#ifndef INTERNAL_SCMI_SYSTEM_POWER_H
+#define INTERNAL_SCMI_SYSTEM_POWER_H
 
 #define SCMI_PROTOCOL_ID_SYS_POWER      UINT32_C(0x12)
 #define SCMI_PROTOCOL_VERSION_SYS_POWER UINT32_C(0x10000)
@@ -83,4 +83,4 @@ struct __attribute((packed)) scmi_sys_power_state_notifier_p2a {
     uint32_t system_state;
 };
 
-#endif
+#endif /* INTERNAL_SCMI_SYSTEM_POWER_H */

--- a/module/smt/include/internal/smt.h
+++ b/module/smt/include/internal/smt.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SMT_H
-#define SMT_H
+#ifndef INTERNAL_SMT_H
+#define INTERNAL_SMT_H
 
 struct __attribute((packed)) mod_smt_memory {
     uint32_t reserved0;
@@ -38,4 +38,4 @@ struct __attribute((packed)) mod_smt_memory {
 #define MOD_SMT_MIN_MAILBOX_SIZE \
     (sizeof(struct mod_smt_memory) + MOD_SMT_MIN_PAYLOAD_SIZE)
 
-#endif /* SMT_H */
+#endif /* INTERNAL_SMT_H */

--- a/product/n1sdp/module/n1sdp_ddr_phy/include/internal/n1sdp_ddr_phy.h
+++ b/product/n1sdp/module/n1sdp_ddr_phy/include/internal/n1sdp_ddr_phy.h
@@ -8,8 +8,8 @@
  *     N1SDP DDR PHY configuration registers.
  */
 
-#ifndef N1SDP_DDR_PHY_H
-#define N1SDP_DDR_PHY_H
+#ifndef INTERNAL_N1SDP_DDR_PHY_H
+#define INTERNAL_N1SDP_DDR_PHY_H
 
 #include <stdint.h>
 #include <fwk_macros.h>
@@ -2446,4 +2446,4 @@ struct mod_n1sdp_ddr_phy_reg {
     FWK_RW uint32_t DENALI_PHY_2425_DATA;
 };
 
-#endif  /* N1SDP_DDR_PHY_H */
+#endif  /* INTERNAL_N1SDP_DDR_PHY_H */

--- a/product/n1sdp/module/n1sdp_flash/include/internal/n1sdp_flash_layout.h
+++ b/product/n1sdp/module/n1sdp_flash/include/internal/n1sdp_flash_layout.h
@@ -10,8 +10,8 @@
  *     and UUID values of binary images within the firmware package.
  */
 
-#ifndef N1SDP_FLASH_LAYOUT_H
-#define N1SDP_FLASH_LAYOUT_H
+#ifndef INTERNAL_N1SDP_FLASH_LAYOUT_H
+#define INTERNAL_N1SDP_FLASH_LAYOUT_H
 
 #include <stdint.h>
 #include "uuid.h"
@@ -92,4 +92,4 @@ struct n1sdp_fip_memory_toc {
     struct n1sdp_fip_toc_entry entry[];
 } __attribute__((packed));
 
-#endif /* N1SDP_FLASH_LAYOUT_H */
+#endif /* INTERNAL_N1SDP_FLASH_LAYOUT_H */

--- a/product/n1sdp/module/n1sdp_flash/include/internal/uuid.h
+++ b/product/n1sdp/module/n1sdp_flash/include/internal/uuid.h
@@ -10,8 +10,8 @@
  *     the firmware package.
  */
 
-#ifndef UUID_H
-#define UUID_H
+#ifndef INTERNAL_UUID_H
+#define INTERNAL_UUID_H
 
 /* Length of a node address (an IEEE 802 address). */
 #define _UUID_NODE_LEN 6
@@ -35,4 +35,4 @@ struct uuid_t {
     uint8_t node[_UUID_NODE_LEN];
 };
 
-#endif /* UUID_H */
+#endif /* INTERNAL_UUID_H */

--- a/product/n1sdp/module/n1sdp_i2c/include/internal/n1sdp_i2c.h
+++ b/product/n1sdp/module/n1sdp_i2c/include/internal/n1sdp_i2c.h
@@ -8,8 +8,8 @@
  *      N1SDP I2C register definitions
  */
 
-#ifndef N1SDP_I2C_H
-#define N1SDP_I2C_H
+#ifndef INTERNAL_N1SDP_I2C_H
+#define INTERNAL_N1SDP_I2C_H
 
 #include <fwk_macros.h>
 
@@ -206,4 +206,4 @@ struct i2c_reg {
 
 #define I2C_TSR_TANSFER_SIZE 0xF
 
-#endif /* N1SDP_I2C_H */
+#endif /* INTERNAL_N1SDP_I2C_H */

--- a/product/n1sdp/module/n1sdp_mhu/include/internal/mhu.h
+++ b/product/n1sdp/module/n1sdp_mhu/include/internal/mhu.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef MHU_H
-#define MHU_H
+#ifndef INTERNAL_MHU_H
+#define INTERNAL_MHU_H
 
 #include <stdint.h>
 #include <fwk_macros.h>
@@ -26,4 +26,4 @@ struct mhu_reg {
     FWK_W  uint32_t CLEAR;
 };
 
-#endif /* MHU_H */
+#endif /* INTERNAL_MHU_H */

--- a/product/n1sdp/module/n1sdp_pcie/include/internal/pcie_ctrl_apb_reg.h
+++ b/product/n1sdp/module/n1sdp_pcie/include/internal/pcie_ctrl_apb_reg.h
@@ -8,8 +8,8 @@
  *     PCIe controller configuration registers.
  */
 
-#ifndef PCIE_CTRL_APB_REG_H
-#define PCIE_CTRL_APB_REG_H
+#ifndef INTERNAL_PCIE_CTRL_APB_REG_H
+#define INTERNAL_PCIE_CTRL_APB_REG_H
 
 #include <stdint.h>
 #include <fwk_macros.h>
@@ -187,4 +187,4 @@ struct pcie_ctrl_apb_reg {
 #define EP_MISC_CTRL_CONFIG_EN_MASK \
         (0x1 << EP_MISC_CTRL_CONFIG_EN_POS)
 
-#endif  /* PCIE_CTRL_APB_REG_H */
+#endif  /* INTERNAL_PCIE_CTRL_APB_REG_H */

--- a/product/n1sdp/module/n1sdp_pll/include/internal/n1sdp_pll.h
+++ b/product/n1sdp/module/n1sdp_pll/include/internal/n1sdp_pll.h
@@ -8,8 +8,8 @@
  *      N1SDP PLL register definitions
  */
 
-#ifndef N1SDP_PLL_H
-#define N1SDP_PLL_H
+#ifndef INTERNAL_N1SDP_PLL_H
+#define INTERNAL_N1SDP_PLL_H
 
 #include <fwk_macros.h>
 
@@ -54,4 +54,4 @@
 /*! The maximum post divider value */
 #define MOD_N1SDP_PLL_POSTDIV_MAX    7
 
-#endif /* N1SDP_PLL_H */
+#endif /* INTERNAL_N1SDP_PLL_H */

--- a/product/n1sdp/module/n1sdp_scp2pcc/include/internal/n1sdp_scp2pcc.h
+++ b/product/n1sdp/module/n1sdp_scp2pcc/include/internal/n1sdp_scp2pcc.h
@@ -8,8 +8,8 @@
  *      N1SDP SCP to PCC message transfer prototypes.
  */
 
-#ifndef N1SDP_SCP2PCC_H
-#define N1SDP_SCP2PCC_H
+#ifndef INTERNAL_N1SDP_SCP2PCC_H
+#define INTERNAL_N1SDP_SCP2PCC_H
 
 #include <stdint.h>
 
@@ -31,4 +31,4 @@ struct mem_msg_packet_st {
     uint8_t payload[MSG_PAYLOAD_SIZE];
 } __attribute__((packed));
 
-#endif /* N1SDP_SCP2PCC_H */
+#endif /* INTERNAL_N1SDP_SCP2PCC_H */

--- a/product/n1sdp/module/n1sdp_smt/include/internal/smt.h
+++ b/product/n1sdp/module/n1sdp_smt/include/internal/smt.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SMT_H
-#define SMT_H
+#ifndef INTERNAL_SMT_H
+#define INTERNAL_SMT_H
 
 struct __attribute((packed)) mod_smt_memory {
     uint32_t reserved0;
@@ -57,4 +57,4 @@ struct __attribute((packed)) mod_smt_memory {
     (((TOKEN) << SCMI_MESSAGE_HEADER_TOKEN_POS) & \
         SCMI_MESSAGE_HEADER_TOKEN_POS))
 
-#endif /* SMT_H */
+#endif /* INTERNAL_SMT_H */

--- a/product/n1sdp/module/scmi_ccix_config/include/internal/mod_scmi_ccix_config.h
+++ b/product/n1sdp/module/scmi_ccix_config/include/internal/mod_scmi_ccix_config.h
@@ -8,8 +8,8 @@
  *      System Control and Management Interface (SCMI) support.
  */
 
-#ifndef SCMI_CCIX_CONFIG_H
-#define SCMI_CCIX_CONFIG_H
+#ifndef INTERNAL_SCMI_CCIX_CONFIG_H
+#define INTERNAL_SCMI_CCIX_CONFIG_H
 
 /*
  * SCMI CCIX config ID definition.
@@ -126,4 +126,4 @@ struct __attribute((packed)) scmi_ccix_config_protocol_sys_coherency_a2p {
 };
 
 
-#endif /* SCMI_CCIX_CONFIG_H */
+#endif /* INTERNAL_SCMI_CCIX_CONFIG_H */

--- a/product/synquacer/module/ccn512/include/internal/ccn512.h
+++ b/product/synquacer/module/ccn512/include/internal/ccn512.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef CCN512_H
-#define CCN512_H
+#ifndef INTERNAL_CCN512_H
+#define INTERNAL_CCN512_H
 
 #include <stdint.h>
 #include <fwk_macros.h>
@@ -262,4 +262,4 @@ typedef struct {
     uint8_t RESERVED1[0xF8];
 } ccn5xx_region_t;
 
-#endif /* CCN512_H */
+#endif /* INTERNAL_CCN512_H */

--- a/product/synquacer/module/f_i2c/include/internal/i2c_depend.h
+++ b/product/synquacer/module/f_i2c/include/internal/i2c_depend.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef I2C_DEPEND_H
-#define I2C_DEPEND_H
+#ifndef INTERNAL_I2C_DEPEND_H
+#define INTERNAL_I2C_DEPEND_H
 
 #include <stdint.h>
 #include <internal/i2c_driver.h>
@@ -23,4 +23,4 @@ I2C_ERR_t f_i2c_api_initialize(
     I2C_TYPE type,
     const I2C_PARAM_t *param);
 
-#endif /* I2C_DEPEND_H */
+#endif /* INTERNAL_I2C_DEPEND_H */

--- a/product/synquacer/module/f_i2c/include/internal/i2c_driver.h
+++ b/product/synquacer/module/f_i2c/include/internal/i2c_driver.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef I2C_DRIVER_H
-#define I2C_DRIVER_H
+#ifndef INTERNAL_I2C_DRIVER_H
+#define INTERNAL_I2C_DRIVER_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -128,4 +128,4 @@ void i2c_disable(I2C_ST_PACKET_INFO_t *packet);
 
 void i2c_enable(I2C_ST_PACKET_INFO_t *packet_info);
 
-#endif /* I2C_DRIVER_H */
+#endif /* INTERNAL_I2C_DRIVER_H */

--- a/product/synquacer/module/f_i2c/include/internal/i2c_reg.h
+++ b/product/synquacer/module/f_i2c/include/internal/i2c_reg.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef I2C_REG_H
-#define I2C_REG_H
+#ifndef INTERNAL_I2C_REG_H
+#define INTERNAL_I2C_REG_H
 
 #include <stdint.h>
 
@@ -280,4 +280,4 @@ typedef union {
 #define I2C_SP1_REG_ADDR_TSHRH ((0x16U) << 2)
 #define I2C_SP1_REG_ADDR_TPSRH ((0x17U) << 2)
 
-#endif /* I2C_REG_H */
+#endif /* INTERNAL_I2C_REG_H */

--- a/product/synquacer/module/f_i2c/include/internal/i2c_reg_access.h
+++ b/product/synquacer/module/f_i2c/include/internal/i2c_reg_access.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef I2C_REG_ACCESS_H
-#define I2C_REG_ACCESS_H
+#ifndef INTERNAL_I2C_REG_ACCESS_H
+#define INTERNAL_I2C_REG_ACCESS_H
 
 #include <stdint.h>
 #include <internal/i2c_driver.h>
@@ -146,4 +146,4 @@ struct I2C_REG_FUNC_TABLE {
     uint8_t (*get_FSR)(I2C_ST_PACKET_INFO_t *packet_info);
 };
 
-#endif /* I2C_REG_ACCESS_H */
+#endif /* INTERNAL_I2C_REG_ACCESS_H */

--- a/product/synquacer/module/hsspi/include/internal/hsspi_api.h
+++ b/product/synquacer/module/hsspi/include/internal/hsspi_api.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef HSSPI_API_H
-#define HSSPI_API_H
+#ifndef INTERNAL_HSSPI_API_H
+#define INTERNAL_HSSPI_API_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -27,4 +27,4 @@ void HSSPI_init(void);
  */
 void HSSPI_exit(void);
 
-#endif /* HSSPI_API_H */
+#endif /* INTERNAL_HSSPI_API_H */

--- a/product/synquacer/module/hsspi/include/internal/hsspi_driver.h
+++ b/product/synquacer/module/hsspi/include/internal/hsspi_driver.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef HSSPI_DRIVER_H
-#define HSSPI_DRIVER_H
+#ifndef INTERNAL_HSSPI_DRIVER_H
+#define INTERNAL_HSSPI_DRIVER_H
 
 #include <stdint.h>
 #include <synquacer_mmap.h>
@@ -86,4 +86,4 @@ void hsspi_set_window_size(
 
 void hsspi_init(volatile REG_ST_HSSPI_t *reg_hsspi);
 
-#endif /* HSSPI_DRIVER_H */
+#endif /* INTERNAL_HSSPI_DRIVER_H */

--- a/product/synquacer/module/hsspi/include/internal/reg_HSSPI.h
+++ b/product/synquacer/module/hsspi/include/internal/reg_HSSPI.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef REG_HSSPI_H
-#define REG_HSSPI_H
+#ifndef INTERNAL_REG_HSSPI_H
+#define INTERNAL_REG_HSSPI_H
 
 #ifdef RESERVED_AREA_BYTE
 #undef RESERVED_AREA_BYTE
@@ -425,4 +425,4 @@ typedef struct {
     unsigned int MID;
 } REG_ST_HSSPI_t;
 
-#endif /* REG_HSSPI_H */
+#endif /* INTERNAL_REG_HSSPI_H */

--- a/product/synquacer/module/scmi_vendor_ext/include/internal/scmi_vendor_ext.h
+++ b/product/synquacer/module/scmi_vendor_ext/include/internal/scmi_vendor_ext.h
@@ -8,8 +8,8 @@
  *      System Control and Management Interface (SCMI) support.
  */
 
-#ifndef SCMI_VENDOR_EXT_H
-#define SCMI_VENDOR_EXT_H
+#ifndef INTERNAL_SCMI_VENDOR_EXT_H
+#define INTERNAL_SCMI_VENDOR_EXT_H
 
 /*!
  * \addtogroup GroupSYNQUACERModule SYNQUACER Product Modules
@@ -102,4 +102,4 @@ struct scmi_vendor_ext_memory_info_get_resp {
  * @}
  */
 
-#endif /* SCMI_VENDOR_EXT_H */
+#endif /* INTERNAL_SCMI_VENDOR_EXT_H */

--- a/product/synquacer/module/synquacer_memc/include/internal/reg_DDRPHY_CONFIG.h
+++ b/product/synquacer/module/synquacer_memc/include/internal/reg_DDRPHY_CONFIG.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef REG_DDRPHY_CONFIG_H
-#define REG_DDRPHY_CONFIG_H
+#ifndef INTERNAL_REG_DDRPHY_CONFIG_H
+#define INTERNAL_REG_DDRPHY_CONFIG_H
 
 #include <stdint.h>
 
@@ -1037,4 +1037,4 @@ typedef volatile struct {
     uint32_t __Reserved_3FF__; // 0x3FF
 } REG_ST_DDRPHY_CONFIG_t;
 
-#endif // REG_DDRPHY_CONFIG_H
+#endif // INTERNAL_REG_DDRPHY_CONFIG_H

--- a/product/synquacer/module/synquacer_memc/include/internal/reg_DMA330.h
+++ b/product/synquacer/module/synquacer_memc/include/internal/reg_DMA330.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef REG_DMA330_H
-#define REG_DMA330_H
+#ifndef INTERNAL_REG_DMA330_H
+#define INTERNAL_REG_DMA330_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -199,4 +199,4 @@ typedef struct {
 
 } REG_ST_DMA330_NS_t;
 
-#endif /* REG_DMA330_H */
+#endif /* INTERNAL_REG_DMA330_H */

--- a/product/synquacer/module/synquacer_memc/include/internal/reg_DMC520.h
+++ b/product/synquacer/module/synquacer_memc/include/internal/reg_DMC520.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef REG_DMC520_H
-#define REG_DMC520_H
+#ifndef INTERNAL_REG_DMC520_H
+#define INTERNAL_REG_DMC520_H
 
 #include <stdint.h>
 
@@ -424,4 +424,4 @@ typedef volatile struct {
     uint32_t component_id_3; // 0x1FFC
 } REG_ST_DMC520;
 
-#endif /* REG_DMC520_H */
+#endif /* INTERNAL_REG_DMC520_H */

--- a/product/synquacer/module/synquacer_system/include/internal/crg11.h
+++ b/product/synquacer/module/synquacer_system/include/internal/crg11.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef CRG11_H
-#define CRG11_H
+#ifndef INTERNAL_CRG11_H
+#define INTERNAL_CRG11_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -33,4 +33,4 @@ typedef struct crg11_state_s {
     unsigned int ap_change_allowed_flag : 1;
 } crg11_state_t;
 
-#endif /* CRG11_H */
+#endif /* INTERNAL_CRG11_H */

--- a/product/synquacer/module/synquacer_system/include/internal/gpio.h
+++ b/product/synquacer/module/synquacer_system/include/internal/gpio.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef GPIO_H
-#define GPIO_H
+#ifndef INTERNAL_GPIO_H
+#define INTERNAL_GPIO_H
 
 #include <stdint.h>
 #include <synquacer_mmap.h>
@@ -23,4 +23,4 @@ uint8_t gpio_get_direction(void *gpio_base_addr, uint32_t idx);
 void gpio_set_function(void *gpio_base_addr, uint32_t idx, uint8_t value);
 uint8_t gpio_get_function(void *gpio_base_addr, uint32_t idx);
 
-#endif /* GPIO_H */
+#endif /* INTERNAL_GPIO_H */

--- a/product/synquacer/module/synquacer_system/include/internal/nic400.h
+++ b/product/synquacer/module/synquacer_system/include/internal/nic400.h
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef NIC400_H
-#define NIC400_H
+#ifndef INTERNAL_NIC400_H
+#define INTERNAL_NIC400_H
 
 #define END_OF_NIC_LIST 0xffU
 #define NIC_SETUP_SKIP 0
 
 void nic_secure_access_ctrl_init(void);
 
-#endif /* NIC_400_H */
+#endif /* INTERNAL_NIC_400_H */

--- a/product/synquacer/module/synquacer_system/include/internal/pmu.h
+++ b/product/synquacer/module/synquacer_system/include/internal/pmu.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef PMU_H
-#define PMU_H
+#ifndef INTERNAL_PMU_H
+#define INTERNAL_PMU_H
 
 #include <stdint.h>
 
@@ -31,4 +31,4 @@ void pmu_write_power_on_priority(uint8_t pd_no, uint8_t value);
 void pmu_write_pwr_cyc_sel(uint32_t value);
 uint32_t pmu_read_pwr_cyc_sel(void);
 
-#endif /* PMU_H */
+#endif /* INTERNAL_PMU_H */

--- a/product/synquacer/module/synquacer_system/include/internal/reg_PPU.h
+++ b/product/synquacer/module/synquacer_system/include/internal/reg_PPU.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef REG_PPU_H
-#define REG_PPU_H
+#ifndef INTERNAL_REG_PPU_H
+#define INTERNAL_REG_PPU_H
 
 #define PPU_BASE_AP 0x54120000
 #define PPU_BASE_SCP 0x48120000
@@ -66,4 +66,4 @@
 #define PPU_COMP_ID2 (PPU_BASE + 0xFF8)
 #define PPU_COMP_ID3 (PPU_BASE + 0xFFC)
 
-#endif /* REG_PPU_H */
+#endif /* INTERNAL_REG_PPU_H */

--- a/product/synquacer/module/synquacer_system/include/internal/reset.h
+++ b/product/synquacer/module/synquacer_system/include/internal/reset.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef RESET_H
-#define RESET_H
+#ifndef INTERNAL_RESET_H
+#define INTERNAL_RESET_H
 
 typedef enum { RST_TYPE_ALL = 0, RST_TYPE_WO_BUS, RST_TYPE_BUS } RST_TYPE_t;
 
@@ -110,4 +110,4 @@ typedef enum {
 void lpcm_sysoc_reset(RST_TYPE_t type, RST_BLOCK block);
 void lpcm_sysoc_reset_clear(RST_TYPE_t type, RST_BLOCK block);
 
-#endif /* RESET_H */
+#endif /* INTERNAL_RESET_H */

--- a/product/synquacer/module/synquacer_system/include/internal/smmu_wrapper.h
+++ b/product/synquacer/module/synquacer_system/include/internal/smmu_wrapper.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SMMU_WRAPPER_H
-#define SMMU_WRAPPER_H
+#ifndef INTERNAL_SMMU_WRAPPER_H
+#define INTERNAL_SMMU_WRAPPER_H
 
 #include <synquacer_debug.h>
 #include <synquacer_mmap.h>
@@ -30,4 +30,4 @@ void smmu_wrapper_initialize(uint8_t mir_id, uint8_t mav_id);
 void smmu_wrapper_initialize(void);
 #endif /* CONFIG_SCB_USE_PCIE_INTERCONNECT */
 
-#endif /* SMMU_WRAPPER_H */
+#endif /* INTERNAL_SMMU_WRAPPER_H */

--- a/product/synquacer/module/synquacer_system/include/internal/synquacer_pd.h
+++ b/product/synquacer/module/synquacer_system/include/internal/synquacer_pd.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SYNQUACER_PD_H
-#define SYNQUACER_PD_H
+#ifndef INTERNAL_SYNQUACER_PD_H
+#define INTERNAL_SYNQUACER_PD_H
 
 #include <internal/reset.h>
 #include <ppu_v0.h>
@@ -281,4 +281,4 @@ uint32_t pmu_wait(uint32_t pmu_bitmap, bool on);
 void power_domain_coldboot(void);
 void power_domain_reboot(void);
 
-#endif /* SYNQUACER_PD_H */
+#endif /* INTERNAL_SYNQUACER_PD_H */

--- a/product/synquacer/module/synquacer_system/include/internal/synquacer_ppu_driver.h
+++ b/product/synquacer/module/synquacer_system/include/internal/synquacer_ppu_driver.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SYNQUACER_PPU_DRIVER_H
-#define SYNQUACER_PPU_DRIVER_H
+#ifndef INTERNAL_SYNQUACER_PPU_DRIVER_H
+#define INTERNAL_SYNQUACER_PPU_DRIVER_H
 
 #include <internal/reg_PPU.h>
 
@@ -39,4 +39,4 @@ int change_power_state(
     int reten);
 int read_power_status(int domain);
 
-#endif /* SYNQUACER_PPU_DRIVER_H */
+#endif /* INTERNAL_SYNQUACER_PPU_DRIVER_H */

--- a/product/synquacer/module/synquacer_system/include/internal/sysoc.h
+++ b/product/synquacer/module/synquacer_system/include/internal/sysoc.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef SYSOC_H
-#define SYSOC_H
+#ifndef INTERNAL_SYSOC_H
+#define INTERNAL_SYSOC_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -22,4 +22,4 @@ int sysoc_wait_status_change(
     bool reset_set_flag,
     uint32_t set_bit);
 
-#endif /* SYSOC_H */
+#endif /* INTERNAL_SYSOC_H */

--- a/product/synquacer/module/synquacer_system/include/internal/thermal_sensor.h
+++ b/product/synquacer/module/synquacer_system/include/internal/thermal_sensor.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef THERMAL_SENSOR_H
-#define THERMAL_SENSOR_H
+#ifndef INTERNAL_THERMAL_SENSOR_H
+#define INTERNAL_THERMAL_SENSOR_H
 
 #define THERMAL_BASE_ADDRESS 0x48190000
 #define THERMAL_INDIVIDUAL_BASE_OFFSET 0x800
@@ -66,4 +66,4 @@
 
 int thermal_enable(void);
 
-#endif /* THERMAL_SENSOR_H */
+#endif /* INTERNAL_THERMAL_SENSOR_H */

--- a/product/synquacer/module/synquacer_system/include/internal/transaction_sw.h
+++ b/product/synquacer/module/synquacer_system/include/internal/transaction_sw.h
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef TRANSACTION_SW_H
-#define TRANSACTION_SW_H
+#ifndef INTERNAL_TRANSACTION_SW_H
+#define INTERNAL_TRANSACTION_SW_H
 
 void set_transactionsw_off(
     uint32_t transactionsw_reg_addr,
@@ -14,4 +14,4 @@ void set_transactionsw_off(
 
 void set_transactionsw_on(uint32_t transactionsw_reg_addr, uint32_t enable_bit);
 
-#endif /* TRANSACTION_SW_H */
+#endif /* INTERNAL_TRANSACTION_SW_H */


### PR DESCRIPTION
Add prefix INTERNAL_ to defined macro for internal header file.
This change prevents an internal/foo.h from obscuring generic
foo.h because former and later both guards from

#ifndef FOO_H
#define FOO_H
(...)
#endif /*FOO_H*/

As internal/*.h are included with #include <internal/*.h>, INTERNAL_
looks a generic enough prefix.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>