### PR TITLE
N1sdp/c2c phase 1

### DIFF
--- a/product/n1sdp/include/n1sdp_scp_mmap.h
+++ b/product/n1sdp/include/n1sdp_scp_mmap.h
@@ -42,7 +42,8 @@
  * Peripherals - Serial communication
  */
 #define SCP_UART_BASE                (SCP_PERIPHERAL_BASE + 0x2000)
-#define SCP_I2C0_BASE                (0xBC040000)
+#define DIMM_SPD_I2C_BASE            (0xBC040000)
+#define SCP_I2C0_BASE                (0x3FFFA000)
 #define SCP_I2C1_BASE                (0x3FFFB000)
 #define SCP_I2C2_BASE                (0x3FFFC000)
 

--- a/product/n1sdp/module/n1sdp_c2c/include/mod_n1sdp_c2c_i2c.h
+++ b/product/n1sdp/module/n1sdp_c2c/include/mod_n1sdp_c2c_i2c.h
@@ -1,0 +1,127 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     N1SDP SCP to SCP I2C communication protocol module.
+ */
+
+#ifndef MOD_N1SDP_C2C_I2C_H
+#define MOD_N1SDP_C2C_I2C_H
+
+#include <stdint.h>
+#include <fwk_id.h>
+
+/*!
+ * \addtogroup GroupN1SDPModule N1SDP Product Modules
+ * @{
+ */
+
+/*!
+ * \defgroup GroupN1SDPN1SDPC2C N1SDP SCP2SCP I2C communication protocol
+ *
+ * \brief Driver support for N1SDP C2C.
+ *
+ * \details This module provides support for SCP to SCP I2C communication.
+ *
+ * \{
+ */
+
+/*!
+ * \brief N1SDP C2C Handshake commands
+ */
+enum n1sdp_c2c_cmd {
+    N1SDP_C2C_CMD_CHECK_SLAVE,
+    N1SDP_C2C_CMD_PCIE_POWER_ON,
+    N1SDP_C2C_CMD_PCIE_PHY_INIT,
+    N1SDP_C2C_CMD_PCIE_CTRL_INIT,
+    N1SDP_C2C_CMD_PCIE_LINK_TRAIN,
+    N1SDP_C2C_CMD_PCIE_RC_SETUP,
+    N1SDP_C2C_CMD_PCIE_VC1_CONFIG,
+    N1SDP_C2C_CMD_PCIE_CCIX_CONFIG,
+    N1SDP_C2C_CMD_CMN600_SET_CONFIG,
+    N1SDP_C2C_CMD_CMN600_XCHANGE_CREDITS,
+    N1SDP_C2C_CMD_CMN600_ENTER_SYS_COHERENCY,
+    N1SDP_C2C_CMD_CMN600_ENTER_DVM_DOMAIN,
+    N1SDP_C2C_CMD_GET_SLV_DDR_SIZE,
+    N1SDP_C2C_CMD_POWER_DOMAIN_ON,
+    N1SDP_C2C_CMD_POWER_DOMAIN_OFF,
+};
+
+/*!
+ * \brief N1SDP SCP to SCP I2C module configuration
+ */
+struct n1sdp_c2c_dev_config {
+    /*! Identifier of I2C device ID */
+    fwk_id_t i2c_id;
+    /*! I2C slave address to be used */
+    uint8_t slave_addr;
+    /*! PCIe element identifier for CCIX */
+    fwk_id_t ccix_id;
+};
+
+/*!
+ * \brief Module API indices
+ */
+enum n1sdp_c2c_api_idx {
+    /*! Index of the N1SDP C2C slave information API */
+    N1SDP_C2C_API_IDX_SLAVE_INFO,
+
+    /*! Index of the N1SDP C2C power domain API */
+    N1SDP_C2C_API_IDX_PD,
+
+    /*! Number of APIs */
+    N1SDP_C2C_API_COUNT
+};
+
+/*!
+ * \brief N1SDP C2C slave information API
+ */
+struct n1sdp_c2c_slave_info_api {
+   /*!
+    * \brief API to check if slave is alive or not.
+    *
+    * \retval true If slave is alive.
+    * \return false If slave is not alive.
+    */
+   bool (*is_slave_alive)(void);
+   /*!
+    * \brief API to get slave chip's DDR size in GB.
+    *
+    * \param size_gb Pointer to storage where the size is stored.
+    *
+    * \retval FWK_SUCCESS If operation succeeds.
+    * \return One of the possible error return codes.
+    */
+   int (*get_ddr_size_gb)(uint8_t *size_gb);
+};
+
+/*!
+ * \brief N1SDP C2C power domain API
+ */
+struct n1sdp_c2c_pd_api {
+   /*!
+    * \brief API to execute a power domain command.
+    *
+    * \param cmd The C2C command type to issue.
+    * \param pd_id The target power domain ID.
+    * \param pd_type The target power domain type.
+    *
+    * \retval true If slave is alive.
+    * \return false If slave is not alive.
+    */
+   int (*pd_run_cmd)(enum n1sdp_c2c_cmd cmd, unsigned int pd_id,
+                 unsigned int pd_type);
+};
+
+/*!
+ * @}
+ */
+
+/*!
+ * @}
+ */
+
+#endif /* MOD_N1SDP_C2C_I2C_H */

--- a/product/n1sdp/module/n1sdp_c2c/src/Makefile
+++ b/product/n1sdp/module/n1sdp_c2c/src/Makefile
@@ -1,0 +1,11 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BS_LIB_NAME := "N1SDP-C2C"
+BS_LIB_SOURCES += mod_n1sdp_c2c_i2c.c
+
+include $(BS_DIR)/lib.mk

