### PR TITLE
log: discard non standard %e format

### DIFF
--- a/framework/include/fwk_status.h
+++ b/framework/include/fwk_status.h
@@ -82,6 +82,15 @@
 #define FWK_E_PANIC         -18
 
 /*!
+ * \brief Return a human readable string representation of a status code.
+ *
+ * \param status Status code value.
+ *
+ * \return String representation of \p status
+ */
+const char *fwk_status_str(int status);
+
+/*!
  * @}
  */
 

--- a/framework/src/Makefile
+++ b/framework/src/Makefile
@@ -23,6 +23,7 @@ endif
 ifeq ($(BUILD_HAS_NOTIFICATION),yes)
     BS_LIB_SOURCES += fwk_notification.c
 endif
+BS_LIB_SOURCES += fwk_status.c
 
 BS_LIB_INCLUDES += $(ARCH_DIR)/include
 BS_LIB_INCLUDES += $(FWK_DIR)/include

--- a/framework/src/fwk_status.c
+++ b/framework/src/fwk_status.c
@@ -1,0 +1,52 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     Framework status code helpers.
+ */
+
+#include <fwk_macros.h>
+#include <fwk_status.h>
+
+static const char * const error_string[] = {
+    [-FWK_E_PARAM]       = "E_PARAM",
+    [-FWK_E_ALIGN]       = "E_ALIGN",
+    [-FWK_E_SIZE]        = "E_SIZE",
+    [-FWK_E_HANDLER]     = "E_HANDLER",
+    [-FWK_E_ACCESS]      = "E_ACCESS",
+    [-FWK_E_RANGE]       = "E_RANGE",
+    [-FWK_E_TIMEOUT]     = "E_TIMEOUT",
+    [-FWK_E_NOMEM]       = "E_NOMEM",
+    [-FWK_E_PWRSTATE]    = "E_PWRSTATE",
+    [-FWK_E_SUPPORT]     = "E_SUPPORT",
+    [-FWK_E_DEVICE]      = "E_DEVICE",
+    [-FWK_E_BUSY]        = "E_BUSY",
+    [-FWK_E_OS]          = "E_OS",
+    [-FWK_E_DATA]        = "E_DATA",
+    [-FWK_E_STATE]       = "E_STATE",
+    [-FWK_E_INIT]        = "E_INIT",
+    [-FWK_E_OVERWRITTEN] = "E_OVERWRITTEN",
+    [-FWK_E_PANIC]       = "E_PANIC",
+};
+
+static const char * const status_string[] = {
+    [FWK_SUCCESS]        = "SUCCESS",
+    [FWK_PENDING]        = "PENDING",
+};
+
+const char *fwk_status_str(int status)
+{
+    static const char unknown[] = "unknown";
+
+    unsigned int error_idx = (unsigned int)(-status);
+
+    if ((status < 0) && (error_idx < FWK_ARRAY_SIZE(error_string)))
+        return error_string[error_idx];
+    else if ((status >= 0) && (status < (int)FWK_ARRAY_SIZE(status_string)))
+        return status_string[status];
+
+    return unknown;
+}

--- a/module/log/include/mod_log.h
+++ b/module/log/include/mod_log.h
@@ -146,7 +146,6 @@ struct mod_log_api {
      *      * \%s - string format
      *      * \%u - unsigned 32-bit decimal format
      *      * \%x - 32-bit hexadecimal format
-     *      * \%e - framework error code format
      *
      *      Numeric formats also accept a padding flag '0\<width\>' between the
      *      '\%' and the format specifier where the resulting string number will

--- a/module/log/src/mod_log.c
+++ b/module/log/src/mod_log.c
@@ -25,28 +25,6 @@ static struct mod_log_driver_api *log_driver;
                          MOD_LOG_GROUP_INFO | \
                          MOD_LOG_GROUP_WARNING)
 
