### PR TITLE
[RFC] Changes in framework to support build in OP-TEE core

### DIFF
--- a/framework/include/fwk_align.h
+++ b/framework/include/fwk_align.h
@@ -22,4 +22,11 @@
 #   include <stdalign.h>
 #endif
 
+#ifdef BUILD_OPTEE
+#include <stddef.h>
+#ifndef _GCC_MAX_ALIGN_T
+typedef uintmax_t max_align_t;
+#endif
+#endif /*BUILD_OPTEE*/
+
 #endif /* FWK_ALIGN_H */

--- a/framework/include/fwk_host.h
+++ b/framework/include/fwk_host.h
@@ -23,6 +23,9 @@
  */
 #define FWK_HOST_PRINT printf
 
+#elif defined(BUILD_OPTEE)
+#include <trace.h>
+#define FWK_HOST_PRINT(...)	DMSG(__VA_ARGS__)
 #else
 #define FWK_HOST_PRINT(...) \
     do { \

--- a/framework/include/internal/fwk_thread.h
+++ b/framework/include/internal/fwk_thread.h
@@ -32,6 +32,13 @@ int __fwk_thread_init(size_t event_count);
 noreturn void __fwk_thread_run(void);
 
 /*
+ * \brief Processing events already raised by modules and interrupt handlers.
+ *
+ * \return The function does not return.
+ */
+void __fwk_run_event(void);
+
+/*
  * \brief Get the event being currently processed.
  *
  * \return The event being currently processed, or \c NULL if event processing

--- a/framework/src/fwk_assert.c
+++ b/framework/src/fwk_assert.c
@@ -8,6 +8,10 @@
 #include <fwk_assert.h>
 #include <fwk_interrupt.h>
 
+#if defined(BUILD_OPTEE)
+#include <kernel/panic.h>
+#endif
+
 void fwk_trap(void)
 {
     #ifdef BUILD_MODE_DEBUG
@@ -28,6 +32,8 @@ void fwk_unreachable(void)
 {
     #ifdef BUILD_MODE_DEBUG
         fwk_trap();
+    #elif defined(BUILD_OPTEE)
+	panic();
     #else
         /*
          * Let the optimizer know that anything after this point is unreachable.

--- a/framework/src/fwk_module.c
+++ b/framework/src/fwk_module.c
@@ -55,7 +55,7 @@ extern const struct fwk_module_config *module_config_table[];
 
 static struct context ctx;
 
-#ifdef BUILD_HOST
+#if defined(BUILD_HOST) || defined(BUILD_OPTEE)
 static const char err_msg_line[] = "[MOD] Error %d in %s @%d\n";
 static const char err_msg_func[] = "[MOD] Error %d in %s\n";
 #endif
@@ -419,7 +419,9 @@ int __fwk_module_init(void)
 
     ctx.initialized = true;
 
+    #ifndef BUILD_OPTEE
     __fwk_thread_run();
+    #endif
 
     return FWK_SUCCESS;
 }

--- a/framework/src/fwk_multi_thread.c
+++ b/framework/src/fwk_multi_thread.c
@@ -25,9 +25,12 @@
 #define SIGNAL_NO_READY_THREAD 0x08
 
 static struct __fwk_multi_thread_ctx ctx;
-#ifdef BUILD_HOST
-static const char err_msg_line[] = "[THR] Error %d @%d\n";
-static const char err_msg_func[] = "[THR] Error %d in %s\n";
+
+#if defined(BUILD_HOST) || defined(BUILD_OPTEE)
+static const char __attribute__((unused)) err_msg_line[] =
+	"[THR] Error %d @%d\n";
+static const char __attribute__((unused)) err_msg_func[] =
+	"[THR] Error %d in %s\n";
 #endif
 
 /*

--- a/framework/src/fwk_thread.c
+++ b/framework/src/fwk_thread.c
@@ -172,6 +172,19 @@ noreturn void __fwk_thread_run(void)
     }
 }
 
+void __fwk_run_event(void)
+{
+    for (;;) {
+        while (!fwk_list_is_empty(&ctx.event_queue))
+            process_next_event();
+
+        if (fwk_list_is_empty(&ctx.isr_event_queue))
+            return;
+
+        process_isr();
+    }
+}
+
 struct __fwk_thread_ctx *__fwk_thread_get_ctx(void)
 {
     return &ctx;

--- a/framework/src/fwk_thread.c
+++ b/framework/src/fwk_thread.c
@@ -24,9 +24,11 @@
 
 static struct __fwk_thread_ctx ctx;
 
-#ifdef BUILD_HOST
-static const char err_msg_line[] = "[THR] Error %d in %s @%d\n";
-static const char err_msg_func[] = "[THR] Error %d in %s\n";
+#if defined(BUILD_HOST) || defined(BUILD_OPTEE)
+static const char __attribute__((unused)) err_msg_line[] =
+	"[THR] Error %d in %s @%d\n";
+static const char __attribute__((unused)) err_msg_func[] =
+	"[THR] Error %d in %s\n";
 #endif
 
 /*


### PR DESCRIPTION
This P-R presents change proposals in the framework that are needed to build the SCP-firmware as a SCMI server library embedded in OP-TEE core. When OP-TEE does so, it builds SCP-firmware sources from OP-TEE OS source tree.

`BUILD_OPTEE` is expected defined in C source files scope when SCP-firmware builds for OP-TEE OS.

Please feel free to give your feedback on this proposal.

Alone, this P-R does not build a OP-TEE SCMI server library. P-Rs (**todo**) proposes other required changes. One can get the full picture of the SCP-firmware changes in the PoC branch [optee-stm32mp1 for this repo](https://github.com/etienne-lms/SCP-firmware/commits/optee-stm32mp1).