--- a/product/n1sdp/module/n1sdp_c2c/src/mod_n1sdp_c2c_i2c.c
+++ b/product/n1sdp/module/n1sdp_c2c/src/mod_n1sdp_c2c_i2c.c
@@ -1,0 +1,907 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     N1SDP SCP to SCP I2C communications protocol driver
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <stdbool.h>
+#include <fwk_assert.h>
+#include <fwk_element.h>
+#include <fwk_id.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+#include <fwk_notification.h>
+#include <mod_clock.h>
+#include <mod_cmn600.h>
+#include <mod_log.h>
+#include <mod_n1sdp_c2c_i2c.h>
+#include <mod_n1sdp_dmc620.h>
+#include <mod_n1sdp_i2c.h>
+#include <mod_n1sdp_pcie.h>
+#include <mod_power_domain.h>
+#include <config_clock.h>
+#include <n1sdp_core.h>
+
+/* Module definitions */
+#define N1SDP_C2C_DATA_SIZE        8
+#define CCIX_VC1_TC                7
+#define CCIX_OPT_TLP_EN            1
+#define CMN600_CCIX_LINK_ID        0
+
+#define N1SDP_C2C_SUCCESS          0
+#define N1SDP_C2C_ERROR            1
+
+static const char * const cmd_str[] = {
+    [N1SDP_C2C_CMD_CHECK_SLAVE] = "Check slave alive",
+    [N1SDP_C2C_CMD_PCIE_POWER_ON] = "PCIe power ON",
+    [N1SDP_C2C_CMD_PCIE_PHY_INIT] = "PCIe PHY init",
+    [N1SDP_C2C_CMD_PCIE_CTRL_INIT] = "PCIe controller init",
+    [N1SDP_C2C_CMD_PCIE_LINK_TRAIN] = "PCIe link training",
+    [N1SDP_C2C_CMD_PCIE_RC_SETUP] = "PCIe RC setup",
+    [N1SDP_C2C_CMD_PCIE_VC1_CONFIG] = "PCIe VC1 setup",
+    [N1SDP_C2C_CMD_PCIE_CCIX_CONFIG] = "PCIe CCIX setup",
+    [N1SDP_C2C_CMD_CMN600_SET_CONFIG] = "CMN600 CCIX setup",
+    [N1SDP_C2C_CMD_CMN600_XCHANGE_CREDITS] = "CMN600 exchange credits",
+    [N1SDP_C2C_CMD_CMN600_ENTER_SYS_COHERENCY] =
+        "CMN600 enter system coherency",
+    [N1SDP_C2C_CMD_CMN600_ENTER_DVM_DOMAIN] = "CMN600 enter DVM domain",
+    [N1SDP_C2C_CMD_GET_SLV_DDR_SIZE] = "Get slave DDR size",
+    [N1SDP_C2C_CMD_POWER_DOMAIN_ON] = "Power domain ON",
+    [N1SDP_C2C_CMD_POWER_DOMAIN_OFF] = "Power domain OFF",
+};
+
+/* Module context */
+struct n1sdp_c2c_ctx {
+    /*  Pointer to module configuration */
+    struct n1sdp_c2c_dev_config *config;
+
+    /* Log API pointer */
+    const struct mod_log_api *log_api;
+
+    /* I2C Master API ID */
+    struct mod_n1sdp_i2c_master_api_polled *master_api;
+
+    /* I2C Slave API ID */
+    struct mod_n1sdp_i2c_slave_api_irq *slave_api;
+
+    /* PCIe init API */
+    struct n1sdp_pcie_init_api *pcie_init_api;
+
+    /* CCIX config API */
+    struct n1sdp_pcie_ccix_config_api *ccix_config_api;
+
+    /* CMN600 config API */
+    struct mod_cmn600_ccix_config_api *cmn600_api;
+
+    /* Power domain module API */
+    struct mod_pd_restricted_api *pd_api;
+
+    /* DMC620 memory information API */
+    struct mod_dmc620_mem_info_api *dmc620_api;
+
+    /* Chip ID */
+    uint8_t chip_id;
+
+    /* Multi chip mode flag */
+    bool mc_mode;
+
+    /* Identifier if slave chip is alive or not */
+    bool slave_alive;
+
+    /* Storage for slave DDR size in GB */
+    uint8_t slave_ddr_size_gb;
+
+    /* Storage for transmit data in master mode */
+    uint8_t master_tx_data[N1SDP_C2C_DATA_SIZE];
+
+    /* Storage for received data in master mode */
+    uint8_t master_rx_data[N1SDP_C2C_DATA_SIZE];
+
+    /* Storage for received data in slave mode */
+    uint8_t slave_rx_data[N1SDP_C2C_DATA_SIZE];
+
+    /* Storage for transmit data in slave mode */
+    uint8_t slave_tx_data[N1SDP_C2C_DATA_SIZE];
+};
+
+static struct n1sdp_c2c_ctx n1sdp_c2c_ctx;
+
+/*
+ * Master side protocol functions
+ */
+static int n1sdp_c2c_master_tx_command(uint8_t cmd)
+{
+    int status;
+
+    n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                               "[C2C] %s in slave...", cmd_str[cmd]);
+
+    n1sdp_c2c_ctx.master_tx_data[0] = cmd;
+    status = n1sdp_c2c_ctx.master_api->write(
+        n1sdp_c2c_ctx.config->i2c_id,
+        n1sdp_c2c_ctx.config->slave_addr,
+        (char *)&n1sdp_c2c_ctx.master_tx_data[0],
+        N1SDP_C2C_DATA_SIZE, true);
+    if (status != FWK_SUCCESS) {
+        n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+        return status;
+    }
+    n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
+
+    return FWK_SUCCESS;
+}
+
+static int n1sdp_c2c_master_rx_response(void)
+{
+    int status;
+
+    n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                               "[C2C] Waiting for response from slave...");
+    status = n1sdp_c2c_ctx.master_api->read(
+        n1sdp_c2c_ctx.config->i2c_id,
+        n1sdp_c2c_ctx.config->slave_addr,
+        (char *)&n1sdp_c2c_ctx.master_rx_data[0], N1SDP_C2C_DATA_SIZE);
+    if (status != FWK_SUCCESS) {
+        n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error %d!\n", status);
+        return status;
+    }
+    n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Received\n");
+
+    return FWK_SUCCESS;
+}
+
+static int n1sdp_c2c_check_remote(void)
+{
+    int status;
+
+    if (n1sdp_c2c_ctx.chip_id == 0) {
+        status = n1sdp_c2c_master_tx_command(
+            (uint8_t)N1SDP_C2C_CMD_CHECK_SLAVE);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.slave_alive = false;
+            return FWK_E_DEVICE;
+        }
+
+        status = n1sdp_c2c_master_rx_response();
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.slave_alive = false;
+            return status;
+        }
+
+        n1sdp_c2c_ctx.slave_alive = true;
+        n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "[C2C] Slave Alive!\n");
+        return FWK_SUCCESS;
+    } else {
+        status = n1sdp_c2c_ctx.slave_api->read(
+            n1sdp_c2c_ctx.config->i2c_id,
+            &n1sdp_c2c_ctx.slave_rx_data[0], N1SDP_C2C_DATA_SIZE);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                "[C2C] Error setting up I2C for reception!\n");
+            return status;
+        }
+    }
+
+    return FWK_SUCCESS;
+}
+
+static int n1sdp_c2c_multichip_run_command(uint8_t cmd, bool run_in_slave)
+{
+    struct mod_cmn600_ccix_remote_node_config remote_config;
+    int status;
+
+    if (run_in_slave) {
+        status = n1sdp_c2c_master_tx_command(cmd);
+        if (status != FWK_SUCCESS)
+            return status;
+    }
+
+    n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                               "[C2C] %s in master...\n", cmd_str[cmd]);
+
+    switch (cmd) {
+    case N1SDP_C2C_CMD_PCIE_POWER_ON:
+        status = n1sdp_c2c_ctx.pcie_init_api->power_on(
+            n1sdp_c2c_ctx.config->ccix_id);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+        }
+        break;
+
+    case N1SDP_C2C_CMD_PCIE_PHY_INIT:
+        status = n1sdp_c2c_ctx.pcie_init_api->phy_init(
+            n1sdp_c2c_ctx.config->ccix_id);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+        }
+        break;
+
+    case N1SDP_C2C_CMD_PCIE_CTRL_INIT:
+        status = n1sdp_c2c_ctx.pcie_init_api->controller_init(
+            n1sdp_c2c_ctx.config->ccix_id, false);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+        }
+        break;
+
+    case N1SDP_C2C_CMD_PCIE_LINK_TRAIN:
+        status = n1sdp_c2c_ctx.pcie_init_api->link_training(
+            n1sdp_c2c_ctx.config->ccix_id, false);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+        }
+        break;
+
+    case N1SDP_C2C_CMD_PCIE_RC_SETUP:
+        status = n1sdp_c2c_ctx.pcie_init_api->rc_setup(
+            n1sdp_c2c_ctx.config->ccix_id);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+        }
+        break;
+
+    case N1SDP_C2C_CMD_PCIE_VC1_CONFIG:
+        status = n1sdp_c2c_ctx.pcie_init_api->vc1_setup(
+            n1sdp_c2c_ctx.config->ccix_id, CCIX_VC1_TC);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+        }
+        break;
+
+    case N1SDP_C2C_CMD_PCIE_CCIX_CONFIG:
+        status = n1sdp_c2c_ctx.ccix_config_api->enable_opt_tlp(
+            CCIX_OPT_TLP_EN);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+        }
+        break;
+
+    case N1SDP_C2C_CMD_CMN600_SET_CONFIG:
+        remote_config.remote_ra_count = 2;
+        remote_config.remote_sa_count = 0;
+        remote_config.remote_ha_count = 1;
+        remote_config.ccix_tc = CCIX_VC1_TC;
+        remote_config.ccix_msg_pack_enable = false;
+        remote_config.pcie_bus_num = 1;
+        remote_config.ccix_link_id = 0;
+        remote_config.ccix_opt_tlp = CCIX_OPT_TLP_EN;
+        remote_config.remote_ha_mmap_count = 1;
+        remote_config.remote_ha_mmap[0].ha_id = 0x1;
+        remote_config.remote_ha_mmap[0].base = (4ULL * FWK_TIB);
+        remote_config.remote_ha_mmap[0].size = (4ULL * FWK_TIB);
+
+        status = n1sdp_c2c_ctx.cmn600_api->set_config(&remote_config);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+        }
+        break;
+
+    case N1SDP_C2C_CMD_CMN600_XCHANGE_CREDITS:
+        status = n1sdp_c2c_ctx.cmn600_api->exchange_protocol_credit(
+            CMN600_CCIX_LINK_ID);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+        }
+        break;
+
+    case N1SDP_C2C_CMD_CMN600_ENTER_SYS_COHERENCY:
+        status = n1sdp_c2c_ctx.cmn600_api->enter_system_coherency(
+            CMN600_CCIX_LINK_ID);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+        }
+        break;
+
+    case N1SDP_C2C_CMD_CMN600_ENTER_DVM_DOMAIN:
+        status = n1sdp_c2c_ctx.cmn600_api->enter_dvm_domain(
+            CMN600_CCIX_LINK_ID);
+        if (status != FWK_SUCCESS) {
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+        }
+        break;
+
+    case N1SDP_C2C_CMD_GET_SLV_DDR_SIZE:
+        if (run_in_slave) {
+            status = n1sdp_c2c_master_rx_response();
+            if (status != FWK_SUCCESS)
+                return status;
+            if (n1sdp_c2c_ctx.master_rx_data[0] != N1SDP_C2C_SUCCESS) {
+                n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                           "[C2C] Command failed in slave!\n");
+                return FWK_E_STATE;
+            }
+            n1sdp_c2c_ctx.slave_ddr_size_gb = n1sdp_c2c_ctx.master_rx_data[1];
+            n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                       "[C2C] Slave DDR Size: %d GB\n",
+                                       n1sdp_c2c_ctx.slave_ddr_size_gb);
+        }
+        break;
+
+    default:
+        n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                   "[C2C] Unsupported command\n");
+        return FWK_E_DEVICE;
+    }
+
+    return FWK_SUCCESS;
+}
+
+static int n1sdp_c2c_multichip_init(void)
+{
+    int status;
+
+    status = n1sdp_c2c_multichip_run_command(N1SDP_C2C_CMD_PCIE_POWER_ON,
+                                             true);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_multichip_run_command(N1SDP_C2C_CMD_PCIE_PHY_INIT,
+                                             true);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_multichip_run_command(N1SDP_C2C_CMD_PCIE_CCIX_CONFIG,
+                                             true);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_multichip_run_command(N1SDP_C2C_CMD_PCIE_CTRL_INIT,
+                                             true);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_multichip_run_command(N1SDP_C2C_CMD_PCIE_LINK_TRAIN,
+                                             true);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_multichip_run_command(N1SDP_C2C_CMD_PCIE_RC_SETUP,
+                                             false);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_multichip_run_command(N1SDP_C2C_CMD_PCIE_VC1_CONFIG,
+                                             false);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_multichip_run_command(N1SDP_C2C_CMD_CMN600_SET_CONFIG,
+                                             true);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_multichip_run_command(
+        N1SDP_C2C_CMD_CMN600_XCHANGE_CREDITS, true);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_multichip_run_command(
+        N1SDP_C2C_CMD_CMN600_ENTER_SYS_COHERENCY, true);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_multichip_run_command(
+        N1SDP_C2C_CMD_CMN600_ENTER_DVM_DOMAIN, true);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_multichip_run_command(N1SDP_C2C_CMD_GET_SLV_DDR_SIZE,
+                                             true);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    return FWK_SUCCESS;
+}
+
+/*
+ * Slave side protocol functions
+ */
+static int n1sdp_c2c_process_command(const struct fwk_event *event)
+{
+    int status;
+    uint8_t cmd;
+    uint8_t rx_data[N1SDP_C2C_DATA_SIZE];
+    uint32_t ddr_size_gb = 0;
+    struct mod_cmn600_ccix_remote_node_config remote_config;
+
+    memcpy(rx_data, n1sdp_c2c_ctx.slave_rx_data, N1SDP_C2C_DATA_SIZE);
+
+    cmd = rx_data[0];
+
+    switch (cmd) {
+    case N1SDP_C2C_CMD_CHECK_SLAVE:
+        status = FWK_SUCCESS;
+        break;
+
+    case N1SDP_C2C_CMD_PCIE_POWER_ON:
+        status = n1sdp_c2c_ctx.pcie_init_api->power_on(
+            n1sdp_c2c_ctx.config->ccix_id);
+        if (status != FWK_SUCCESS)
+            goto error;
+        break;
+
+    case N1SDP_C2C_CMD_PCIE_PHY_INIT:
+        status = n1sdp_c2c_ctx.pcie_init_api->phy_init(
+            n1sdp_c2c_ctx.config->ccix_id);
+        if (status != FWK_SUCCESS)
+            goto error;
+        break;
+
+    case N1SDP_C2C_CMD_PCIE_CTRL_INIT:
+        status = n1sdp_c2c_ctx.pcie_init_api->controller_init(
+            n1sdp_c2c_ctx.config->ccix_id, true);
+        if (status != FWK_SUCCESS)
+            goto error;
+        break;
+
+    case N1SDP_C2C_CMD_PCIE_LINK_TRAIN:
+        status = n1sdp_c2c_ctx.pcie_init_api->link_training(
+            n1sdp_c2c_ctx.config->ccix_id, true);
+        if (status != FWK_SUCCESS)
+            goto error;
+        break;
+
+    case N1SDP_C2C_CMD_PCIE_CCIX_CONFIG:
+        status = n1sdp_c2c_ctx.ccix_config_api->enable_opt_tlp(
+            CCIX_OPT_TLP_EN);
+        if (status != FWK_SUCCESS)
+            goto error;
+        break;
+
+    case N1SDP_C2C_CMD_CMN600_SET_CONFIG:
+        remote_config.remote_ra_count = 2;
+        remote_config.remote_sa_count = 0;
+        remote_config.remote_ha_count = 1;
+        remote_config.ccix_tc = CCIX_VC1_TC;
+        remote_config.ccix_msg_pack_enable = false;
+        remote_config.pcie_bus_num = 1;
+        remote_config.ccix_link_id = 0;
+        remote_config.ccix_opt_tlp = CCIX_OPT_TLP_EN;
+        remote_config.remote_ha_mmap_count = 1;
+        remote_config.remote_ha_mmap[0].ha_id = 0x0;
+        remote_config.remote_ha_mmap[0].base = 0;
+        remote_config.remote_ha_mmap[0].size = (4ULL * FWK_TIB);
+        status = n1sdp_c2c_ctx.cmn600_api->set_config(&remote_config);
+        if (status != FWK_SUCCESS)
+            goto error;
+        break;
+
+    case N1SDP_C2C_CMD_CMN600_XCHANGE_CREDITS:
+        status = n1sdp_c2c_ctx.cmn600_api->exchange_protocol_credit(
+            CMN600_CCIX_LINK_ID);
+        if (status != FWK_SUCCESS)
+            goto error;
+        break;
+
+    case N1SDP_C2C_CMD_CMN600_ENTER_SYS_COHERENCY:
+        status = n1sdp_c2c_ctx.cmn600_api->enter_system_coherency(
+            CMN600_CCIX_LINK_ID);
+        if (status != FWK_SUCCESS)
+            goto error;
+        break;
+
+    case N1SDP_C2C_CMD_CMN600_ENTER_DVM_DOMAIN:
+        status = n1sdp_c2c_ctx.cmn600_api->enter_dvm_domain(
+            CMN600_CCIX_LINK_ID);
+        if (status != FWK_SUCCESS)
+            goto error;
+        break;
+
+    case N1SDP_C2C_CMD_GET_SLV_DDR_SIZE:
+        status = n1sdp_c2c_ctx.dmc620_api->get_mem_size_gb(&ddr_size_gb);
+        if (status != FWK_SUCCESS)
+            goto error;
+        n1sdp_c2c_ctx.slave_tx_data[1] = (uint8_t)ddr_size_gb;
+        break;
+
+    case N1SDP_C2C_CMD_POWER_DOMAIN_OFF:
+        status = n1sdp_c2c_ctx.pd_api->set_composite_state_async(
+            FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
+            false,
+            MOD_PD_COMPOSITE_STATE(MOD_PD_LEVEL_2, 0, MOD_PD_STATE_ON,
+                                   MOD_PD_STATE_ON, MOD_PD_STATE_OFF));
+        if (status != FWK_SUCCESS)
+            goto error;
+        break;
+
+    case N1SDP_C2C_CMD_POWER_DOMAIN_ON:
+        status = n1sdp_c2c_ctx.pd_api->set_composite_state_async(
+            FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
+            false,
+            MOD_PD_COMPOSITE_STATE(MOD_PD_LEVEL_2, 0, MOD_PD_STATE_ON,
+                                   MOD_PD_STATE_ON, MOD_PD_STATE_ON));
+        if (status != FWK_SUCCESS)
+            goto error;
+        break;
+
+    default:
+        n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                   "[C2C] Unsupported command %d\n", cmd);
+        status = FWK_E_SUPPORT;
+    }
+
+error:
+    if (status == FWK_SUCCESS)
+        n1sdp_c2c_ctx.slave_tx_data[0] = N1SDP_C2C_SUCCESS;
+    else
+        n1sdp_c2c_ctx.slave_tx_data[0] = N1SDP_C2C_ERROR;
+
+    status = n1sdp_c2c_ctx.slave_api->write(
+        n1sdp_c2c_ctx.config->i2c_id,
+        &n1sdp_c2c_ctx.slave_tx_data[0], N1SDP_C2C_DATA_SIZE);
+    if (status != FWK_SUCCESS) {
+        n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                   "[C2C] Error setting up write transfer!\n");
+        return status;
+    }
+
+    return FWK_SUCCESS;
+}
+
+static int n1sdp_c2c_wait_for_next_command(const struct fwk_event *event)
+{
+    int status;
+
+    status = n1sdp_c2c_ctx.slave_api->read(
+        n1sdp_c2c_ctx.config->i2c_id,
+        &n1sdp_c2c_ctx.slave_rx_data[0], N1SDP_C2C_DATA_SIZE);
+    if (status != FWK_SUCCESS) {
+        n1sdp_c2c_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                                   "[C2C] Error setting up read transfer!\n");
+        return status;
+    }
+    return FWK_SUCCESS;
+}
+
+/*
+ * Module APIs
+ */
+
+/*
+ * Slave information API
+ */
+static bool n1sdp_c2c_is_slave_alive(void)
+{
+    return n1sdp_c2c_ctx.slave_alive;
+}
+
+static int n1sdp_c2c_get_ddr_size_gb(uint8_t *size_gb)
+{
+    fwk_assert(size_gb != NULL);
+
+    *size_gb = n1sdp_c2c_ctx.slave_ddr_size_gb;
+
+    return FWK_SUCCESS;
+}
+
+
+static const struct n1sdp_c2c_slave_info_api slave_info_api = {
+    .is_slave_alive = n1sdp_c2c_is_slave_alive,
+    .get_ddr_size_gb = n1sdp_c2c_get_ddr_size_gb,
+};
+
+/*
+ * Power domain API
+ */
+static int n1sdp_c2c_pd_run_cmd(enum n1sdp_c2c_cmd cmd, unsigned int pd_id,
+    unsigned int pd_type)
+{
+    int status;
+
+    if ((cmd != N1SDP_C2C_CMD_POWER_DOMAIN_ON) ||
+        (cmd != N1SDP_C2C_CMD_POWER_DOMAIN_OFF))
+        return FWK_E_PARAM;
+
+    n1sdp_c2c_ctx.master_tx_data[1] = pd_id;
+    n1sdp_c2c_ctx.master_tx_data[2] = pd_type;
+    status = n1sdp_c2c_master_tx_command(cmd);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = n1sdp_c2c_master_rx_response();
+    if (status != FWK_SUCCESS)
+        return status;
+
+    return FWK_SUCCESS;
+}
+
+static const struct n1sdp_c2c_pd_api pd_api = {
+    .pd_run_cmd = n1sdp_c2c_pd_run_cmd,
+};
+
+/*
+ * Framework Handlers
+ */
+
+static int n1sdp_c2c_init(fwk_id_t module_id, unsigned int unused,
+    const void *data)
+{
+    if (data == NULL)
+        return FWK_E_PARAM;
+
+    n1sdp_c2c_ctx.config = (struct n1sdp_c2c_dev_config *)data;
+
+    n1sdp_c2c_ctx.mc_mode = n1sdp_is_multichip_enabled();
+    if (!n1sdp_c2c_ctx.mc_mode)
+        return FWK_SUCCESS;
+
+    n1sdp_c2c_ctx.chip_id = n1sdp_get_chipid();
+
+    return FWK_SUCCESS;
+}
+
+static int n1sdp_c2c_bind(fwk_id_t id, unsigned int round)
+{
+    int status;
+
+    if (!n1sdp_c2c_ctx.mc_mode)
+        return FWK_SUCCESS;
+
+    if (round == 0) {
+        status = fwk_module_bind(FWK_ID_MODULE(FWK_MODULE_IDX_LOG),
+                                 MOD_LOG_API_ID, &n1sdp_c2c_ctx.log_api);
+        if (status != FWK_SUCCESS)
+            return status;
+
+        status = fwk_module_bind(n1sdp_c2c_ctx.config->ccix_id,
+                                 FWK_ID_API(FWK_MODULE_IDX_N1SDP_PCIE,
+                                            N1SDP_PCIE_API_IDX_PCIE_INIT),
+                                 &n1sdp_c2c_ctx.pcie_init_api);
+        if (status != FWK_SUCCESS)
+            return status;
+
+        status = fwk_module_bind(n1sdp_c2c_ctx.config->ccix_id,
+                                 FWK_ID_API(FWK_MODULE_IDX_N1SDP_PCIE,
+                                            N1SDP_PCIE_API_IDX_CCIX_CONFIG),
+                                 &n1sdp_c2c_ctx.ccix_config_api);
+        if (status != FWK_SUCCESS)
+            return status;
+
+        status = fwk_module_bind(FWK_ID_MODULE(FWK_MODULE_IDX_CMN600),
+                                 FWK_ID_API(FWK_MODULE_IDX_CMN600,
+                                            MOD_CMN600_API_IDX_CCIX_CONFIG),
+                                 &n1sdp_c2c_ctx.cmn600_api);
+        if (status != FWK_SUCCESS)
+            return status;
+
+        status = fwk_module_bind(fwk_module_id_power_domain,
+                                 mod_pd_api_id_restricted,
+                                 &n1sdp_c2c_ctx.pd_api);
+        if (status != FWK_SUCCESS)
+            return status;
+
+        status = fwk_module_bind(FWK_ID_MODULE(FWK_MODULE_IDX_N1SDP_DMC620),
+                                 FWK_ID_API(FWK_MODULE_IDX_N1SDP_DMC620,
+                                            MOD_DMC620_API_IDX_MEM_INFO),
+                                 &n1sdp_c2c_ctx.dmc620_api);
+        if (status != FWK_SUCCESS)
+            return status;
+
+        if (n1sdp_c2c_ctx.chip_id == 0) {
+            status = fwk_module_bind(n1sdp_c2c_ctx.config->i2c_id,
+                FWK_ID_API(FWK_MODULE_IDX_N1SDP_I2C,
+                           MOD_N1SDP_I2C_API_MASTER_POLLED),
+                &n1sdp_c2c_ctx.master_api);
+            if (status != FWK_SUCCESS)
+                return status;
+        } else {
+            status = fwk_module_bind(n1sdp_c2c_ctx.config->i2c_id,
+                                     FWK_ID_API(FWK_MODULE_IDX_N1SDP_I2C,
+                                                MOD_N1SDP_I2C_API_SLAVE_IRQ),
+                                     &n1sdp_c2c_ctx.slave_api);
+            if (status != FWK_SUCCESS)
+                return status;
+        }
+    }
+
+    return FWK_SUCCESS;
+}
+
+static int n1sdp_c2c_process_bind_request(fwk_id_t requester_id,
+    fwk_id_t target_id, fwk_id_t api_id, const void **api)
+{
+    switch (fwk_id_get_api_idx(api_id)) {
+    case N1SDP_C2C_API_IDX_SLAVE_INFO:
+        *api = &slave_info_api;
+        break;
+    case N1SDP_C2C_API_IDX_PD:
+        *api = &pd_api;
+        break;
+    default:
+        return FWK_E_PARAM;
+    }
+
+    return FWK_SUCCESS;
+}
+
+static int n1sdp_c2c_start(fwk_id_t id)
+{
+    int status;
+
+    if (!n1sdp_c2c_ctx.mc_mode)
+        return FWK_SUCCESS;
+
+    if (fwk_id_is_type(id, FWK_ID_TYPE_ELEMENT))
+        return FWK_SUCCESS;
+
+    status = fwk_notification_subscribe(
+        mod_clock_notification_id_state_changed,
+        FWK_ID_ELEMENT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_INTERCONNECT), id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    status = fwk_notification_subscribe(mod_n1sdp_i2c_notification_id_slave_rx,
+                                        n1sdp_c2c_ctx.config->i2c_id, id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    return fwk_notification_subscribe(mod_n1sdp_i2c_notification_id_slave_tx,
+                                      n1sdp_c2c_ctx.config->i2c_id, id);
+}
+
+static int n1sdp_c2c_process_notification(const struct fwk_event *event,
+    struct fwk_event *resp_event)
+{
+    int status;
+
+    if (fwk_id_is_equal(event->id, mod_clock_notification_id_state_changed)) {
+        status = n1sdp_c2c_check_remote();
+        if (status == FWK_SUCCESS && (n1sdp_c2c_ctx.chip_id == 0)) {
+            status = n1sdp_c2c_multichip_init();
+            if (status != FWK_SUCCESS)
+                n1sdp_c2c_ctx.slave_alive = false;
+        }
+        /*
+         * Unsubscribe from notification as C2C initialization will be done
+         * only during cold boot and system suspend is not supported in N1SDP.
+         */
+        return fwk_notification_unsubscribe(event->id, event->source_id,
+                                            event->target_id);
+    } else if (fwk_id_is_equal(event->id,
+                               mod_n1sdp_i2c_notification_id_slave_rx)) {
+        return n1sdp_c2c_process_command(event);
+    } else if (fwk_id_is_equal(event->id,
+                               mod_n1sdp_i2c_notification_id_slave_tx)) {
+        return n1sdp_c2c_wait_for_next_command(event);
+    }
+
+    return FWK_SUCCESS;
+}
+
+const struct fwk_module module_n1sdp_c2c = {
+    .name = "N1SDP C2C",
+    .type = FWK_MODULE_TYPE_PROTOCOL,
+    .api_count = N1SDP_C2C_API_COUNT,
+    .init = n1sdp_c2c_init,
+    .bind = n1sdp_c2c_bind,
+    .process_bind_request = n1sdp_c2c_process_bind_request,
+    .process_notification = n1sdp_c2c_process_notification,
+    .start = n1sdp_c2c_start,
+};

--- a/product/n1sdp/module/n1sdp_dmc620/src/dimm_spd.c
+++ b/product/n1sdp/module/n1sdp_dmc620/src/dimm_spd.c
@@ -28,7 +28,7 @@ static struct ddr4_spd ddr4_dimm1;
  * Internal APIs used by SPD functions
  */
 
-static int spd_read(struct mod_n1sdp_i2c_master_api *i2c_api,
+static int spd_read(struct mod_n1sdp_i2c_master_api_polled *i2c_api,
     int address, uint8_t *spd_data)
 {
     char data[2] = {0};
@@ -430,7 +430,7 @@ static uint32_t cal_dly_wth_rounding(int32_t spd_val, int32_t spd_val_fine)
 /*
  * APIs invoked by DMC-620 core functions
  */
-int dimm_spd_init_check(struct mod_n1sdp_i2c_master_api *i2c_api,
+int dimm_spd_init_check(struct mod_n1sdp_i2c_master_api_polled *i2c_api,
                          struct dimm_info *ddr)
 {
     int status;

--- a/product/n1sdp/module/n1sdp_dmc620/src/dimm_spd.h
+++ b/product/n1sdp/module/n1sdp_dmc620/src/dimm_spd.h
@@ -360,7 +360,7 @@ struct ddr4_spd {
  * retval - FWK_SUCCESS - if the operation is succeeded
  *          FWK_E_DATA - if the SPD data is wrong
  */
-int dimm_spd_init_check(struct mod_n1sdp_i2c_master_api *i2c_api,
+int dimm_spd_init_check(struct mod_n1sdp_i2c_master_api_polled *i2c_api,
                          struct dimm_info *ddr);
 
 /*

--- a/product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c
+++ b/product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c
@@ -32,7 +32,7 @@
 static struct mod_log_api *log_api;
 static struct mod_dmc_ddr_phy_api *ddr_phy_api;
 static struct mod_timer_api *timer_api;
-static struct mod_n1sdp_i2c_master_api *i2c_api;
+static struct mod_n1sdp_i2c_master_api_polled *i2c_api;
 static struct dimm_info ddr_info;
 
 /*
@@ -1271,7 +1271,8 @@ static int mod_dmc620_bind(fwk_id_t id, unsigned int round)
         return status;
 
     status = fwk_module_bind(FWK_ID_MODULE(FWK_MODULE_IDX_N1SDP_I2C),
-                             FWK_ID_API(FWK_MODULE_IDX_N1SDP_I2C, 0),
+                             FWK_ID_API(FWK_MODULE_IDX_N1SDP_I2C,
+                                        MOD_N1SDP_I2C_API_MASTER_POLLED),
                              &i2c_api);
     if (status != FWK_SUCCESS)
         return status;

--- a/product/n1sdp/module/n1sdp_i2c/src/mod_n1sdp_i2c.c
+++ b/product/n1sdp/module/n1sdp_i2c/src/mod_n1sdp_i2c.c
@@ -8,15 +8,19 @@
  *     N1SDP I2C Driver
  */
 
+#include <string.h>
+#include <stdbool.h>
 #include <fwk_assert.h>
+#include <fwk_interrupt.h>
 #include <fwk_mm.h>
 #include <fwk_module.h>
+#include <fwk_notification.h>
 #include <fwk_status.h>
 #include <internal/n1sdp_i2c.h>
 #include <mod_log.h>
 #include <mod_n1sdp_i2c.h>
 #include <mod_power_domain.h>
-#include <stdbool.h>
+#include <n1sdp_core.h>
 
 /* I2C divider calculation values */
 #define I2C_HZ                  22
@@ -39,6 +43,13 @@
 /* Read a register field. */
 #define I2C_REG_R(reg, mask, shift)        (((reg) & (mask)) >> (shift))
 
+/* ISR error mask */
+#define I2C_ISR_ERROR_MASK      (I2C_ISR_RXUNF_MASK | \
+                                 I2C_ISR_TXOVF_MASK | \
+                                 I2C_ISR_RXOVF_MASK | \
+                                 I2C_ISR_NACK_MASK  | \
+                                 I2C_ISR_TO_MASK)
+
 /* Device context */
 struct n1sdp_i2c_dev_ctx {
     /* Pointer to the device configuration */
@@ -49,6 +60,16 @@ struct n1sdp_i2c_dev_ctx {
 
     /* Track repeated transfer of data */
     bool perform_repeat_start;
+
+    /* IRQ mode data context */
+    struct mod_n1sdp_i2c_irq_data_ctx irq_data_ctx;
+
+    /* I2C ID */
+    unsigned int i2c_id;
+
+    /* I2C callback pointer */
+    void (*i2c_callback)(struct n1sdp_i2c_dev_ctx *ctx,
+                         enum mod_n1sdp_i2c_notifications cb_type);
 };
 
 /* Module context */
@@ -62,6 +83,39 @@ struct n1sdp_i2c_ctx {
 
 static struct n1sdp_i2c_ctx i2c_ctx;
 
+/* Callback function */
+static void i2c_callback_fn(struct n1sdp_i2c_dev_ctx *ctx,
+    enum mod_n1sdp_i2c_notifications cb_type)
+{
+    unsigned int i;
+    struct fwk_event c2c_event;
+
+    fwk_assert(ctx != NULL);
+
+    if (!fwk_id_is_equal(ctx->config->callback_mod_id, FWK_ID_NONE)) {
+        memset((void *)&c2c_event, 0, sizeof(struct fwk_event));
+        switch (cb_type) {
+        case MOD_N1SDP_I2C_NOTIFICATION_IDX_TX:
+            c2c_event.id = mod_n1sdp_i2c_notification_id_slave_tx;
+            break;
+        case MOD_N1SDP_I2C_NOTIFICATION_IDX_RX:
+            c2c_event.id = mod_n1sdp_i2c_notification_id_slave_rx;
+            break;
+        case MOD_N1SDP_I2C_NOTIFICATION_IDX_ERROR:
+            c2c_event.id = mod_n1sdp_i2c_notification_id_slave_error;
+            break;
+        default:
+            fwk_assert(false);
+            return;
+        }
+        c2c_event.response_requested = false;
+        c2c_event.source_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_N1SDP_I2C,
+                                             ctx->i2c_id);
+        c2c_event.target_id = ctx->config->callback_mod_id;
+        fwk_notification_notify(&c2c_event, &i);
+    }
+}
+
 static void clear_isr(struct n1sdp_i2c_dev_ctx *device_ctx)
 {
     uint16_t reg;
@@ -70,11 +124,109 @@ static void clear_isr(struct n1sdp_i2c_dev_ctx *device_ctx)
     I2C_REG_W(device_ctx->reg->ISR, I2C_ISR_MASK, I2C_ISR_SHIFT, reg);
 }
 
+static void i2c_isr(uintptr_t data)
+{
+    struct n1sdp_i2c_dev_ctx *ctx;
+    uint16_t isr = 0;
+    uint32_t i = 0;
+
+    ctx = (struct n1sdp_i2c_dev_ctx *)data;
+
+    /* Save ISR and clear the register */
+    isr = ctx->reg->ISR;
+    ctx->reg->ISR = isr;
+
+    if (isr == 0)
+        return;
+
+    if (isr & I2C_ISR_ERROR_MASK)
+        goto i2c_error;
+
+    switch (ctx->irq_data_ctx.state) {
+    case MOD_N1SDP_I2C_STATE_TX:
+        /* Check for data interrupt */
+        if (isr & I2C_ISR_DATA_MASK) {
+            for (i = 0; (i < (I2C_TSR_TANSFER_SIZE - 2)) &&
+                        (ctx->irq_data_ctx.index < ctx->irq_data_ctx.size);
+                 i++) {
+                ctx->reg->DR = ctx->irq_data_ctx.data[ctx->irq_data_ctx.index];
+                ctx->irq_data_ctx.index++;
+            }
+        }
+        break;
+
+    case MOD_N1SDP_I2C_STATE_RX:
+        /* Read new data from FIFO. */
+        for (; (ctx->reg->SR & I2C_SR_RXDV_MASK) &&
+               (ctx->irq_data_ctx.index < ctx->irq_data_ctx.size);
+             ctx->irq_data_ctx.index++) {
+            ctx->irq_data_ctx.data[ctx->irq_data_ctx.index] =
+                (uint8_t)ctx->reg->DR;
+        }
+
+        /* Make sure transaction sizes align. */
+        if (ctx->reg->SR & I2C_SR_RXDV_MASK)
+            goto i2c_error;
+
+        /* If master, reload TSR if more data expected. */
+        if ((ctx->config->mode == MOD_N1SDP_I2C_MASTER_MODE) &&
+            (ctx->irq_data_ctx.index < ctx->irq_data_ctx.size)) {
+            if ((ctx->irq_data_ctx.size - ctx->irq_data_ctx.index) >
+                I2C_TSR_TANSFER_SIZE)
+                ctx->reg->TSR = I2C_TSR_TANSFER_SIZE;
+            else
+                ctx->reg->TSR = (ctx->irq_data_ctx.size -
+                                 ctx->irq_data_ctx.index);
+        }
+        break;
+
+    default:
+        goto i2c_error;
+    }
+
+    /* Check for completion interrupt */
+    if (isr & I2C_ISR_COMP_MASK) {
+        /* Make sure the correct amount of data was transferred */
+        if (ctx->irq_data_ctx.index != ctx->irq_data_ctx.size)
+            goto i2c_error;
+
+        ctx->irq_data_ctx.busy = false;
+
+        /* Run completion callback */
+        if ((ctx->irq_data_ctx.state == MOD_N1SDP_I2C_STATE_TX) &&
+            (ctx->i2c_callback))
+            ctx->i2c_callback(ctx, MOD_N1SDP_I2C_NOTIFICATION_IDX_TX);
+        else if ((ctx->irq_data_ctx.state == MOD_N1SDP_I2C_STATE_RX) &&
+                 (ctx->i2c_callback))
+            ctx->i2c_callback(ctx, MOD_N1SDP_I2C_NOTIFICATION_IDX_RX);
+
+        /* Reset I2C driver state */
+        ctx->reg->IDR = 0xFFFF;
+        I2C_REG_RMW(ctx->reg->CR, I2C_CR_CLRFIFO_MASK, I2C_CR_CLRFIFO_SHIFT,
+                    I2C_CLRFIFO_ON);
+        ctx->irq_data_ctx.data = NULL;
+    }
+    return;
+
+i2c_error:
+    if (ctx->i2c_callback)
+        ctx->i2c_callback(ctx, MOD_N1SDP_I2C_NOTIFICATION_IDX_ERROR);
+
+    ctx->reg->IDR = 0xFFFF;
+    I2C_REG_RMW(ctx->reg->CR, I2C_CR_CLRFIFO_MASK, I2C_CR_CLRFIFO_SHIFT,
+                I2C_CLRFIFO_ON);
+    ctx->irq_data_ctx.data = NULL;
+}
+
 /*
- * Module I2C driver API
+ * Module I2C driver APIs
  */
-static int i2c_master_read(fwk_id_t device_id, uint16_t address, char *data,
-                           uint16_t length)
+
+/*
+ * I2C master polled mode driver API
+ */
+static int i2c_master_read_polled(fwk_id_t device_id,
+    uint16_t address, char *data, uint16_t length)
 {
     bool complete = false;
     unsigned int timeout;
@@ -121,7 +273,8 @@ static int i2c_master_read(fwk_id_t device_id, uint16_t address, char *data,
     }
 
     if (timeout == 0) {
-        i2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "read: timeout expired\n");
+        I2C_REG_RMW(device_ctx->reg->CR, I2C_CR_HOLD_MASK, I2C_CR_HOLD_SHIFT,
+                    I2C_HOLD_OFF);
         return FWK_E_STATE;
     }
 
@@ -149,8 +302,8 @@ static int i2c_master_read(fwk_id_t device_id, uint16_t address, char *data,
     return FWK_SUCCESS;
 }
 
-static int i2c_master_write(fwk_id_t device_id, uint16_t address,
-                            const char *data, uint16_t length, bool stop)
+static int i2c_master_write_polled(fwk_id_t device_id, uint16_t address,
+    const char *data, uint16_t length, bool stop)
 {
     bool complete = false;
     unsigned int timeout;
@@ -215,7 +368,10 @@ static int i2c_master_write(fwk_id_t device_id, uint16_t address,
     }
 
     if (timeout == 0) {
-        i2c_ctx.log_api->log(MOD_LOG_GROUP_INFO, "write: timeout expired\n");
+        /* Clear the hold bit to signify the end of the write sequence */
+        I2C_REG_RMW(device_ctx->reg->CR, I2C_CR_HOLD_MASK, I2C_CR_HOLD_SHIFT,
+                    I2C_HOLD_OFF);
+        clear_isr(device_ctx);
         return FWK_E_STATE;
     }
 
@@ -234,9 +390,94 @@ static int i2c_master_write(fwk_id_t device_id, uint16_t address,
     return FWK_SUCCESS;
 }
 
-static const struct mod_n1sdp_i2c_master_api driver_api = {
-    .read = i2c_master_read,
-    .write = i2c_master_write,
+static const struct mod_n1sdp_i2c_master_api_polled i2c_master_api_polled = {
+    .read = i2c_master_read_polled,
+    .write = i2c_master_write_polled,
+};
+
+/*
+ * I2C slave interrupt mode driver API
+ */
+static int i2c_slave_write_irq(fwk_id_t device_id,
+    uint8_t *data, uint8_t length)
+{
+    int status;
+    struct n1sdp_i2c_dev_ctx *device_ctx;
+
+    status = fwk_module_check_call(device_id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    device_ctx = &i2c_ctx.device_ctx_table[fwk_id_get_element_idx(device_id)];
+
+    fwk_assert((length != 0) && (data != NULL));
+
+    if (device_ctx->irq_data_ctx.busy)
+        return FWK_E_BUSY;
+
+    device_ctx->irq_data_ctx.state = MOD_N1SDP_I2C_STATE_TX;
+    device_ctx->irq_data_ctx.data = data;
+    device_ctx->irq_data_ctx.size = length;
+    device_ctx->irq_data_ctx.index = 0;
+    device_ctx->irq_data_ctx.busy = true;
+
+    /* Clear FIFO */
+    I2C_REG_RMW(device_ctx->reg->CR, I2C_CR_CLRFIFO_MASK, I2C_CR_CLRFIFO_SHIFT,
+                    I2C_CLRFIFO_ON);
+
+    /* Clear any pending IRQs and re-enable interrupts */
+    device_ctx->reg->ISR = I2C_ISR_MASK;
+    device_ctx->reg->IER = (I2C_IER_COMP_MASK | I2C_IER_DATA_MASK |
+                            I2C_IER_NACK_MASK | I2C_IER_RXOVF_MASK |
+                            I2C_IER_TXOVF_MASK | I2C_IER_RXUNF_MASK);
+
+    /* ISR will take over from here */
+    return FWK_SUCCESS;
+}
+
+static int i2c_slave_read_irq(fwk_id_t device_id,
+    uint8_t *data, uint8_t length)
+{
+    int status;
+    struct n1sdp_i2c_dev_ctx *device_ctx;
+
+    status = fwk_module_check_call(device_id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    device_ctx = &i2c_ctx.device_ctx_table[fwk_id_get_element_idx(device_id)];
+
+    fwk_assert((length != 0) && (data != NULL));
+
+    if (device_ctx->irq_data_ctx.busy)
+        return FWK_E_BUSY;
+
+    device_ctx->irq_data_ctx.state = MOD_N1SDP_I2C_STATE_RX;
+    device_ctx->irq_data_ctx.data = data;
+    device_ctx->irq_data_ctx.size = length;
+    device_ctx->irq_data_ctx.index = 0;
+    device_ctx->irq_data_ctx.busy = true;
+
+    /* Clear FIFO */
+    I2C_REG_RMW(device_ctx->reg->CR, I2C_CR_CLRFIFO_MASK, I2C_CR_CLRFIFO_SHIFT,
+                    I2C_CLRFIFO_ON);
+
+    if (length < (I2C_TSR_TANSFER_SIZE - 2))
+        device_ctx->reg->TSR = length;
+
+    /* Clear any pending IRQs and re-enable interrupts */
+    device_ctx->reg->ISR = I2C_ISR_MASK;
+    device_ctx->reg->IER = (I2C_IER_COMP_MASK | I2C_IER_DATA_MASK |
+                            I2C_IER_NACK_MASK | I2C_IER_RXOVF_MASK |
+                            I2C_IER_TXOVF_MASK | I2C_IER_RXUNF_MASK);
+
+    /* ISR will take over from here */
+    return FWK_SUCCESS;
+}
+
+static const struct mod_n1sdp_i2c_slave_api_irq i2c_slave_api_irq = {
+    .read = i2c_slave_read_irq,
+    .write = i2c_slave_write_irq,
 };
 
 static void i2c_init(struct n1sdp_i2c_dev_ctx *device_ctx,
@@ -284,10 +525,8 @@ static int n1sdp_i2c_element_init(fwk_id_t element_id, unsigned int unused,
 
     config = (struct mod_n1sdp_i2c_device_config *)data;
 
-    if ((config->mode != MOD_N1SDP_I2C_MASTER_MODE) ||
-        (config->addr_size != MOD_N1SDP_I2C_ADDRESS_7_BIT) ||
-        (config->ack_en != MOD_N1SDP_I2C_ACK_ENABLE) ||
-        (config->hold_mode != MOD_N1SDP_I2C_HOLD_ON))
+    if ((config->addr_size != MOD_N1SDP_I2C_ADDRESS_7_BIT) ||
+        (config->ack_en != MOD_N1SDP_I2C_ACK_ENABLE))
         return FWK_E_SUPPORT;
 
     device_ctx = &i2c_ctx.device_ctx_table[fwk_id_get_element_idx(element_id)];
@@ -297,8 +536,20 @@ static int n1sdp_i2c_element_init(fwk_id_t element_id, unsigned int unused,
     device_ctx->config = config;
     device_ctx->reg = (struct i2c_reg *)config->reg_base;
 
-    I2C_REG_RMW(device_ctx->reg->CR, I2C_CR_MS_MASK, I2C_CR_MS_SHIFT,
-                config->mode);
+    if (config->c2c_mode) {
+        if (n1sdp_get_chipid() == 0x0) {
+            I2C_REG_RMW(device_ctx->reg->CR, I2C_CR_MS_MASK, I2C_CR_MS_SHIFT,
+                        MOD_N1SDP_I2C_MASTER_MODE);
+        } else {
+            I2C_REG_RMW(device_ctx->reg->CR, I2C_CR_MS_MASK, I2C_CR_MS_SHIFT,
+                        MOD_N1SDP_I2C_SLAVE_MODE);
+            I2C_REG_W(device_ctx->reg->AR, I2C_AR_ADD7_MASK, I2C_AR_ADD7_SHIFT,
+                      config->slave_addr);
+        }
+    } else {
+        I2C_REG_RMW(device_ctx->reg->CR, I2C_CR_MS_MASK, I2C_CR_MS_SHIFT,
+                    config->mode);
+    }
 
     I2C_REG_RMW(device_ctx->reg->CR, I2C_CR_NEA_MASK, I2C_CR_NEA_SHIFT,
                 config->addr_size);
@@ -328,7 +579,55 @@ static int n1sdp_i2c_bind(fwk_id_t id, unsigned int round)
 static int n1sdp_i2c_process_bind_request(fwk_id_t requester_id,
     fwk_id_t target_id, fwk_id_t api_id, const void **api)
 {
-    *api = &driver_api;
+    switch (fwk_id_get_api_idx(api_id)) {
+    case MOD_N1SDP_I2C_API_MASTER_POLLED:
+        *api = &i2c_master_api_polled;
+        break;
+    case MOD_N1SDP_I2C_API_SLAVE_IRQ:
+        *api = &i2c_slave_api_irq;
+        break;
+    default:
+        return FWK_E_PARAM;
+    }
+
+    return FWK_SUCCESS;
+}
+
+static int n1sdp_i2c_start(fwk_id_t id)
+{
+    int status;
+    struct n1sdp_i2c_dev_ctx *device_ctx;
+    unsigned int i2c_irq;
+    unsigned int i2c_element_id;
+
+    /* Nothing to do for module */
+    if (!fwk_module_is_valid_element_id(id))
+        return FWK_SUCCESS;
+
+    i2c_element_id = fwk_id_get_element_idx(id);
+    device_ctx = &i2c_ctx.device_ctx_table[i2c_element_id];
+    if (device_ctx == NULL)
+        return FWK_E_DATA;
+
+    device_ctx->i2c_id = i2c_element_id;
+
+    if (device_ctx->config->c2c_mode && (n1sdp_get_chipid() != 0x0)) {
+        i2c_irq = device_ctx->config->irq;
+        status = fwk_interrupt_set_isr_param(i2c_irq, i2c_isr,
+                                             (uintptr_t)device_ctx);
+        if (status != FWK_SUCCESS)
+            return FWK_E_DEVICE;
+
+        status = fwk_interrupt_clear_pending(i2c_irq);
+        if (status != FWK_SUCCESS)
+            return FWK_E_DEVICE;
+
+        status = fwk_interrupt_enable(i2c_irq);
+        if (status != FWK_SUCCESS)
+            return FWK_E_DEVICE;
+
+        device_ctx->i2c_callback = i2c_callback_fn;
+    }
 
     return FWK_SUCCESS;
 }
@@ -336,9 +635,11 @@ static int n1sdp_i2c_process_bind_request(fwk_id_t requester_id,
 const struct fwk_module module_n1sdp_i2c = {
     .name = "N1SDP_I2C",
     .type = FWK_MODULE_TYPE_DRIVER,
-    .api_count = 1,
+    .api_count = MOD_N1SDP_I2C_API_COUNT,
+    .notification_count = MOD_N1SDP_I2C_NOTIFICATION_COUNT,
     .init = n1sdp_i2c_init,
     .element_init = n1sdp_i2c_element_init,
     .bind = n1sdp_i2c_bind,
     .process_bind_request = n1sdp_i2c_process_bind_request,
+    .start = n1sdp_i2c_start,
 };

--- a/product/n1sdp/module/n1sdp_pcie/include/mod_n1sdp_pcie.h
+++ b/product/n1sdp/module/n1sdp_pcie/include/mod_n1sdp_pcie.h
@@ -10,6 +10,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <fwk_id.h>
 
 /*!
  * \addtogroup GroupN1SDPModule N1SDP Product Modules
@@ -67,11 +68,72 @@ struct n1sdp_pcie_dev_config {
  * \brief Module API indices
  */
 enum n1sdp_pcie_api_idx {
+    /*! Index of the PCIe initialization API */
+    N1SDP_PCIE_API_IDX_PCIE_INIT,
+
     /*! Index of the CCIX config API */
     N1SDP_PCIE_API_IDX_CCIX_CONFIG,
 
     /*! Number of APIs */
     N1SDP_PCIE_API_COUNT
+};
+
+/*!
+ * \brief N1SDP PCIe initialization api
+ */
+struct n1sdp_pcie_init_api {
+   /*!
+    * \brief API to power ON the PCIe controller
+    *
+    * \param id Identifier of the PCIe instance
+    *
+    * \retval FWK_SUCCESS The operation succeeded.
+    * \return One of the standard error codes.
+    */
+   int (*power_on)(fwk_id_t id);
+
+   /*!
+    * \brief API to initialize the PHY layer
+    *
+    * \param id Identifier of the PCIe instance
+    *
+    * \retval FWK_SUCCESS The operation succeeded.
+    * \return One of the standard error codes.
+    */
+   int (*phy_init)(fwk_id_t id);
+
+   /*!
+    * \brief API to initialize the PCIe controller
+    *
+    * \param id Identifier of the PCIe instance
+    * \param ep_mode Identifier to configure the controller
+    * in root port or endpoint mode
+    *
+    * \retval FWK_SUCCESS The operation succeeded.
+    * \return One of the standard error codes.
+    */
+   int (*controller_init)(fwk_id_t id, bool ep_mode);
+
+   /*!
+    * \brief API to perform the link training process
+    *
+    * \param id Identifier of the PCIe instance
+    *
+    * \retval FWK_SUCCESS The operation succeeded.
+    * \return One of the standard error codes.
+    */
+   int (*link_training)(fwk_id_t id, bool ep_mode);
+
+   /*!
+    * \brief API to setup the root complex
+    *
+    * \param id Identifier of the PCIe instance
+    *
+    * \retval FWK_SUCCESS The operation succeeded.
+    * \return One of the standard error codes.
+    */
+   int (*rc_setup)(fwk_id_t id);
+
 };
 
 /*!
@@ -91,7 +153,6 @@ struct n1sdp_pcie_ccix_config_api {
    int (*enable_opt_tlp)(bool enable);
 
 };
-
 
 /*!
  * \}

--- a/product/n1sdp/module/n1sdp_pcie/include/mod_n1sdp_pcie.h
+++ b/product/n1sdp/module/n1sdp_pcie/include/mod_n1sdp_pcie.h
@@ -134,6 +134,18 @@ struct n1sdp_pcie_init_api {
     */
    int (*rc_setup)(fwk_id_t id);
 
+   /*!
+    * \brief API to enable Virtual Channel 1 and map to
+    * specified Traffic class. This API is used in multichip mode.
+    *
+    * \param id Identifier of the PCIe instance
+    * \param vc1_tc Traffic class to be mapped to VC1
+    *
+    * \retval FWK_SUCCESS The operation succeeded.
+    * \return One of the standard error codes.
+    */
+   int (*vc1_setup)(fwk_id_t id, uint8_t vc1_tc);
+
 };
 
 /*!

--- a/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
+++ b/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
@@ -87,8 +87,10 @@ struct n1sdp_pcie_ctx {
 
 struct n1sdp_pcie_ctx pcie_ctx;
 
+static const char * const pcie_type[2] = {"PCIe", "CCIX"};
+
 /*
- * Module functions
+ * CCIX configuration API
  */
 static int n1sdp_pcie_ccix_enable_opt_tlp(bool enable)
 {
@@ -116,7 +118,7 @@ static int n1sdp_pcie_ccix_enable_opt_tlp(bool enable)
         value = (CCIX_CTRL_CAW | CCIX_VENDER_ID);
 
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-                          "[PCIE] CCIX_CONTROL: 0x%08x\n", value);
+                          "[CCIX] CCIX_CONTROL: 0x%08x\n", value);
 
     *(uint32_t *)(dev_ctx->lm_apb + PCIE_LM_RC_CCIX_CTRL_REG) = value;
 
@@ -126,19 +128,27 @@ static int n1sdp_pcie_ccix_enable_opt_tlp(bool enable)
     return FWK_SUCCESS;
 }
 
+static const struct n1sdp_pcie_ccix_config_api pcie_ccix_config_api = {
+    .enable_opt_tlp = n1sdp_pcie_ccix_enable_opt_tlp,
+};
 
-static int n1sdp_pcie_setup(struct n1sdp_pcie_dev_ctx *dev_ctx)
+/*
+ * PCIe initialization APIs
+ */
+static int n1sdp_pcie_power_on(fwk_id_t id)
 {
-    uint32_t ecam_base_addr;
-    uint8_t neg_config;
     struct pcie_wait_condition_data wait_data;
+    struct n1sdp_pcie_dev_ctx *dev_ctx;
     int status;
-    enum pcie_gen gen_speed;
-    uint32_t reg_val;
+    unsigned int did;
 
-    gen_speed = dev_ctx->config->ccix_capable ? PCIE_GEN_4 : PCIE_GEN_3;
+    did = fwk_id_get_element_idx(id);
+    dev_ctx = &pcie_ctx.device_ctx_table[did];
+    if (dev_ctx == NULL)
+        return FWK_E_PARAM;
 
-    /* Enable the CCIX/PCIe controller */
+    pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                          "[%s] Powering ON controller...", pcie_type[did]);
     wait_data.ctrl_apb = NULL;
     if (dev_ctx->config->ccix_capable) {
         SCC->AXI_OVRD_CCIX = AXI_OVRD_VAL_CCIX;
@@ -150,8 +160,7 @@ static int n1sdp_pcie_setup(struct n1sdp_pcie_dev_ctx *dev_ctx)
                                           pcie_wait_condition,
                                           &wait_data);
         if (status != FWK_SUCCESS) {
-            pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-                "[PCIe] Controller power-on failed!\n");
+            pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Timeout!\n");
             return status;
         }
         SCC->SYS_MAN_RESET &= ~(1 << SCC_SYS_MAN_RESET_CCIX_POS);
@@ -165,17 +174,34 @@ static int n1sdp_pcie_setup(struct n1sdp_pcie_dev_ctx *dev_ctx)
                                           pcie_wait_condition,
                                           &wait_data);
         if (status != FWK_SUCCESS) {
-            pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-                "[PCIe] Controller power-on failed!\n");
+            pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Timeout!\n");
             return status;
         }
         SCC->SYS_MAN_RESET &= ~(1 << SCC_SYS_MAN_RESET_PCIE_POS);
     }
+    pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
-    /* PHY initialization */
-    pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "[PCIe] Initializing PHY...");
+    return FWK_SUCCESS;
+}
 
-    pcie_phy_init(dev_ctx->phy_apb, gen_speed);
+static int n1sdp_pcie_phy_init(fwk_id_t id)
+{
+    struct n1sdp_pcie_dev_ctx *dev_ctx;
+    enum pcie_gen gen_speed;
+    int status;
+    unsigned int did;
+
+    did = fwk_id_get_element_idx(id);
+    dev_ctx = &pcie_ctx.device_ctx_table[did];
+    if (dev_ctx == NULL)
+        return FWK_E_PARAM;
+
+    gen_speed = dev_ctx->config->ccix_capable ? PCIE_GEN_4 : PCIE_GEN_3;
+
+    pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                          "[%s] Initializing PHY...", pcie_type[did]);
+
+    pcie_phy_init(dev_ctx->phy_apb);
     status = pcie_init(dev_ctx->ctrl_apb,
                        pcie_ctx.timer_api,
                        PCIE_INIT_STAGE_PHY,
@@ -186,9 +212,32 @@ static int n1sdp_pcie_setup(struct n1sdp_pcie_dev_ctx *dev_ctx)
     }
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
-    /* Controller initialization */
+    return FWK_SUCCESS;
+}
+
+static int n1sdp_pcie_controller_init(fwk_id_t id, bool ep_mode)
+{
+    struct n1sdp_pcie_dev_ctx *dev_ctx;
+    enum pcie_gen gen_speed;
+    int status;
+    int did;
+
+    did = fwk_id_get_element_idx(id);
+    dev_ctx = &pcie_ctx.device_ctx_table[did];
+    if (dev_ctx == NULL)
+        return FWK_E_PARAM;
+
+    gen_speed = dev_ctx->config->ccix_capable ? PCIE_GEN_4 : PCIE_GEN_3;
+
+    if (ep_mode) {
+        dev_ctx->ctrl_apb->MODE_CTRL = 0x0;
+        dev_ctx->ctrl_apb->EP_MISC_CTRL |= 0x100;
+    }
+
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-                          "[PCIe] Initializing controller...");
+                          "[%s] Initializing controller in %s mode...",
+                          pcie_type[did],
+                          (ep_mode ? "endpoint" : "root port"));
     status = pcie_init(dev_ctx->ctrl_apb,
                        pcie_ctx.timer_api,
                        PCIE_INIT_STAGE_CTRL,
@@ -199,44 +248,69 @@ static int n1sdp_pcie_setup(struct n1sdp_pcie_dev_ctx *dev_ctx)
     }
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
-    pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Setting TX preset for GEN%d...", gen_speed);
-    status = pcie_set_gen_tx_preset(dev_ctx->rp_ep_config_apb,
-                                    TX_PRESET_VALUE,
-                                    gen_speed);
-    if (status != FWK_SUCCESS) {
-        pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Equalization failed!\n");
-        return status;
+    return FWK_SUCCESS;
+}
+
+static int n1sdp_pcie_link_training(fwk_id_t id, bool ep_mode)
+{
+    struct n1sdp_pcie_dev_ctx *dev_ctx;
+    enum pcie_gen gen_speed;
+    uint8_t neg_config;
+    uint32_t reg_val;
+    int status;
+    unsigned int did;
+
+    did = fwk_id_get_element_idx(id);
+    dev_ctx = &pcie_ctx.device_ctx_table[did];
+    if (dev_ctx == NULL)
+        return FWK_E_PARAM;
+
+    gen_speed = dev_ctx->config->ccix_capable ? PCIE_GEN_4 : PCIE_GEN_3;
+
+    if (gen_speed >= PCIE_GEN_3 && !ep_mode) {
+        pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+                              "[%s] Setting TX Preset for GEN%d...",
+                              pcie_type[did], gen_speed + 1);
+        status = pcie_set_gen_tx_preset(dev_ctx->rp_ep_config_apb,
+                                        TX_PRESET_VALUE,
+                                        gen_speed);
+        if (status != FWK_SUCCESS) {
+            pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Error!\n");
+            return status;
+        }
+        pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
     }
 
     /* Link training */
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-                          "[PCIe] Starting link training...");
+                          "[%s] Starting link training...", pcie_type[did]);
     status = pcie_init(dev_ctx->ctrl_apb,
                        pcie_ctx.timer_api,
                        PCIE_INIT_STAGE_LINK_TRNG,
                        gen_speed);
     if (status != FWK_SUCCESS) {
         pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Timeout!\n");
-        return dev_ctx->config->ccix_capable ? FWK_SUCCESS : status;
+        return status;
     }
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
     neg_config = (dev_ctx->ctrl_apb->RP_CONFIG_OUT &
         RP_CONFIG_OUT_NEGOTIATED_SPD_MASK) >> RP_CONFIG_OUT_NEGOTIATED_SPD_POS;
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Negotiated speed: GEN%d\n", neg_config + 1);
+                          "[%s] Negotiated speed: GEN%d\n",
+                          pcie_type[did], neg_config + 1);
 
     neg_config = (dev_ctx->ctrl_apb->RP_CONFIG_OUT &
         RP_CONFIG_OUT_NEGOTIATED_LINK_WIDTH_MASK) >>
         RP_CONFIG_OUT_NEGOTIATED_LINK_WIDTH_POS;
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Negotiated link width: x%d\n", fwk_math_pow2(neg_config));
+                          "[%s] Negotiated link width: x%d\n",
+                          pcie_type[did], fwk_math_pow2(neg_config));
 
