### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 # Ctags Index
 tags
 
+# Cscope Index
+cscope.*
+
 # Eclipse IDE
 .cproject
 .project
@@ -26,6 +29,7 @@ tags
 
 # Git
 *.orig
+*.patch
 
 # Intellij IDE
 .idea


### PR DESCRIPTION
This patch updates .gitignore file to ignore patch files(often generated
by git format-patch) and cscope index files(similar to ctags)

Change-Id: I134631306e7741e9e2e4e8d4a86c2f84f5166f77
Signed-off-by: Sudeep Holla <sudeep.holla@arm.com>