### PR TITLE
Add asynchronous support to the `psu` module

### DIFF
--- a/module/mock_psu/include/mod_mock_psu.h
+++ b/module/mock_psu/include/mod_mock_psu.h
@@ -20,6 +20,15 @@
  *      alongside the `psu` interface on systems that do not provide a real
  *      power supply.
  *
+ *      In addition to the standard synchronous mode of operation, mock PSUs
+ *      support an emulated form of asynchronous operation. This mode reproduces
+ *      the behaviour of some real devices which cannot respond to requests
+ *      immediately, and is useful for testing interfaces that must support
+ *      devices of this kind.
+ *
+ *      To enable the asynchronous operation mode, see the documentation for
+ *      ::mod_mock_psu_element_cfg::async_alarm_id.
+ *
  * \{
  */
 
@@ -27,6 +36,52 @@
  * \brief Element configuration.
  */
 struct mod_mock_psu_element_cfg {
+    /*!
+     * \brief Alarm entity identifier used for asynchronous driver emulation.
+     *
+     * \details This identifies the entity of a timer alarm, which must
+     *      implement ::mod_timer_alarm_api.
+     *
+     * \note This field may be set to ::FWK_ID_NONE, in which case asynchronous
+     *      driver emulation is not enabled.
+     */
+    fwk_id_t async_alarm_id;
+
+    /*!
+     * \brief Alarm API identifier used for asynchronous driver emulation.
+     *
+     * \details This identifies the API of a timer alarm, which must
+     *      implement ::mod_timer_alarm_api.
+     *
+     * \note This field may be set to ::FWK_ID_NONE if asynchronous driver
+     *      emulation is not enabled.
+     */
+    fwk_id_t async_alarm_api_id;
+
+    /*!
+     * \brief Driver response entity identifier used for asynchronous driver
+     *      emulation.
+     *
+     * \details This identifies the entity of a driver response entity, which
+     *      must implement ::mod_psu_driver_response_api.
+     *
+     * \note This field may be set to ::FWK_ID_NONE if asynchronous driver
+     *      emulation is not enabled.
+     */
+    fwk_id_t async_response_id;
+
+    /*!
+     * \brief Driver response API identifier used for asynchronous driver
+     *      emulation.
+     *
+     * \details This identifies the API of a driver response entity, which must
+     *      implement ::mod_psu_driver_response_api.
+     *
+     * \note This field may be set to ::FWK_ID_NONE if asynchronous driver
+     *      emulation is not enabled.
+     */
+    fwk_id_t async_response_api_id;
+
     /*!
      * \brief Default state of the mock device's supply (enabled or disabled).
      */

--- a/module/mock_psu/src/mod_mock_psu.c
+++ b/module/mock_psu/src/mod_mock_psu.c
@@ -7,6 +7,7 @@
 
 #include <mod_mock_psu.h>
 #include <mod_psu.h>
+#include <mod_timer.h>
 #include <fwk_assert.h>
 #include <fwk_id.h>
 #include <fwk_macros.h>
@@ -17,14 +18,41 @@
 #include <stddef.h>
 #include <stdint.h>
 
-static struct mod_mock_psu_ctx {
-    struct mod_mock_psu_element_ctx {
+enum mod_mock_psu_request {
+    MOD_MOCK_PSU_REQUEST_NONE,
+
+    MOD_MOCK_PSU_REQUEST_GET_ENABLED,
+    MOD_MOCK_PSU_REQUEST_SET_ENABLED,
+    MOD_MOCK_PSU_REQUEST_GET_VOLTAGE,
+    MOD_MOCK_PSU_REQUEST_SET_VOLTAGE,
+};
+
+struct mod_mock_psu_operation {
+    enum mod_mock_psu_request request;
+
+    union {
         bool enabled;
         uint64_t voltage;
+    };
+};
+
+static struct mod_mock_psu_ctx {
+    struct mod_mock_psu_element_ctx {
+        struct {
+            bool enabled;
+            uint64_t voltage;
+        } state;
+
+        struct mod_mock_psu_operation op;
+
+        struct {
+            const struct mod_timer_alarm_api *alarm;
+            const struct mod_psu_driver_response_api *hal;
+        } apis;
     } *elements;
 } mod_mock_psu_ctx;
 
-static struct mod_mock_psu_element_ctx *mod_mock_psu_get_ctx_unchecked(
+static struct mod_mock_psu_element_ctx *mod_mock_psu_get_ctx(
     fwk_id_t element_id)
 {
     unsigned int element_idx = fwk_id_get_element_idx(element_id);
@@ -32,15 +60,19 @@ static struct mod_mock_psu_element_ctx *mod_mock_psu_get_ctx_unchecked(
     return &mod_mock_psu_ctx.elements[element_idx];
 }
 
-static struct mod_mock_psu_element_ctx *mod_mock_psu_get_element_ctx(
-    fwk_id_t element_id)
+static int mod_mock_psu_check_call(fwk_id_t element_id)
 {
+    int status = FWK_E_PARAM;
+
     if (fwk_id_get_module_idx(element_id) != FWK_MODULE_IDX_MOCK_PSU)
-        return NULL;
-    else if (!fwk_module_is_valid_element_id(element_id))
-        return NULL;
-    else
-        return mod_mock_psu_get_ctx_unchecked(element_id);
+        goto exit;
+
+    status = fwk_module_check_call(element_id);
+    if (status != FWK_SUCCESS)
+        status = FWK_E_STATE;
+
+exit:
+    return status;
 }
 
 static int mod_mock_psu_get_cfg_ctx(
@@ -50,80 +82,229 @@ static int mod_mock_psu_get_cfg_ctx(
 {
     int status;
 
-    status = fwk_module_check_call(element_id);
-    if (status != FWK_SUCCESS) {
-        status = FWK_E_STATE;
-
+    status = mod_mock_psu_check_call(element_id);
+    if (status != FWK_SUCCESS)
         goto exit;
-    }
 
-    if (ctx != NULL) {
-        *ctx = mod_mock_psu_get_element_ctx(element_id);
-        if (ctx == NULL) {
-            status = FWK_E_PARAM;
+    if (ctx != NULL)
+        *ctx = mod_mock_psu_get_ctx(element_id);
 
-            goto exit;
-        }
-    }
-
-    if (cfg != NULL) {
+    if (cfg != NULL)
         *cfg = fwk_module_get_data(element_id);
-        fwk_assert(cfg != NULL);
-    }
 
 exit:
     return status;
 }
 
-static int mod_mock_psu_get_enabled(fwk_id_t device_id, bool *enabled)
+static void mod_mock_psu_alarm_callback(uintptr_t element_idx)
 {
     int status;
 
+    fwk_id_t element_id = fwk_id_build_element_id(
+        fwk_module_id_mock_psu, element_idx);
+
+    const struct mod_mock_psu_element_cfg *cfg;
+    struct mod_mock_psu_element_ctx *ctx;
+    struct mod_psu_driver_response response;
+
+    status = mod_mock_psu_get_cfg_ctx(element_id, &cfg, &ctx);
+    if (!fwk_expect(status == FWK_SUCCESS))
+        return;
+
+    response = (struct mod_psu_driver_response){
+        .status = FWK_SUCCESS,
+    };
+
+    switch (ctx->op.request) {
+    case MOD_MOCK_PSU_REQUEST_GET_ENABLED:
+        response.enabled = ctx->state.enabled;
+
+        break;
+
+    case MOD_MOCK_PSU_REQUEST_SET_ENABLED:
+        ctx->state.enabled = ctx->op.enabled;
+
+        break;
+
+    case MOD_MOCK_PSU_REQUEST_GET_VOLTAGE:
+        response.voltage = ctx->state.voltage;
+
+        break;
+
+    case MOD_MOCK_PSU_REQUEST_SET_VOLTAGE:
+        ctx->state.voltage = ctx->op.voltage;
+
+        break;
+
+    default:
+        fwk_unreachable();
+    }
+
+    ctx->op.request = MOD_MOCK_PSU_REQUEST_NONE;
+
+    ctx->apis.hal->respond(cfg->async_response_id, response);
+}
+
+static int mod_mock_psu_trigger(
+    fwk_id_t element_id,
+    struct mod_mock_psu_operation op)
+{
+    static const unsigned int ASYNC_DELAY = 1 /* ms */;
+
+    int status;
+
+    const struct mod_mock_psu_element_cfg *cfg;
     struct mod_mock_psu_element_ctx *ctx;
 
-    status = mod_mock_psu_get_cfg_ctx(device_id, NULL, &ctx);
-    if (status == FWK_SUCCESS)
-        *enabled = ctx->enabled;
+    status = mod_mock_psu_get_cfg_ctx(element_id, &cfg, &ctx);
+    if (status != FWK_SUCCESS)
+        goto exit;
 
+    status = ctx->apis.alarm->start(
+        cfg->async_alarm_id,
+        ASYNC_DELAY,
+        MOD_TIMER_ALARM_TYPE_ONCE,
+        mod_mock_psu_alarm_callback,
+        fwk_id_get_element_idx(element_id));
+
+    if (status == FWK_SUCCESS) {
+        status = FWK_PENDING;
+
+        ctx->op = op;
+    } else
+        status = FWK_E_HANDLER;
+
+exit:
     return status;
 }
 
-static int mod_mock_psu_set_enabled(fwk_id_t device_id, bool enabled)
+static int mod_mock_psu_get_enabled(
+    fwk_id_t element_id,
+    bool *enabled)
 {
     int status;
 
+    const struct mod_mock_psu_element_cfg *cfg;
     struct mod_mock_psu_element_ctx *ctx;
 
-    status = mod_mock_psu_get_cfg_ctx(device_id, NULL, &ctx);
-    if (status == FWK_SUCCESS)
-        ctx->enabled = enabled;
+    status = mod_mock_psu_get_cfg_ctx(element_id, &cfg, &ctx);
+    if (status != FWK_SUCCESS)
+        goto exit;
 
+    if (ctx->apis.alarm == NULL) {
+        *enabled = ctx->state.enabled;
+
+        goto exit;
+    }
+
+    if (ctx->op.request == MOD_MOCK_PSU_REQUEST_NONE) {
+        struct mod_mock_psu_operation op = {
+            .request = MOD_MOCK_PSU_REQUEST_GET_ENABLED,
+        };
+
+        status = mod_mock_psu_trigger(element_id, op);
+    } else
+        status = FWK_E_BUSY;
+
+exit:
     return status;
 }
 
-static int mod_mock_psu_get_voltage(fwk_id_t device_id, uint64_t *voltage)
+static int mod_mock_psu_set_enabled(
+    fwk_id_t element_id,
+    bool enabled)
 {
     int status;
 
+    const struct mod_mock_psu_element_cfg *cfg;
     struct mod_mock_psu_element_ctx *ctx;
 
-    status = mod_mock_psu_get_cfg_ctx(device_id, NULL, &ctx);
-    if (status == FWK_SUCCESS)
-        *voltage = ctx->voltage;
+    status = mod_mock_psu_get_cfg_ctx(element_id, &cfg, &ctx);
+    if (status != FWK_SUCCESS)
+        goto exit;
 
+    if (ctx->apis.alarm == NULL) {
+        ctx->state.enabled = enabled;
+
+        goto exit;
+    }
+
+    if (ctx->op.request == MOD_MOCK_PSU_REQUEST_NONE) {
+        struct mod_mock_psu_operation op = {
+            .request = MOD_MOCK_PSU_REQUEST_SET_ENABLED,
+            .enabled = enabled,
+        };
+
+        status = mod_mock_psu_trigger(element_id, op);
+    } else
+        status = FWK_E_BUSY;
+
+exit:
     return status;
 }
 
-static int mod_mock_psu_set_voltage(fwk_id_t device_id, uint64_t voltage)
+static int mod_mock_psu_get_voltage(
+    fwk_id_t element_id,
+    uint64_t *voltage)
 {
     int status;
 
+    const struct mod_mock_psu_element_cfg *cfg;
     struct mod_mock_psu_element_ctx *ctx;
 
-    status = mod_mock_psu_get_cfg_ctx(device_id, NULL, &ctx);
-    if (status == FWK_SUCCESS)
-        ctx->voltage = voltage;
+    status = mod_mock_psu_get_cfg_ctx(element_id, &cfg, &ctx);
+    if (status != FWK_SUCCESS)
+        goto exit;
 
+    if (ctx->apis.alarm == NULL) {
+        *voltage = ctx->state.voltage;
+
+        goto exit;
+    }
+
+    if (ctx->op.request == MOD_MOCK_PSU_REQUEST_NONE) {
+        struct mod_mock_psu_operation op = {
+            .request = MOD_MOCK_PSU_REQUEST_GET_VOLTAGE,
+        };
+
+        status = mod_mock_psu_trigger(element_id, op);
+    } else
+        status = FWK_E_BUSY;
+
+exit:
+    return status;
+}
+
+static int mod_mock_psu_set_voltage(
+    fwk_id_t element_id,
+    uint64_t voltage)
+{
+    int status;
+
+    const struct mod_mock_psu_element_cfg *cfg;
+    struct mod_mock_psu_element_ctx *ctx;
+
+    status = mod_mock_psu_get_cfg_ctx(element_id, &cfg, &ctx);
+    if (status != FWK_SUCCESS)
+        goto exit;
+
+    if (ctx->apis.alarm == NULL) {
+        ctx->state.voltage = voltage;
+
+        goto exit;
+    }
+
+    if (ctx->op.request == MOD_MOCK_PSU_REQUEST_NONE) {
+        struct mod_mock_psu_operation op = {
+            .request = MOD_MOCK_PSU_REQUEST_SET_VOLTAGE,
+            .voltage = voltage,
+        };
+
+        status = mod_mock_psu_trigger(element_id, op);
+    } else
+        status = FWK_E_BUSY;
+
+exit:
     return status;
 }
 
@@ -150,7 +331,7 @@ static int mod_mock_psu_init(
 }
 
 static int mod_mock_psu_element_init(
-    fwk_id_t device_id,
+    fwk_id_t element_id,
     unsigned int sub_element_count,
     const void *data)
 {
@@ -159,12 +340,49 @@ static int mod_mock_psu_element_init(
 
     fwk_expect(sub_element_count == 0);
 
-    ctx = mod_mock_psu_get_ctx_unchecked(device_id);
+    ctx = mod_mock_psu_get_ctx(element_id);
 
-    ctx->enabled = cfg->default_enabled;
-    ctx->voltage = cfg->default_voltage;
+    *ctx = (struct mod_mock_psu_element_ctx) {
+        .state = {
+            .enabled = cfg->default_enabled,
+            .voltage = cfg->default_voltage,
+        },
+
+        .op = {
+            .request = MOD_MOCK_PSU_REQUEST_NONE,
+        },
+    };
 
     return FWK_SUCCESS;
+}
+
+static int mod_mock_psu_bind(fwk_id_t id, unsigned int round)
+{
+    int status = FWK_SUCCESS;
+
+    if ((round == 0) && fwk_id_is_type(id, FWK_ID_TYPE_ELEMENT)) {
+        const struct mod_mock_psu_element_cfg *cfg = fwk_module_get_data(id);
+
+        if (!fwk_id_is_equal(cfg->async_alarm_id, FWK_ID_NONE)) {
+            struct mod_mock_psu_element_ctx *ctx =
+                mod_mock_psu_get_ctx(id);
+
+            status = fwk_module_bind(
+                cfg->async_alarm_id,
+                cfg->async_alarm_api_id,
+                &ctx->apis.alarm);
+            if (status != FWK_SUCCESS)
+                goto exit;
+
+            status = fwk_module_bind(
+                cfg->async_response_id,
+                cfg->async_response_api_id,
+                &ctx->apis.hal);
+        }
+    }
+
+exit:
+    return status;
 }
 
 static int mod_mock_psu_process_bind_request(
@@ -173,22 +391,38 @@ static int mod_mock_psu_process_bind_request(
     fwk_id_t api_id,
     const void **api)
 {
-    /* Only accept binds to the elements */
+    const struct mod_mock_psu_element_cfg *cfg;
+
     if (!fwk_id_is_type(target_id, FWK_ID_TYPE_ELEMENT))
-        return FWK_E_PARAM;
+        return FWK_E_ACCESS;
+
+    if (!fwk_id_is_equal(api_id, mod_mock_psu_api_id_driver))
+        return FWK_E_ACCESS;
+
+    cfg = fwk_module_get_data(target_id);
+
+    if (!fwk_id_is_equal(cfg->async_alarm_id, FWK_ID_NONE)) {
+        /*
+         * If we are configured to respond asynchronously, the only entity we
+         * accept bind requests from is the entity that we have configured to be
+         * our designated driver respondee.
+         */
+        if (!fwk_id_is_equal(source_id, cfg->async_response_id))
+            return FWK_E_ACCESS;
+    }
 
     *api = &mod_mock_psu_driver_api;
 
     return FWK_SUCCESS;
 }
 
-/* Module description */
 const struct fwk_module module_mock_psu = {
     .name = "mock_psu",
     .type = FWK_MODULE_TYPE_DRIVER,
 
     .init = mod_mock_psu_init,
     .element_init = mod_mock_psu_element_init,
+    .bind = mod_mock_psu_bind,
 
     .api_count = MOD_MOCK_PSU_API_IDX_COUNT,
     .process_bind_request = mod_mock_psu_process_bind_request,

--- a/module/psu/include/mod_psu.h
+++ b/module/psu/include/mod_psu.h
@@ -21,14 +21,101 @@
  * \details The `psu` module represents an abstract interface through which
  *      power supply units can be used. It provides functions for manipulating
  *      the voltage as well as enabling/disabling the supply.
+ *
+ *      Users of the HAL interact with the individual power supply units through
+ *      the [device API](::mod_psu_device_api). This is the primary interface
+ *      that this module exposes and implements.
+ *
+ *      Separate to this is the [driver API](::mod_psu_driver_api), through
+ *      which the HAL will communicate with various driver implementations.
+ *      Driver implementations that need it may also utilise the [driver
+ *      response API](::mod_psu_driver_response_api), which allows power supply
+ *      units to pend requests and respond on-demand.
+ *
  * \{
  */
+
+/*!
+ * \brief API indices.
+ */
+enum mod_psu_api_idx {
+    /*!
+     * \brief Device API.
+     *
+     * \note This API identifier implements the ::mod_psu_device_api interface.
+     *
+     * \warning Binding to this API must occur through an element of this
+     *      module.
+     */
+    MOD_PSU_API_IDX_DEVICE,
+
+    /*!
+     * \brief Driver response API index.
+     *
+     * \note This API identifier implements the ::mod_psu_driver_response_api
+     *      interface.
+     *
+     * \warning Binding to this API must occur through an element of this
+     *      module.
+     */
+    MOD_PSU_API_IDX_DRIVER_RESPONSE,
+
+    /*!
+     * \brief Number of defined APIs.
+     */
+    MOD_PSU_API_IDX_COUNT
+};
+
+/*!
+ * \brief Event indices.
+ */
+enum mod_psu_event_idx {
+    /*!
+     * \brief Response event to a ::mod_psu_device_api::get_enabled call.
+     *
+     * \note This event identifier uses the ::mod_psu_response structure as its
+     *      event parameters. The ::mod_psu_response::enabled field is active.
+     */
+    MOD_PSU_EVENT_IDX_GET_ENABLED,
+
+    /*!
+     * \brief Response event to a ::mod_psu_device_api::set_enabled call.
+     *
+     * \note This event identifier uses the ::mod_psu_response structure as its
+     *      event parameters.
+     */
+    MOD_PSU_EVENT_IDX_SET_ENABLED,
+
+    /*!
+     * \brief Response event to a ::mod_psu_device_api::get_voltage call.
+     *
+     * \note This event identifier uses the ::mod_psu_response structure as its
+     *      event parameters. The ::mod_psu_response::voltage field is active.
+     */
+    MOD_PSU_EVENT_IDX_GET_VOLTAGE,
+
+    /*!
+     * \brief Response event to a ::mod_psu_device_api::set_voltage call.
+     *
+     * \note This event identifier uses the ::mod_psu_response structure as its
+     *      event parameters.
+     */
+    MOD_PSU_EVENT_IDX_SET_VOLTAGE,
+
+    /*!
+     * \brief Number of defined events.
+     */
+    MOD_PSU_EVENT_IDX_COUNT,
+};
 
 /*!
  * \brief Device API.
  *
  * \details The PSU device API represents the abstract interface used to control
  *      individual power supplies.
+ *
+ *      This is the primary interface through which users of the HAL will
+ *      interact with individual power supply units.
  */
 struct mod_psu_device_api {
     /*!
@@ -93,6 +180,92 @@ struct mod_psu_device_api {
 };
 
 /*!
+ * \brief Device API identifier.
+ *
+ * \note This identifier corresponds to the ::MOD_PSU_API_IDX_DEVICE API index.
+ */
+static const fwk_id_t mod_psu_api_id_device =
+    FWK_ID_API_INIT(FWK_MODULE_IDX_PSU, MOD_PSU_API_IDX_DEVICE);
+
+/*!
+ * \brief Response parameters.
+ *
+ * \details This structure is passed as the parameters to a response event
+ *      dispatched by the `psu` module.
+ */
+struct mod_psu_response {
+    /*!
+     * \brief Status code representing the result of the operation.
+     */
+    int status;
+
+    /*!
+     * \brief Response fields.
+     *
+     * \details These fields are used if the module is responding with extra
+     *      information. The activated field, if there is one, is based on the
+     *      event identifier of the response.
+     */
+    union {
+        /*!
+         * \brief `true` if the device is enabled, otherwise `false`.
+         *
+         * \warning Used only in response to a ::mod_psu_device_api::get_enabled
+         *      call.
+         */
+        bool enabled;
+
+        /*!
+         * \brief Voltage in millivolts (mV).
+         *
+         * \warning Used only in response to a ::mod_psu_device_api::get_voltage
+         *      call.
+         */
+        uint64_t voltage;
+    };
+};
+
+/*!
+ * \brief Identifier for a ::mod_psu_device_api::get_enabled call response
+ *      event.
+ *
+ * \note This identifier corresponds to the
+ *      ::MOD_PSU_EVENT_IDX_GET_ENABLED event index.
+ */
+static const fwk_id_t mod_psu_event_id_get_enabled = FWK_ID_EVENT_INIT(
+    FWK_MODULE_IDX_PSU, MOD_PSU_EVENT_IDX_GET_ENABLED);
+
+/*!
+ * \brief Identifier for a ::mod_psu_device_api::set_enabled call response
+ *      event.
+ *
+ * \note This identifier corresponds to the
+ *      ::MOD_PSU_EVENT_IDX_SET_ENABLED event index.
+ */
+static const fwk_id_t mod_psu_event_id_set_enabled = FWK_ID_EVENT_INIT(
+    FWK_MODULE_IDX_PSU, MOD_PSU_EVENT_IDX_SET_ENABLED);
+
+/*!
+ * \brief Identifier for a ::mod_psu_device_api::get_voltage call response
+ *      event.
+ *
+ * \note This identifier corresponds to the
+ *      ::MOD_PSU_EVENT_IDX_GET_VOLTAGE event index.
+ */
+static const fwk_id_t mod_psu_event_id_get_voltage = FWK_ID_EVENT_INIT(
+    FWK_MODULE_IDX_PSU, MOD_PSU_EVENT_IDX_GET_VOLTAGE);
+
+/*!
+ * \brief Identifier for a ::mod_psu_device_api::set_voltage call response
+ *      event.
+ *
+ * \note This identifier corresponds to the
+ *      ::MOD_PSU_EVENT_IDX_SET_VOLTAGE event index.
+ */
+static const fwk_id_t mod_psu_event_id_set_voltage = FWK_ID_EVENT_INIT(
+    FWK_MODULE_IDX_PSU, MOD_PSU_EVENT_IDX_SET_VOLTAGE);
+
+/*!
  * \brief Driver API.
  *
  * \details The PSU driver API represents the abstract interface that power
@@ -108,6 +281,7 @@ struct mod_psu_driver_api {
      *      disabled.
      *
      * \retval ::FWK_E_HANDLER The operation failed.
+     * \retval ::FWK_PENDING The result of the operation is pending.
      * \retval ::FWK_SUCCESS The operation succeeded.
      *
      * \return Status code representing the result of the operation.
@@ -121,6 +295,7 @@ struct mod_psu_driver_api {
      * \param[in] enable `true` to enable the device, or `false` to disable it.
      *
      * \retval ::FWK_E_HANDLER The operation failed.
+     * \retval ::FWK_PENDING The result of the operation is pending.
      * \retval ::FWK_SUCCESS The operation succeeded.
      *
      * \return Status code representing the result of the operation.
@@ -134,6 +309,7 @@ struct mod_psu_driver_api {
      * \param[out] voltage Voltage in millivolts (mV).
      *
      * \retval ::FWK_E_HANDLER The operation failed.
+     * \retval ::FWK_PENDING The result of the operation is pending.
      * \retval ::FWK_SUCCESS The operation succeeded.
      *
      * \return Status code representing the result of the operation.
@@ -147,12 +323,79 @@ struct mod_psu_driver_api {
      * \param[in] voltage New voltage in millivolts (mV).
      *
      * \retval ::FWK_E_HANDLER The operation failed.
+     * \retval ::FWK_PENDING The result of the operation is pending.
      * \retval ::FWK_SUCCESS The operation succeeded.
      *
      * \return Status code representing the result of the operation.
      */
     int (*set_voltage)(fwk_id_t id, uint64_t voltage);
 };
+
+/*!
+ * \brief Driver response.
+ *
+ * \details This structure is passed to the `psu` module through the [driver
+ *      response API](::mod_psu_driver_response_api::respond).
+ */
+struct mod_psu_driver_response {
+    /*!
+     * \brief Status code representing the result of the operation.
+     */
+    int status;
+
+    /*!
+     * \brief Response fields.
+     *
+     * \details These fields are used if the driver is responding with extra
+     *      information. The activated field, if there is one, is based on the
+     *      event type of the response.
+     */
+    union {
+        /*!
+         * \brief `true` if the device is enabled, otherwise `false`.
+         *
+         * \warning Used only in response to a
+         *      ::mod_psu_driver_api::get_enabled call.
+         */
+        bool enabled;
+
+        /*!
+         * \brief Voltage in millivolts (mV).
+         *
+         * \warning Used only in response to a
+         *      ::mod_psu_driver_api::get_voltage call.
+         */
+        uint64_t voltage;
+    };
+};
+
+/*!
+ * \brief Driver response API.
+ *
+ * \details The driver response API is the API used by drivers to communicate
+ *      the result of a previously-pended operation.
+ */
+struct mod_psu_driver_response_api {
+    /*!
+     * \brief Respond to a previous driver request.
+     *
+     * \param element_id Identifier of the power supply element which submitted
+     *      the request to the driver.
+     * \param response Driver operation response.
+     */
+    void (*respond)(
+        fwk_id_t element_id,
+        struct mod_psu_driver_response response);
+};
+
+/*!
+ * \brief Driver response API identifier.
+ *
+ * \note This identifier corresponds to the ::MOD_PSU_API_IDX_DRIVER_RESPONSE
+ *      API index.
+ */
+static const fwk_id_t mod_psu_api_id_driver_response =
+    FWK_ID_API_INIT(FWK_MODULE_IDX_PSU, MOD_PSU_API_IDX_DRIVER_RESPONSE);
 
 /*!
  * \brief Device configuration.
@@ -177,37 +420,6 @@ struct mod_psu_element_cfg {
      */
     fwk_id_t driver_api_id;
 };
-
-/*!
- * \brief API indices.
- */
-enum mod_psu_api_idx {
-    /*!
-     * \brief Device API index.
-     *
-     * \details This API is the abstract power supply interface exposed and
-     *      implemented by this module.
-     *
-     * \note This API identifier implements the ::mod_psu_device_api interface.
-     *
-     * \warning Binding to this API must occur through an element of this
-     *      module.
-     */
-    MOD_PSU_API_IDX_DEVICE,
-
-    /*!
-     * \brief Number of defined APIs.
-     */
-    MOD_PSU_API_IDX_COUNT
-};
-
-/*!
- * \brief Device API identifier.
- *
- * \note This identifier corresponds to the ::MOD_PSU_API_IDX_DEVICE API index.
- */
-static const fwk_id_t mod_psu_api_id_device =
-    FWK_ID_API_INIT(FWK_MODULE_IDX_PSU, MOD_PSU_API_IDX_DEVICE);
 
 /*!
  * \}

--- a/module/psu/src/mod_psu.c
+++ b/module/psu/src/mod_psu.c
@@ -11,10 +11,34 @@
 #include <fwk_macros.h>
 #include <fwk_mm.h>
 #include <fwk_module.h>
+#include <fwk_thread.h>
+#include <string.h>
+
+enum mod_psu_state {
+    MOD_PSU_STATE_IDLE,
+    MOD_PSU_STATE_BUSY,
+};
+
+struct mod_psu_operation {
+    enum mod_psu_state state;
+
+    unsigned int cookie;
+};
+
+enum mod_psu_impl_event_idx {
+    MOD_PSU_IMPL_EVENT_IDX_RESPONSE = MOD_PSU_EVENT_IDX_COUNT,
+
+    MOD_PSU_IMPL_EVENT_IDX_COUNT,
+};
+
+static const fwk_id_t mod_psu_impl_event_id_response =
+    FWK_ID_EVENT_INIT(FWK_MODULE_IDX_PSU, MOD_PSU_IMPL_EVENT_IDX_RESPONSE);
 
 static struct mod_psu_ctx {
     struct mod_psu_element_ctx {
         const struct mod_psu_driver_api *driver;
+
+        struct mod_psu_operation op;
     } *elements;
 } mod_psu_ctx;
 
@@ -63,7 +87,7 @@ exit:
 
 static int mod_psu_get_enabled(fwk_id_t element_id, bool *enabled)
 {
-    int status = FWK_E_STATE;
+    int status;
 
     const struct mod_psu_element_cfg *cfg;
     struct mod_psu_element_ctx *ctx;
@@ -72,7 +96,30 @@ static int mod_psu_get_enabled(fwk_id_t element_id, bool *enabled)
     if (status != FWK_SUCCESS)
         goto exit;
 
+    if (ctx->op.state != MOD_PSU_STATE_IDLE) {
+        status = FWK_E_BUSY;
+
+        goto exit;
+    }
+
     status = ctx->driver->get_enabled(cfg->driver_id, enabled);
+    if (status == FWK_PENDING) {
+        struct fwk_event request = (struct fwk_event){
+            .id = mod_psu_event_id_get_enabled,
+            .target_id = element_id,
+
+            .response_requested = true,
+        };
+
+        status = fwk_thread_put_event(&request);
+        if (status == FWK_SUCCESS) {
+            ctx->op.state = MOD_PSU_STATE_BUSY;
+
+            status = FWK_PENDING;
+        } else
+            status = FWK_E_STATE;
+    } else if (status != FWK_SUCCESS)
+        status = FWK_E_HANDLER;
 
 exit:
     return status;
@@ -80,7 +127,7 @@ exit:
 
 static int mod_psu_set_enabled(fwk_id_t element_id, bool enabled)
 {
-    int status = FWK_E_STATE;
+    int status;
 
     const struct mod_psu_element_cfg *cfg;
     struct mod_psu_element_ctx *ctx;
@@ -89,7 +136,30 @@ static int mod_psu_set_enabled(fwk_id_t element_id, bool enabled)
     if (status != FWK_SUCCESS)
         goto exit;
 
+    if (ctx->op.state != MOD_PSU_STATE_IDLE) {
+        status = FWK_E_BUSY;
+
+        goto exit;
+    }
+
     status = ctx->driver->set_enabled(cfg->driver_id, enabled);
+    if (status == FWK_PENDING) {
+        struct fwk_event request = (struct fwk_event){
+            .id = mod_psu_event_id_set_enabled,
+            .target_id = element_id,
+
+            .response_requested = true,
+        };
+
+        status = fwk_thread_put_event(&request);
+        if (status == FWK_SUCCESS) {
+            ctx->op.state = MOD_PSU_STATE_BUSY;
+
+            status = FWK_PENDING;
+        } else
+            status = FWK_E_STATE;
+    } else if (status != FWK_SUCCESS)
+        status = FWK_E_HANDLER;
 
 exit:
     return status;
@@ -97,7 +167,7 @@ exit:
 
 static int mod_psu_get_voltage(fwk_id_t element_id, uint64_t *voltage)
 {
-    int status = FWK_E_STATE;
+    int status;
 
     const struct mod_psu_element_cfg *cfg;
     struct mod_psu_element_ctx *ctx;
@@ -106,7 +176,30 @@ static int mod_psu_get_voltage(fwk_id_t element_id, uint64_t *voltage)
     if (status != FWK_SUCCESS)
         goto exit;
 
+    if (ctx->op.state != MOD_PSU_STATE_IDLE) {
+        status = FWK_E_BUSY;
+
+        goto exit;
+    }
+
     status = ctx->driver->get_voltage(cfg->driver_id, voltage);
+    if (status == FWK_PENDING) {
+        struct fwk_event request = (struct fwk_event){
+            .id = mod_psu_event_id_get_voltage,
+            .target_id = element_id,
+
+            .response_requested = true,
+        };
+
+        status = fwk_thread_put_event(&request);
+        if (status == FWK_SUCCESS) {
+            ctx->op.state = MOD_PSU_STATE_BUSY;
+
+            status = FWK_PENDING;
+        } else
+            status = FWK_E_STATE;
+    } else if (status != FWK_SUCCESS)
+        status = FWK_E_HANDLER;
 
 exit:
     return status;
@@ -114,7 +207,7 @@ exit:
 
 static int mod_psu_set_voltage(fwk_id_t element_id, uint64_t voltage)
 {
-    int status = FWK_E_STATE;
+    int status;
 
     const struct mod_psu_element_cfg *cfg;
     struct mod_psu_element_ctx *ctx;
@@ -123,7 +216,30 @@ static int mod_psu_set_voltage(fwk_id_t element_id, uint64_t voltage)
     if (status != FWK_SUCCESS)
         goto exit;
 
+    if (ctx->op.state != MOD_PSU_STATE_IDLE) {
+        status = FWK_E_BUSY;
+
+        goto exit;
+    }
+
     status = ctx->driver->set_voltage(cfg->driver_id, voltage);
+    if (status == FWK_PENDING) {
+        struct fwk_event request = (struct fwk_event){
+            .id = mod_psu_event_id_set_voltage,
+            .target_id = element_id,
+
+            .response_requested = true,
+        };
+
+        status = fwk_thread_put_event(&request);
+        if (status == FWK_SUCCESS) {
+            ctx->op.state = MOD_PSU_STATE_BUSY;
+
+            status = FWK_PENDING;
+        } else
+            status = FWK_E_STATE;
+    } else if (status != FWK_SUCCESS)
+        status = FWK_E_HANDLER;
 
 exit:
     return status;
@@ -134,6 +250,39 @@ static const struct mod_psu_device_api mod_psu_device_api = {
     .set_enabled = mod_psu_set_enabled,
     .get_voltage = mod_psu_get_voltage,
     .set_voltage = mod_psu_set_voltage,
+};
+
+static void mod_psu_respond(
+    fwk_id_t element_id,
+    struct mod_psu_driver_response response)
+{
+    int status;
+
+    const struct mod_psu_element_cfg *cfg;
+    struct mod_psu_element_ctx *ctx;
+
+    struct fwk_event event;
+
+    status = mod_psu_get_cfg_ctx(element_id, &cfg, &ctx);
+    if (!fwk_expect(status == FWK_SUCCESS))
+        return;
+
+    event = (struct fwk_event){
+        .id = mod_psu_impl_event_id_response,
+
+        .source_id = cfg->driver_id,
+        .target_id = element_id,
+    };
+
+    memcpy(event.params, &response, sizeof(response));
+
+    status = fwk_thread_put_event(&event);
+    if (!fwk_expect(status == FWK_SUCCESS))
+        ctx->op.state = MOD_PSU_STATE_IDLE;
+}
+
+static const struct mod_psu_driver_response_api mod_psu_driver_response_api = {
+    .respond = mod_psu_respond,
 };
 
 static int mod_psu_init(
@@ -156,7 +305,17 @@ static int mod_psu_element_init(
     unsigned int sub_element_count,
     const void *data)
 {
+    struct mod_psu_element_ctx *ctx;
+
     fwk_expect(sub_element_count == 0);
+
+    ctx = mod_psu_get_element_ctx(element_id);
+
+    *ctx = (struct mod_psu_element_ctx){
+        .op = (struct mod_psu_operation){
+            .state = MOD_PSU_STATE_IDLE,
+        },
+    };
 
     return FWK_SUCCESS;
 }
@@ -173,9 +332,6 @@ static int mod_psu_bind_element(fwk_id_t element_id, unsigned int round)
 
     ctx = mod_psu_get_element_ctx(element_id);
     cfg = fwk_module_get_data(element_id);
-
-    fwk_assert(ctx != NULL);
-    fwk_assert(cfg != NULL);
 
     status = fwk_module_bind(cfg->driver_id, cfg->driver_api_id, &ctx->driver);
     if (status != FWK_SUCCESS)
@@ -209,15 +365,92 @@ static int mod_psu_process_bind_request(
     if (!fwk_id_is_type(target_id, FWK_ID_TYPE_ELEMENT))
         return FWK_E_PARAM;
 
-    if (!fwk_id_is_equal(api_id, mod_psu_api_id_device))
-        return FWK_E_PARAM;
+    switch (fwk_id_get_api_idx(api_id)) {
+    case MOD_PSU_API_IDX_DEVICE:
+        *api = &mod_psu_device_api;
 
-    *api = &mod_psu_device_api;
+        break;
+
+    case MOD_PSU_API_IDX_DRIVER_RESPONSE:
+        *api = &mod_psu_driver_response_api;
+
+        break;
+    }
 
     return FWK_SUCCESS;
 }
 
-/* Module description */
+static int mod_psu_process_event(
+    const struct fwk_event *event,
+    struct fwk_event *resp_event)
+{
+    int status = FWK_SUCCESS;
+
+    const struct mod_psu_driver_response *params =
+        (struct mod_psu_driver_response *)event->params;
+    struct mod_psu_response *resp_params =
+        (struct mod_psu_response *)resp_event->params;
+
+    const struct mod_psu_element_cfg *cfg;
+    struct mod_psu_element_ctx *ctx;
+
+    resp_params->status =
+        mod_psu_get_cfg_ctx(event->target_id, &cfg, &ctx);
+    if (resp_params->status != FWK_SUCCESS)
+        goto exit;
+
+    switch (fwk_id_get_event_idx(event->id)) {
+    case MOD_PSU_EVENT_IDX_GET_ENABLED:
+    case MOD_PSU_EVENT_IDX_GET_VOLTAGE:
+    case MOD_PSU_EVENT_IDX_SET_ENABLED:
+    case MOD_PSU_EVENT_IDX_SET_VOLTAGE:
+        ctx->op.cookie = event->cookie;
+
+        resp_event->is_delayed_response = true;
+
+        break;
+
+    case MOD_PSU_IMPL_EVENT_IDX_RESPONSE:
+        ctx->op.state = MOD_PSU_STATE_IDLE;
+
+        status = fwk_thread_get_delayed_response(
+            event->target_id,
+            ctx->op.cookie,
+            resp_event);
+        if (status != FWK_SUCCESS)
+            return status;
+
+        *resp_params = (struct mod_psu_response){
+            .status = params->status,
+        };
+
+        switch (fwk_id_get_element_idx(event->id)) {
+        case MOD_PSU_EVENT_IDX_GET_ENABLED:
+            resp_params->enabled = params->enabled;
+
+            break;
+
+        case MOD_PSU_EVENT_IDX_GET_VOLTAGE:
+            resp_params->voltage = params->voltage;
+
+            break;
+
+        default:
+            break;
+        }
+
+        status = fwk_thread_put_event(resp_event);
+
+        break;
+
+    default:
+        fwk_unreachable();
+    }
+
+exit:
+    return status;
+}
+
 const struct fwk_module module_psu = {
     .name = "psu",
     .type = FWK_MODULE_TYPE_HAL,
@@ -228,4 +461,7 @@ const struct fwk_module module_psu = {
 
     .api_count = MOD_PSU_API_IDX_COUNT,
     .process_bind_request = mod_psu_process_bind_request,
+
+    .event_count = MOD_PSU_IMPL_EVENT_IDX_COUNT,
+    .process_event = mod_psu_process_event,
 };

--- a/product/rdn1e1/scp_ramfw/config_mock_psu.c
+++ b/product/rdn1e1/scp_ramfw/config_mock_psu.c
@@ -14,6 +14,12 @@ static const struct fwk_element element_table[] = {
         .name = "DVFS_GROUP0",
         .data =
             &(const struct mod_mock_psu_element_cfg){
+                .async_alarm_id = FWK_ID_NONE_INIT,
+                .async_alarm_api_id = FWK_ID_NONE_INIT,
+
+                .async_response_id = FWK_ID_NONE_INIT,
+                .async_response_api_id = FWK_ID_NONE_INIT,
+
                 .default_enabled = true,
                 .default_voltage = 100,
             },
@@ -22,6 +28,12 @@ static const struct fwk_element element_table[] = {
         .name = "DVFS_GROUP1",
         .data =
             &(const struct mod_mock_psu_element_cfg){
+                .async_alarm_id = FWK_ID_NONE_INIT,
+                .async_alarm_api_id = FWK_ID_NONE_INIT,
+
+                .async_response_id = FWK_ID_NONE_INIT,
+                .async_response_api_id = FWK_ID_NONE_INIT,
+
                 .default_enabled = true,
                 .default_voltage = 100,
             },

--- a/product/sgi575/scp_ramfw/config_mock_psu.c
+++ b/product/sgi575/scp_ramfw/config_mock_psu.c
@@ -14,6 +14,12 @@ static const struct fwk_element element_table[] = {
         .name = "DVFS_GROUP0",
         .data =
             &(const struct mod_mock_psu_element_cfg){
+                .async_alarm_id = FWK_ID_NONE_INIT,
+                .async_alarm_api_id = FWK_ID_NONE_INIT,
+
+                .async_response_id = FWK_ID_NONE_INIT,
+                .async_response_api_id = FWK_ID_NONE_INIT,
+
                 .default_enabled = true,
                 .default_voltage = 100,
             },
@@ -22,6 +28,12 @@ static const struct fwk_element element_table[] = {
         .name = "DVFS_GROUP1",
         .data =
             &(const struct mod_mock_psu_element_cfg){
+                .async_alarm_id = FWK_ID_NONE_INIT,
+                .async_alarm_api_id = FWK_ID_NONE_INIT,
+
+                .async_response_id = FWK_ID_NONE_INIT,
+                .async_response_api_id = FWK_ID_NONE_INIT,
+
                 .default_enabled = true,
                 .default_voltage = 100,
             },

--- a/product/sgm775/scp_ramfw/config_mock_psu.c
+++ b/product/sgm775/scp_ramfw/config_mock_psu.c
@@ -13,6 +13,12 @@ static const struct fwk_element element_table[] = {
     {
         .name = "CPU_GROUP_LITTLE",
         .data = &(const struct mod_mock_psu_element_cfg) {
+            .async_alarm_id = FWK_ID_NONE_INIT,
+            .async_alarm_api_id = FWK_ID_NONE_INIT,
+
+            .async_response_id = FWK_ID_NONE_INIT,
+            .async_response_api_id = FWK_ID_NONE_INIT,
+
             .default_enabled = true,
             .default_voltage = 100,
         },
@@ -20,6 +26,12 @@ static const struct fwk_element element_table[] = {
     {
         .name = "CPU_GROUP_BIG",
         .data = &(const struct mod_mock_psu_element_cfg) {
+            .async_alarm_id = FWK_ID_NONE_INIT,
+            .async_alarm_api_id = FWK_ID_NONE_INIT,
+
+            .async_response_id = FWK_ID_NONE_INIT,
+            .async_response_api_id = FWK_ID_NONE_INIT,
+
             .default_enabled = true,
             .default_voltage = 100,
         },
@@ -27,6 +39,12 @@ static const struct fwk_element element_table[] = {
     {
         .name = "GPU",
         .data = &(const struct mod_mock_psu_element_cfg) {
+            .async_alarm_id = FWK_ID_NONE_INIT,
+            .async_alarm_api_id = FWK_ID_NONE_INIT,
+
+            .async_response_id = FWK_ID_NONE_INIT,
+            .async_response_api_id = FWK_ID_NONE_INIT,
+
             .default_enabled = true,
             .default_voltage = 100,
         },
@@ -34,6 +52,12 @@ static const struct fwk_element element_table[] = {
     {
         .name = "VPU",
         .data = &(const struct mod_mock_psu_element_cfg) {
+            .async_alarm_id = FWK_ID_NONE_INIT,
+            .async_alarm_api_id = FWK_ID_NONE_INIT,
+
+            .async_response_id = FWK_ID_NONE_INIT,
+            .async_response_api_id = FWK_ID_NONE_INIT,
+
             .default_enabled = true,
             .default_voltage = 100,
         },


### PR DESCRIPTION
This PR enables asynchronous operations at both the HAL and driver level of the `psu` module.