-
-    if (dev_ctx->config->ccix_capable) {
+    if (gen_speed == PCIE_GEN_4) {
         pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-            "[PCIe] Re-training link to GEN4 speed...");
+                              "[%s] Re-training link to GEN4 speed...",
+                              pcie_type[did]);
         /* Set GEN4 as target speed */
         pcie_rp_ep_config_read_word(dev_ctx->rp_ep_config_apb,
                                     PCIE_LINK_CTRL_STATUS_2_OFFSET, &reg_val);
@@ -251,7 +325,7 @@ static int n1sdp_pcie_setup(struct n1sdp_pcie_dev_ctx *dev_ctx)
                                    pcie_ctx.timer_api);
         if (status != FWK_SUCCESS) {
             pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "TIMEOUT\n");
-            goto ctrl_plane_init;
+            return FWK_SUCCESS;
         }
         pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
@@ -260,19 +334,33 @@ static int n1sdp_pcie_setup(struct n1sdp_pcie_dev_ctx *dev_ctx)
         neg_config = (reg_val >> PCIE_LINK_CTRL_NEG_SPEED_POS) &
                      PCIE_LINK_CTRL_NEG_SPEED_MASK;
         pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-            "[PCIe] Re-negotiated speed: GEN%d\n", neg_config);
+                              "[%s] Re-negotiated speed: GEN%d\n",
+                              pcie_type[did], neg_config);
 
         neg_config = (reg_val >> PCIE_LINK_CTRL_NEG_WIDTH_POS) &
                      PCIE_LINK_CTRL_NEG_WIDTH_MASK;
         pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-            "[PCIe] Re-negotiated link width: x%d\n", neg_config);
