### PR TITLE
Add SGM-775 config indices

### DIFF
--- a/product/sgm775/scp_ramfw/config_mock_psu.c
+++ b/product/sgm775/scp_ramfw/config_mock_psu.c
@@ -8,9 +8,10 @@
 #include <fwk_element.h>
 #include <fwk_module.h>
 #include <mod_mock_psu.h>
+#include <config_mock_psu.h>
 
 static const struct fwk_element element_table[] = {
-    {
+    [CONFIG_MOCK_PSU_ELEMENT_IDX_CPU_GROUP_LITTLE] = {
         .name = "CPU_GROUP_LITTLE",
         .data = &(const struct mod_mock_psu_element_cfg) {
             .async_alarm_id = FWK_ID_NONE_INIT,
@@ -23,7 +24,7 @@ static const struct fwk_element element_table[] = {
             .default_voltage = 100,
         },
     },
-    {
+    [CONFIG_MOCK_PSU_ELEMENT_IDX_CPU_GROUP_BIG] = {
         .name = "CPU_GROUP_BIG",
         .data = &(const struct mod_mock_psu_element_cfg) {
             .async_alarm_id = FWK_ID_NONE_INIT,
@@ -36,7 +37,7 @@ static const struct fwk_element element_table[] = {
             .default_voltage = 100,
         },
     },
-    {
+    [CONFIG_MOCK_PSU_ELEMENT_IDX_GPU] = {
         .name = "GPU",
         .data = &(const struct mod_mock_psu_element_cfg) {
             .async_alarm_id = FWK_ID_NONE_INIT,
@@ -49,7 +50,7 @@ static const struct fwk_element element_table[] = {
             .default_voltage = 100,
         },
     },
-    {
+    [CONFIG_MOCK_PSU_ELEMENT_IDX_VPU] = {
         .name = "VPU",
         .data = &(const struct mod_mock_psu_element_cfg) {
             .async_alarm_id = FWK_ID_NONE_INIT,

--- a/product/sgm775/scp_ramfw/config_mock_psu.h
+++ b/product/sgm775/scp_ramfw/config_mock_psu.h
@@ -1,0 +1,20 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef CONFIG_MOCK_PSU_H
+#define CONFIG_MOCK_PSU_H
+
+enum config_mock_psu_element_idx {
+    CONFIG_MOCK_PSU_ELEMENT_IDX_CPU_GROUP_LITTLE,
+    CONFIG_MOCK_PSU_ELEMENT_IDX_CPU_GROUP_BIG,
+    CONFIG_MOCK_PSU_ELEMENT_IDX_GPU,
+    CONFIG_MOCK_PSU_ELEMENT_IDX_VPU,
+
+    CONFIG_MOCK_PSU_ELEMENT_IDX_COUNT,
+};
+
+#endif /* CONFIG_MOCK_PSU_H */

--- a/product/sgm775/scp_ramfw/config_psu.c
+++ b/product/sgm775/scp_ramfw/config_psu.c
@@ -10,38 +10,52 @@
 #include <fwk_module_idx.h>
 #include <mod_mock_psu.h>
 #include <mod_psu.h>
+#include <config_mock_psu.h>
+#include <config_psu.h>
 
 static const struct fwk_element element_table[] = {
-    {
+    [CONFIG_PSU_ELEMENT_IDX_CPU_GROUP_LITTLE] = {
         .name = "CPU_GROUP_LITTLE",
         .data = &(const struct mod_psu_element_cfg) {
-            .driver_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_MOCK_PSU, 0),
-            .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_MOCK_PSU,
-                                             MOD_MOCK_PSU_API_IDX_DRIVER)
+            .driver_id = FWK_ID_ELEMENT_INIT(
+                FWK_MODULE_IDX_MOCK_PSU,
+                CONFIG_MOCK_PSU_ELEMENT_IDX_CPU_GROUP_LITTLE),
+            .driver_api_id = FWK_ID_API_INIT(
+                FWK_MODULE_IDX_MOCK_PSU,
+                MOD_MOCK_PSU_API_IDX_DRIVER),
         },
     },
-    {
+    [CONFIG_PSU_ELEMENT_IDX_CPU_GROUP_BIG] = {
         .name = "CPU_GROUP_BIG",
         .data = &(const struct mod_psu_element_cfg) {
-            .driver_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_MOCK_PSU, 1),
-            .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_MOCK_PSU,
-                                             MOD_MOCK_PSU_API_IDX_DRIVER)
+            .driver_id = FWK_ID_ELEMENT_INIT(
+                FWK_MODULE_IDX_MOCK_PSU,
+                CONFIG_MOCK_PSU_ELEMENT_IDX_CPU_GROUP_BIG),
+            .driver_api_id = FWK_ID_API_INIT(
+                FWK_MODULE_IDX_MOCK_PSU,
+                MOD_MOCK_PSU_API_IDX_DRIVER),
         },
     },
-    {
+    [CONFIG_PSU_ELEMENT_IDX_GPU] = {
         .name = "GPU",
         .data = &(const struct mod_psu_element_cfg) {
-            .driver_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_MOCK_PSU, 2),
-            .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_MOCK_PSU,
-                                             MOD_MOCK_PSU_API_IDX_DRIVER)
+            .driver_id = FWK_ID_ELEMENT_INIT(
+                FWK_MODULE_IDX_MOCK_PSU,
+                CONFIG_MOCK_PSU_ELEMENT_IDX_GPU),
+            .driver_api_id = FWK_ID_API_INIT(
+                FWK_MODULE_IDX_MOCK_PSU,
+                MOD_MOCK_PSU_API_IDX_DRIVER),
         },
     },
-    {
+    [CONFIG_PSU_ELEMENT_IDX_VPU] = {
         .name = "VPU",
         .data = &(const struct mod_psu_element_cfg) {
-            .driver_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_MOCK_PSU, 3),
-            .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_MOCK_PSU,
-                                             MOD_MOCK_PSU_API_IDX_DRIVER)
+            .driver_id = FWK_ID_ELEMENT_INIT(
+                FWK_MODULE_IDX_MOCK_PSU,
+                CONFIG_MOCK_PSU_ELEMENT_IDX_VPU),
+            .driver_api_id = FWK_ID_API_INIT(
+                FWK_MODULE_IDX_MOCK_PSU,
+                MOD_MOCK_PSU_API_IDX_DRIVER),
         },
     },
     { 0 }

--- a/product/sgm775/scp_ramfw/config_psu.h
+++ b/product/sgm775/scp_ramfw/config_psu.h
@@ -1,0 +1,20 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef CONFIG_PSU_H
+#define CONFIG_PSU_H
+
+enum config_psu_element_idx {
+    CONFIG_PSU_ELEMENT_IDX_CPU_GROUP_LITTLE,
+    CONFIG_PSU_ELEMENT_IDX_CPU_GROUP_BIG,
+    CONFIG_PSU_ELEMENT_IDX_GPU,
+    CONFIG_PSU_ELEMENT_IDX_VPU,
+
+    CONFIG_PSU_ELEMENT_IDX_COUNT,
+};
+
+#endif /* CONFIG_PSU_H */

--- a/product/sgm775/scp_ramfw/config_timer.c
+++ b/product/sgm775/scp_ramfw/config_timer.c
@@ -13,6 +13,7 @@
 #include <mod_timer.h>
 #include <sgm775_mmap.h>
 #include <sgm775_irq.h>
+#include <config_timer.h>
 #include <clock_devices.h>
 #include <system_clock.h>
 
@@ -53,12 +54,12 @@ static const struct mod_timer_dev_config refclk_config = {
 };
 
 static const struct fwk_element timer_dev_table[] = {
-    [0] = {
+    [CONFIG_TIMER_ELEMENT_IDX_REFCLK] = {
         .name = "REFCLK",
         .data = &refclk_config,
-        .sub_element_count = 8, /* Number of alarms */
+        .sub_element_count = CONFIG_TIMER_REFCLK_SUB_ELEMENT_IDX_COUNT,
     },
-    [1] = { 0 },
+    [CONFIG_TIMER_ELEMENT_IDX_COUNT] = { 0 },
 };
 
 static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)

--- a/product/sgm775/scp_ramfw/config_timer.h
+++ b/product/sgm775/scp_ramfw/config_timer.h
@@ -1,0 +1,20 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef CONFIG_TIMER_H
+#define CONFIG_TIMER_H
+
+enum config_timer_element_idx {
+    CONFIG_TIMER_ELEMENT_IDX_REFCLK,
+    CONFIG_TIMER_ELEMENT_IDX_COUNT,
+};
+
+enum config_timer_refclk_sub_element_idx {
+    CONFIG_TIMER_REFCLK_SUB_ELEMENT_IDX_COUNT,
+};
+
+#endif /* CONFIG_TIMER_H */


### PR DESCRIPTION
This PR enumerates the `psu` and `timer` element identifier indices configured by SGM-775 so they are no longer identified by fixed integers.