### PR TITLE
n1sdp: use single SDS for mem_info and multichip info

### DIFF
--- a/product/n1sdp/include/n1sdp_sds.h
+++ b/product/n1sdp/include/n1sdp_sds.h
@@ -21,9 +21,8 @@ enum n1sdp_sds_struct_id {
     N1SDP_SDS_FEATURE_AVAILABILITY = 5 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
     N1SDP_SDS_CPU_BOOTCTR =          6 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
     N1SDP_SDS_CPU_FLAGS =            7 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
-    N1SDP_SDS_DDR_MEM_INFO =         8 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
+    N1SDP_SDS_PLATFORM_INFO =        8 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
     N1SDP_SDS_BL33_INFO =            9 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
-    N1SDP_SDS_MULTICHIP_INFO =      10 | (1 << MOD_SDS_ID_VERSION_MAJOR_POS),
 };
 
 /*
@@ -36,9 +35,8 @@ enum n1sdp_sds_struct_id {
 #define N1SDP_SDS_FEATURE_AVAILABILITY_SIZE  4
 #define N1SDP_SDS_CPU_BOOTCTR_SIZE           256
 #define N1SDP_SDS_CPU_FLAGS_SIZE             256
-#define N1SDP_SDS_DDR_MEM_INFO_SIZE          4
+#define N1SDP_SDS_PLATFORM_INFO_SIZE         4
 #define N1SDP_SDS_BL33_INFO_SIZE             12
-#define N1SDP_SDS_MULTICHIP_INFO_SIZE        4
 
 /*
  * Field masks and offsets for the N1SDP_SDS_AP_CPU_INFO structure.
@@ -71,7 +69,6 @@ struct n1sdp_sds_platid {
  * Element identifiers for SDS structures
  */
 #define SDS_ELEMENT_IDX_FEATURE_AVAILABILITY  3
-#define SDS_ELEMENT_IDX_DDR_MEM_INFO          4
+#define SDS_ELEMENT_IDX_PLATFORM_INFO         4
 #define SDS_ELEMENT_IDX_BL33_INFO             5
-#define SDS_ELEMENT_IDX_MULTICHIP_INFO        6
 #endif /* N1SDP_SDS_H */

--- a/product/n1sdp/scp_ramfw/config_sds.c
+++ b/product/n1sdp/scp_ramfw/config_sds.c
@@ -65,10 +65,10 @@ static struct fwk_element sds_element_table[] = {
         }),
     },
     {
-        .name = "DDR Memory Info",
+        .name = "Platform Info",
         .data = &((struct mod_sds_structure_desc) {
-            .id = N1SDP_SDS_DDR_MEM_INFO,
-            .size = N1SDP_SDS_DDR_MEM_INFO_SIZE,
+            .id = N1SDP_SDS_PLATFORM_INFO,
+            .size = N1SDP_SDS_PLATFORM_INFO_SIZE,
             .finalize = true,
         }),
     },
@@ -77,14 +77,6 @@ static struct fwk_element sds_element_table[] = {
         .data = &((struct mod_sds_structure_desc) {
             .id = N1SDP_SDS_BL33_INFO,
             .size = N1SDP_SDS_BL33_INFO_SIZE,
-            .finalize = true,
-        }),
-    },
-    {
-        .name = "Multichip Info",
-        .data = &((struct mod_sds_structure_desc) {
-            .id = N1SDP_SDS_MULTICHIP_INFO,
-            .size = N1SDP_SDS_MULTICHIP_INFO_SIZE,
             .finalize = true,
         }),
     },


### PR DESCRIPTION
Merge mem_info and multichip information into a single data structure
which will be passed on to TF-A.

This patch introduces a new SDS to store platform information, which
will be populated dynamically by SCP.

This structure holds following information:
  - multichip_mode
  - slave_count
  - local_ddr_size
  - remote_ddr_size

Change-Id: Ib71c1adabcaff227a22144fdb0b7eea28495cc2b
Signed-off-by: Manish Pandey <manish.pandey2@arm.com>