+                              "[%s] Re-negotiated link width: x%d\n",
+                              pcie_type[did], neg_config);
     }
 
-ctrl_plane_init:
+    return FWK_SUCCESS;
+}
 
-    /* Root Complex setup */
+static int n1sdp_pcie_rc_setup(fwk_id_t id)
+{
+    struct n1sdp_pcie_dev_ctx *dev_ctx;
+    uint32_t ecam_base_addr;
+    int status;
+    unsigned int did;
+
+    did = fwk_id_get_element_idx(id);
+    dev_ctx = &pcie_ctx.device_ctx_table[did];
+    if (dev_ctx == NULL)
+        return FWK_E_PARAM;
+
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-                          "[PCIe] Setup Type0 configuration...");
+                          "[%s] Setup Type0 configuration...", pcie_type[did]);
     if (dev_ctx->config->ccix_capable)
         ecam_base_addr = dev_ctx->config->axi_slave_base32 +
                          CCIX_AXI_ECAM_TYPE0_OFFSET;
@@ -290,7 +378,7 @@ ctrl_plane_init:
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Setup Type1 configuration...");
+                          "[%s] Setup Type1 configuration...", pcie_type[did]);
     if (dev_ctx->config->ccix_capable)
         ecam_base_addr = dev_ctx->config->axi_slave_base32 +
                          CCIX_AXI_ECAM_TYPE1_OFFSET;
