### PR TITLE
n1sdp: introduce multichip information SDS region.

### DIFF
--- a/product/n1sdp/include/n1sdp_sds.h
+++ b/product/n1sdp/include/n1sdp_sds.h
@@ -23,6 +23,7 @@ enum n1sdp_sds_struct_id {
     N1SDP_SDS_CPU_FLAGS =            7 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
     N1SDP_SDS_DDR_MEM_INFO =         8 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
     N1SDP_SDS_BL33_INFO =            9 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
+    N1SDP_SDS_MULTICHIP_INFO =      10 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
 };
 
 /*
@@ -37,6 +38,7 @@ enum n1sdp_sds_struct_id {
 #define N1SDP_SDS_CPU_FLAGS_SIZE             256
 #define N1SDP_SDS_DDR_MEM_INFO_SIZE          4
 #define N1SDP_SDS_BL33_INFO_SIZE             12
+#define N1SDP_SDS_MULTICHIP_INFO_SIZE        4
 
 /*
  * Field masks and offsets for the N1SDP_SDS_AP_CPU_INFO structure.
@@ -71,5 +73,5 @@ struct n1sdp_sds_platid {
 #define SDS_ELEMENT_IDX_FEATURE_AVAILABILITY  3
 #define SDS_ELEMENT_IDX_DDR_MEM_INFO          4
 #define SDS_ELEMENT_IDX_BL33_INFO             5
-
+#define SDS_ELEMENT_IDX_MULTICHIP_INFO        6
 #endif /* N1SDP_SDS_H */

--- a/product/n1sdp/scp_ramfw/config_sds.c
+++ b/product/n1sdp/scp_ramfw/config_sds.c
@@ -80,6 +80,14 @@ static struct fwk_element sds_element_table[] = {
             .finalize = true,
         }),
     },
+    {
+        .name = "Multichip Info",
+        .data = &((struct mod_sds_structure_desc) {
+            .id = N1SDP_SDS_MULTICHIP_INFO,
+            .size = N1SDP_SDS_MULTICHIP_INFO_SIZE,
+            .finalize = true,
+        }),
+    },
 #ifdef BUILD_HAS_MOD_TEST
     {
         .name = "Boot Counters",


### PR DESCRIPTION
N1SDP can support multichip configuration wherein n1sdp boards are
connected over high speed coherent CCIX link, for now only dual-chip
is supported.

Multichip information can only be probed in SCP, use SDS region to
propagate this information to TF-A.

This patch introduces a new SDS to store multichip information and a
place holder to update this information provided by C2C module which is
responsible for probing chip-to-chip information.

Currently it is configured as single-chip system but once C2C module is
added this information will be filled dynamically.

Change-Id: I57e4aac5c32aa22f927faac4a3f91876ef34dd23
Signed-off-by: Manish Pandey <manish.pandey2@arm.com>