### PR TITLE
fwk_interrupt: add missing declaration of exported functions

### DIFF
--- a/framework/include/fwk_interrupt.h
+++ b/framework/include/fwk_interrupt.h
@@ -11,6 +11,7 @@
 #ifndef FWK_INTERRUPT_H
 #define FWK_INTERRUPT_H
 
+#include <fwk_arch.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <limits.h>
@@ -55,6 +56,16 @@
  *      Please refer to the individual function documentation for more details.
  */
 #define FWK_INTERRUPT_EXCEPTION (UINT_MAX - 2)
+
+/*!
+ * \brief Register interrupt driver in the framework.
+ *
+ * \param driver Interrupt driver instance to register
+ *
+ * \retval FWK_SUCCESS Operation succeeded.
+ * \retval FWK_E_PARAM One or more parameters were invalid.
+ */
+int fwk_interrupt_init(const struct fwk_arch_interrupt_driver *driver);
 
 /*!
  * \brief Enable interrupts.

--- a/framework/include/internal/fwk_interrupt.h
+++ b/framework/include/internal/fwk_interrupt.h
@@ -1,0 +1,44 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     Interrupt management internal resources.
+ */
+
+#ifndef INTERNAL_FWK_INTERRUPT_H
+#define INTERNAL_FWK_INTERRUPT_H
+
+/*!
+ * \addtogroup GroupLibFramework Framework
+ * @{
+ */
+
+/*!
+ * \defgroup GroupInterrupt Interrupt Management
+ * @{
+ */
+
+/*!
+ * \brief Set the fault interrupt service routine. This is used internally by
+ *      the framework for test purposes.
+ *
+ * \param isr Pointer to the fault interrupt service routine function.
+ *
+ * \retval FWK_SUCCESS Operation succeeded.
+ * \retval FWK_E_PARAM One or more parameters were invalid.
+ * \retval FWK_E_INIT The component has not been initialized.
+ */
+int fwk_interrupt_set_isr_fault(void (*isr)(void));
+
+/*!
+ * @}
+ */
+
+/*!
+ * @}
+ */
+
+#endif /* INTERNAL_FWK_INTERRUPT_H */

--- a/framework/src/fwk_interrupt.c
+++ b/framework/src/fwk_interrupt.c
@@ -14,6 +14,7 @@
 #include <fwk_interrupt.h>
 #include <fwk_mm.h>
 #include <fwk_status.h>
+#include <internal/fwk_interrupt.h>
 
 static bool initialized;
 static const struct fwk_arch_interrupt_driver *driver;

--- a/framework/test/test_fwk_interrupt.c
+++ b/framework/test/test_fwk_interrupt.c
@@ -12,11 +12,9 @@
 #include <fwk_macros.h>
 #include <fwk_status.h>
 #include <fwk_test.h>
+#include <internal/fwk_interrupt.h>
 
 #define INTERRUPT_ID 42
-
-extern int fwk_interrupt_init(const struct fwk_arch_interrupt_driver *_driver);
-extern int fwk_interrupt_set_isr_fault(void (*isr)(void));
 
 /*
  * Variables for the mock functions


### PR DESCRIPTION
Add missing declaration of exported function fwk_interrupt_init()
and fwk_interrupt_set_isr_fault().

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>