@@ -308,7 +396,8 @@ ctrl_plane_init:
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Setup MMIO32 configuration...");
+                          "[%s] Setup MMIO32 configuration...",
+                          pcie_type[did]);
     if (dev_ctx->config->ccix_capable)
         ecam_base_addr = dev_ctx->config->axi_slave_base32 +
                              CCIX_AXI_MMIO32_OFFSET;
@@ -326,7 +415,7 @@ ctrl_plane_init:
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Setup IO configuration...");
+                          "[%s] Setup IO configuration...", pcie_type[did]);
     if (dev_ctx->config->ccix_capable)
         ecam_base_addr = dev_ctx->config->axi_slave_base32 +
                              CCIX_AXI_IO_OFFSET;
@@ -344,7 +433,8 @@ ctrl_plane_init:
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Setup MMIO64 configuration...");
+                          "[%s] Setup MMIO64 configuration...",
+                          pcie_type[did]);
     status = axi_outbound_region_setup(dev_ctx->rc_axi_config_apb,
                  dev_ctx->config->axi_slave_base64,
                  __builtin_ctz(AXI_MMIO64_SIZE),
@@ -356,7 +446,7 @@ ctrl_plane_init:
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Setup RP classcode...");
+                          "[%s] Setup RP classcode...", pcie_type[did]);
     status = pcie_rp_ep_config_write_word(dev_ctx->rp_ep_config_apb,
                                           PCIE_CLASS_CODE_OFFSET,
                                           PCIE_CLASS_CODE_PCI_BRIDGE);