-static const char * const errstr[] = {
-    [FWK_SUCCESS]        = "SUCCESS",
-    [-FWK_E_PARAM]       = "E_PARAM",
-    [-FWK_E_ALIGN]       = "E_ALIGN",
-    [-FWK_E_SIZE]        = "E_SIZE",
-    [-FWK_E_HANDLER]     = "E_HANDLER",
-    [-FWK_E_ACCESS]      = "E_ACCESS",
-    [-FWK_E_RANGE]       = "E_RANGE",
-    [-FWK_E_TIMEOUT]     = "E_TIMEOUT",
-    [-FWK_E_NOMEM]       = "E_NOMEM",
-    [-FWK_E_PWRSTATE]    = "E_PWRSTATE",
-    [-FWK_E_SUPPORT]     = "E_SUPPORT",
-    [-FWK_E_DEVICE]      = "E_DEVICE",
-    [-FWK_E_BUSY]        = "E_BUSY",
-    [-FWK_E_OS]          = "E_OS",
-    [-FWK_E_DATA]        = "E_DATA",
-    [-FWK_E_STATE]       = "E_STATE",
-    [-FWK_E_INIT]        = "E_INIT",
-    [-FWK_E_OVERWRITTEN] = "E_OVERWRITTEN",
-    [-FWK_E_PANIC]       = "E_PANIC",
-};
-
 static int do_putchar(char c)
 {
     int status;
@@ -141,23 +119,6 @@ static int do_print(const char *fmt, va_list *args)
 next_symbol:
             /* Check the format specifier */
             switch (*fmt) {
-            case 'e':
-                num = va_arg(*args, int);
-                unum = (uint64_t)(-num);
-                if ((num <= 0) && (unum < FWK_ARRAY_SIZE(errstr))) {
-
-                    status = print_string("FWK_");
-                    if (status != FWK_SUCCESS)
-                        return status;
-
-                    status = print_string(errstr[unum]);
-                } else
-                    status = print_int32(num, 0);
-
-                if (status != FWK_SUCCESS)
-                    return status;
-                break;
-
             case 'i': /* Fall through to next one */
             case 'd':
                 if (bit64)

--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -294,7 +294,7 @@ static const unsigned int mod_pd_cs_level_state_shift[MOD_PD_LEVEL_COUNT] = {
  * Internal variables
  */
 static struct mod_pd_ctx mod_pd_ctx;
-static const char driver_error_msg[] = "[PD] Driver error %e in %s @%d\n";
+static const char driver_error_msg[] = "[PD] Driver error %s (%d) in %s @%d\n";
 
 static const unsigned int tree_pos_level_shift[MOD_PD_LEVEL_COUNT] = {
     MOD_PD_TREE_POS_LEVEL_0_SHIFT,
@@ -711,9 +711,9 @@ static int initiate_power_state_transition(struct pd_ctx *pd)
     status = pd->driver_api->set_state(pd->driver_id, state);
 
     mod_pd_ctx.log_api->log(MOD_LOG_GROUP_DEBUG,
-        "[PD] %s: %s->%s, %e\n", fwk_module_get_name(pd->id),
+        "[PD] %s: %s->%s, %s (%d)\n", fwk_module_get_name(pd->id),
         get_state_name(pd, pd->state_requested_to_driver),
-        get_state_name(pd, state), status);
+        get_state_name(pd, state), fwk_status_str(status), status);
 
     pd->state_requested_to_driver = state;
 
@@ -1208,8 +1208,8 @@ static void process_system_shutdown_request(
 
         if (status != FWK_SUCCESS)
             mod_pd_ctx.log_api->log(MOD_LOG_GROUP_ERROR,
-                "[PD] Shutdown of %s returned %e\n",
-                fwk_module_get_name(pd_id), status);
+                "[PD] Shutdown of %s returned %s (%d)\n",
+                fwk_module_get_name(pd_id), fwk_status_str(status), status);
         else
             mod_pd_ctx.log_api->log(MOD_LOG_GROUP_DEBUG,
                 "[PD] %s shutdown\n", fwk_module_get_name(pd_id));
@@ -1795,7 +1795,7 @@ static int pd_start(fwk_id_t id)
         status = pd->driver_api->get_state(pd->driver_id, &state);
         if (status != FWK_SUCCESS) {
             mod_pd_ctx.log_api->log(MOD_LOG_GROUP_ERROR, driver_error_msg,
-                status, __func__, __LINE__);
+                fwk_status_str(status), status, __func__, __LINE__);
         } else {
             pd->requested_state = pd->state_requested_to_driver = state;
 

--- a/module/scmi/src/mod_scmi.c
+++ b/module/scmi/src/mod_scmi.c
@@ -265,7 +265,8 @@ static void respond(fwk_id_t service_id, const void *payload, size_t size)
     status = ctx->respond(ctx->transport_id, payload, size);
     if (status != FWK_SUCCESS)
         scmi_ctx.log_api->log(MOD_LOG_GROUP_ERROR,
-            "[SCMI] Failed to send response (%e)\n", status);
+            "[SCMI] Failed to send response %s (%d)\n",
+            fwk_status_str(status), status);
 }
 
 static const struct mod_scmi_from_protocol_api mod_scmi_from_protocol_api = {
@@ -790,8 +791,9 @@ static int scmi_process_event(const struct fwk_event *event,
 
     if (status != FWK_SUCCESS) {
         scmi_ctx.log_api->log(MOD_LOG_GROUP_ERROR,
-            "[SCMI] Protocol 0x%x handler error (%e), message_id = 0x%x\n",
-            ctx->scmi_protocol_id, status, ctx->scmi_message_id);
+            "[SCMI] Protocol 0x%x handler error %s (%d), message_id = 0x%x\n",
+            ctx->scmi_protocol_id, fwk_status_str(status), status,
+            ctx->scmi_message_id);
     }
 
     return FWK_SUCCESS;

--- a/module/scmi_power_domain/src/mod_scmi_power_domain.c
+++ b/module/scmi_power_domain/src/mod_scmi_power_domain.c
@@ -290,8 +290,8 @@ static int scmi_power_scp_set_core_state(fwk_id_t pd_id,
                                                            composite_state);
     if (status != FWK_SUCCESS) {
         scmi_pd_ctx.log_api->log(MOD_LOG_GROUP_ERROR,
-            "[SCMI:power] Failed to send core set request (error %e)\n",
-            status);
+            "[SCMI:power] Failed to send core set request (error %s (%d))\n",
+            fwk_status_str(status), status);
     }
 
     return status;


### PR DESCRIPTION
Prior this change was %e a valid format for printing error codes as
strings when identified. This change removes such support and replace
use of %e with use of standard format identifier and a error code
to string conversion function.

With this change, any standard printf-like format comply with
SCP-firmware traces implementation. fwk_err2str() helps traces to get
nice string identifier for errors.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>