@@ -367,7 +457,8 @@ ctrl_plane_init:
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Enable inbound region in BAR 2...");
+                          "[%s] Enable inbound region in BAR 2...",
+                          pcie_type[did]);
     status = axi_inbound_region_setup(dev_ctx->rc_axi_config_apb,
                  AXI_IB_REGION_BASE,
                  AXI_IB_REGION_SIZE_MSB, 2);
@@ -378,7 +469,8 @@ ctrl_plane_init:
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Enable Type 1 I/O configuration\n");
+                          "[%s] Enable Type 1 I/O configuration\n",
+                          pcie_type[did]);
     *(uint32_t *)(dev_ctx->lm_apb + PCIE_LM_RC_BAR_CONFIG_REG) =
         (TYPE1_PREF_MEM_BAR_ENABLE_MASK |
          TYPE1_PREF_MEM_BAR_SIZE_64BIT_MASK |
@@ -386,7 +478,7 @@ ctrl_plane_init:
          TYPE1_PREF_IO_BAR_SIZE_32BIT_MASK);
 
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Skipping ATS capability...");
+                          "[%s] Skipping ATS capability...", pcie_type[did]);
     status = pcie_skip_ext_cap(dev_ctx->rp_ep_config_apb, EXT_CAP_ID_ATS);
     if (status != FWK_SUCCESS)
         pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Not found!\n");
@@ -394,7 +486,7 @@ ctrl_plane_init:
         pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Done\n");
 
     pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO,
-        "[PCIe] Skipping PRI capability...");
+                          "[%s] Skipping PRI capability...", pcie_type[did]);
     status = pcie_skip_ext_cap(dev_ctx->rp_ep_config_apb, EXT_CAP_ID_PRI);
     if (status != FWK_SUCCESS)
         pcie_ctx.log_api->log(MOD_LOG_GROUP_INFO, "Not found!\n");
@@ -411,10 +503,53 @@ ctrl_plane_init:
     return FWK_SUCCESS;
 }
 
-static const struct n1sdp_pcie_ccix_config_api pcie_ccix_config_api = {
-    .enable_opt_tlp = n1sdp_pcie_ccix_enable_opt_tlp,
+static const struct n1sdp_pcie_init_api pcie_init_api = {
+    .power_on = n1sdp_pcie_power_on,
+    .phy_init = n1sdp_pcie_phy_init,
+    .controller_init = n1sdp_pcie_controller_init,
+    .link_training = n1sdp_pcie_link_training,
+    .rc_setup = n1sdp_pcie_rc_setup,
 };
 
+/*
+ * Module functions
+ */
+static int n1sdp_pcie_setup(fwk_id_t id)
+{
+    struct n1sdp_pcie_dev_ctx *dev_ctx;
+    int status;
+
+    dev_ctx = &pcie_ctx.device_ctx_table[fwk_id_get_element_idx(id)];
+    if (dev_ctx == NULL)
+        return FWK_E_PARAM;
+
+    /* PCIe controller power ON */
+    status = n1sdp_pcie_power_on(id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    /* PCIe PHY initialization */
+    status = n1sdp_pcie_phy_init(id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    /* PCIe controller initialization */
+    status = n1sdp_pcie_controller_init(id, false);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    /* Link training */
+    status = n1sdp_pcie_link_training(id, false);
+    if (status != FWK_SUCCESS)
+        return dev_ctx->config->ccix_capable ? FWK_SUCCESS : status;
+
+    /* Root Complex setup */
+    status = n1sdp_pcie_rc_setup(id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    return FWK_SUCCESS;
+}
 
 /*
  * Framework handlers
@@ -512,11 +647,19 @@ static int n1sdp_pcie_start(fwk_id_t id)
 static int n1sdp_pcie_process_bind_request(fwk_id_t requester_id,
     fwk_id_t target_id, fwk_id_t api_id, const void **api)
 {
-    *api = &pcie_ccix_config_api;
+    switch (fwk_id_get_api_idx(api_id)) {
+    case N1SDP_PCIE_API_IDX_PCIE_INIT:
+        *api = &pcie_init_api;
+        break;
+    case N1SDP_PCIE_API_IDX_CCIX_CONFIG:
+        *api = &pcie_ccix_config_api;
+        break;
+    default:
+        return FWK_E_PARAM;
+    }
 
     return FWK_SUCCESS;
 }
-
 
 static int n1sdp_pcie_process_notification(const struct fwk_event *event,
                                           struct fwk_event *resp)
@@ -528,7 +671,7 @@ static int n1sdp_pcie_process_notification(const struct fwk_event *event,
     if (dev_ctx == NULL)
         return FWK_E_PARAM;
 
-    return n1sdp_pcie_setup(dev_ctx);
+    return n1sdp_pcie_setup(event->target_id);
 }
 
 const struct fwk_module module_n1sdp_pcie = {

--- a/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.c
+++ b/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.c
@@ -533,3 +533,24 @@ int pcie_skip_ext_cap(uint32_t base, uint16_t ext_cap_id)
 
     return FWK_E_SUPPORT;
 }
+
+int pcie_vc_setup(uint32_t base, uint8_t vc1_tc)
+{
+    /* VC1 Traffic class cannot be greater than 7 or equal to 0 */
+    if ((vc1_tc > 7) || (vc1_tc == 0))
+        return FWK_E_PARAM;
+
+    /* Map all other TCs to VC0 */
+    *(volatile uint32_t *)(base + PCIE_VC_RESOURCE_CTRL_0_OFFSET) =
+        PCIE_VC_CTRL_VCEN_MASK |
+        (0 << PCIE_VC_VCID_SHIFT) |
+        (~(1 << vc1_tc) & 0xFF);
+
+    /* Enable VC1 & map VC1 to TC7 */
+    *(volatile uint32_t *)(base + PCIE_VC_RESOURCE_CTRL_1_OFFSET) =
+        PCIE_VC_CTRL_VCEN_MASK |
+        (1 << PCIE_VC_VCID_SHIFT) |
+        ((1 << vc1_tc) & 0xFF);
+
+    return FWK_SUCCESS;
+}

--- a/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.c
+++ b/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.c
@@ -16,9 +16,8 @@
 #include <n1sdp_pcie.h>
 #include <n1sdp_scp_pik.h>
 
-void pcie_phy_init(uint32_t phy_apb_base, enum pcie_gen gen)
+void pcie_phy_init(uint32_t phy_apb_base)
 {
-
     uint32_t j;
 
     *((unsigned int *)(0x30038 | phy_apb_base)) = 0x00000013;

--- a/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.h
+++ b/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.h
@@ -522,9 +522,8 @@ int pcie_link_retrain(struct pcie_ctrl_apb_reg *ctrl_apb,
  * Brief - Function to initialize PCIe PHY layer.
  *
  * param - pcie_phy_base - Base address of the PHY layer registers
- * param - gen - PCIe Generation
  */
-void pcie_phy_init(uint32_t phy_apb_base, enum pcie_gen gen);
+void pcie_phy_init(uint32_t phy_apb_base);
 
 /*
  * Brief - Function to write to Root Port's/End Point's configuration space.

--- a/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.h
+++ b/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.h
@@ -76,6 +76,9 @@
 #define PCIE_CLASS_CODE_OFFSET         0x8
 #define PCIE_LINK_CTRL_STATUS_OFFSET   0xD0
 #define PCIE_LINK_CTRL_STATUS_2_OFFSET 0xF0
+#define PCIE_DEV_CTRL_STATUS_OFFSET    0xC8
+#define PCIE_VC_RESOURCE_CTRL_0_OFFSET 0x4D4
+#define PCIE_VC_RESOURCE_CTRL_1_OFFSET 0x4E0
 
 /* PCIe configuration space link control status register definitions */
 #define PCIE_LINK_CTRL_LINK_RETRAIN_MASK    0x20
@@ -87,6 +90,13 @@
 /* PCIe configuration space link control status register 2 definitions */
 #define PCIE_LINK_CTRL_2_TARGET_SPEED_MASK  0xF
 #define PCIE_LINK_CTRL_2_TARGET_SPEED_GEN4  0x4
+
+/* PCIe device control & status register definitions */
+#define PCIE_DEV_CTRL_MAX_PAYLOAD_SHIFT 5
+
+/* PCIe virtual channel register definitions */
+#define PCIE_VC_CTRL_VCEN_MASK         (1U << 31)
+#define PCIE_VC_VCID_SHIFT             24
 
 /* PCIe class code for PCI bridge */
 #define PCIE_CLASS_CODE_PCI_BRIDGE     UINT32_C(0x06040000)
@@ -581,5 +591,17 @@ int pcie_set_gen_tx_preset(uint32_t rp_ep_config_apb_base,
  *                          linked list
  */
 int pcie_skip_ext_cap(uint32_t base, uint16_t ext_cap_id);
+
+/*
+ * Brief - Function to setup PCIe virtual channels and map to
+ *         specified traffic class.
+ *
+ * param - base - Base address of RP/EP's configuration memory
+ * param - vc1_tc - Traffic class value for virtual channel 1
+ *
+ * retval - FWK_SUCCESS - if the operation is succeeded
+ *          FWK_E_PARAM - if the passed parameters are inconsistent
+ */
+int pcie_vc_setup(uint32_t base, uint8_t vc1_tc);
 
 #endif /* N1SDP_PCIE_H */

--- a/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.h
+++ b/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.h
@@ -187,7 +187,7 @@
 
 /* AXI inbound region data */
 #define AXI_IB_REGION_BASE             UINT64_C(0)
-#define AXI_IB_REGION_SIZE_MSB         42
+#define AXI_IB_REGION_SIZE_MSB         43
 
 /*
  * PCIe Descriptor Register definitions

--- a/product/n1sdp/scp_ramfw/config_n1sdp_c2c_i2c.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_c2c_i2c.c
@@ -1,0 +1,21 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <fwk_element.h>
+#include <fwk_id.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+#include <mod_n1sdp_c2c_i2c.h>
+#include <mod_n1sdp_i2c.h>
+
+const struct fwk_module_config config_n1sdp_c2c = {
+    .data = &((struct n1sdp_c2c_dev_config) {
+            .i2c_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_N1SDP_I2C, 1),
+            .slave_addr = 0x14,
+            .ccix_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_N1SDP_PCIE, 1),
+        }),
+};

--- a/product/n1sdp/scp_ramfw/config_n1sdp_i2c.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_i2c.c
@@ -5,25 +5,47 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <stdbool.h>
+#include <fwk_id.h>
+#include <fwk_macros.h>
 #include <fwk_module.h>
 #include <mod_n1sdp_i2c.h>
+#include <n1sdp_scp_irq.h>
 #include <n1sdp_scp_mmap.h>
 #include <config_clock.h>
 
 static const struct fwk_element i2c_element_desc_table[] = {
     [0] = {
-        .name = "I2C0",
+        .name = "SPD-I2C",
         .data = &((struct mod_n1sdp_i2c_device_config) {
-            .reg_base = SCP_I2C0_BASE,
+            .reg_base = DIMM_SPD_I2C_BASE,
             .clock_rate_hz = OSC_FREQ_HZ,
             .bus_speed_hz = MOD_N1SDP_I2C_SPEED_NORMAL,
             .mode = MOD_N1SDP_I2C_MASTER_MODE,
             .ack_en = MOD_N1SDP_I2C_ACK_ENABLE,
             .addr_size = MOD_N1SDP_I2C_ADDRESS_7_BIT,
             .hold_mode = MOD_N1SDP_I2C_HOLD_ON,
+            .c2c_mode = false,
+            .callback_mod_id = FWK_ID_NONE_INIT,
         }),
     },
-    [1] = { 0 }, /* Termination description. */
+    [1] = {
+        .name = "C2C-I2C",
+        .data = &((struct mod_n1sdp_i2c_device_config) {
+            .reg_base = SCP_I2C0_BASE,
+            .clock_rate_hz = (50UL * FWK_MHZ),
+            .bus_speed_hz = MOD_N1SDP_I2C_SPEED_NORMAL,
+            .mode = MOD_N1SDP_I2C_SLAVE_MODE,
+            .ack_en = MOD_N1SDP_I2C_ACK_ENABLE,
+            .addr_size = MOD_N1SDP_I2C_ADDRESS_7_BIT,
+            .hold_mode = MOD_N1SDP_I2C_HOLD_OFF,
+            .slave_addr = 0x14,
+            .c2c_mode = true,
+            .irq = SCP_I2C0_IRQ,
+            .callback_mod_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_N1SDP_C2C),
+        }),
+    },
+    [2] = { 0 }, /* Termination description. */
 };
 
 static const struct fwk_element *get_i2c_table(fwk_id_t module_id)

--- a/product/n1sdp/scp_ramfw/firmware.mk
+++ b/product/n1sdp/scp_ramfw/firmware.mk
@@ -45,6 +45,7 @@ BS_FIRMWARE_MODULES := \
     scmi_management \
     scmi_ccix_config \
     n1sdp_flash \
+    n1sdp_c2c \
     n1sdp_pcie \
     n1sdp_system
 
@@ -75,6 +76,7 @@ BS_FIRMWARE_SOURCES := \
     config_n1sdp_pcie.c \
     config_n1sdp_scp2pcc.c \
     config_sensor.c \
-    config_apcontext.c
+    config_apcontext.c \
+    config_n1sdp_c2c_i2c.c
 
 include $(BS_DIR)/firmware.mk


### PR DESCRIPTION
This patch set contains patches to enable multichip initialization with two N1SDP systems over CCIX link. Phase 1 performs CCIX initialization and exposes slave DDR memory to master CPUs. Slave core power-up sequencing will be added in next patchset.