### PR TITLE
[RFC] Changes in modules to support build in OP-TEE core

### DIFF
--- a/framework/include/fwk_status.h
+++ b/framework/include/fwk_status.h
@@ -82,6 +82,15 @@
 #define FWK_E_PANIC         -18
 
 /*!
+ * \brief Return a human readable string representation of a status code.
+ *
+ * \param status Status code value.
+ *
+ * \return String representation of \p status
+ */
+const char *fwk_status_str(int status);
+
+/*!
  * @}
  */
 

--- a/framework/src/Makefile
+++ b/framework/src/Makefile
@@ -23,6 +23,7 @@ endif
 ifeq ($(BUILD_HAS_NOTIFICATION),yes)
     BS_LIB_SOURCES += fwk_notification.c
 endif
+BS_LIB_SOURCES += fwk_status.c
 
 BS_LIB_INCLUDES += $(ARCH_DIR)/include
 BS_LIB_INCLUDES += $(FWK_DIR)/include

--- a/framework/src/fwk_status.c
+++ b/framework/src/fwk_status.c
@@ -1,0 +1,52 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     Framework status code helpers.
+ */
+
+#include <fwk_macros.h>
+#include <fwk_status.h>
+
+static const char * const error_string[] = {
+    [-FWK_E_PARAM]       = "E_PARAM",
+    [-FWK_E_ALIGN]       = "E_ALIGN",
+    [-FWK_E_SIZE]        = "E_SIZE",
+    [-FWK_E_HANDLER]     = "E_HANDLER",
+    [-FWK_E_ACCESS]      = "E_ACCESS",
+    [-FWK_E_RANGE]       = "E_RANGE",
+    [-FWK_E_TIMEOUT]     = "E_TIMEOUT",
+    [-FWK_E_NOMEM]       = "E_NOMEM",
+    [-FWK_E_PWRSTATE]    = "E_PWRSTATE",
+    [-FWK_E_SUPPORT]     = "E_SUPPORT",
+    [-FWK_E_DEVICE]      = "E_DEVICE",
+    [-FWK_E_BUSY]        = "E_BUSY",
+    [-FWK_E_OS]          = "E_OS",
+    [-FWK_E_DATA]        = "E_DATA",
+    [-FWK_E_STATE]       = "E_STATE",
+    [-FWK_E_INIT]        = "E_INIT",
+    [-FWK_E_OVERWRITTEN] = "E_OVERWRITTEN",
+    [-FWK_E_PANIC]       = "E_PANIC",
+};
+
+static const char * const status_string[] = {
+    [FWK_SUCCESS]        = "SUCCESS",
+    [FWK_PENDING]        = "PENDING",
+};
+
+const char *fwk_status_str(int status)
+{
+    static const char unknown[] = "unknown";
+
+    unsigned int error_idx = (unsigned int)(-status);
+
+    if ((status < 0) && (error_idx < FWK_ARRAY_SIZE(error_string)))
+        return error_string[error_idx];
+    else if ((status >= 0) && (status < (int)FWK_ARRAY_SIZE(status_string)))
+        return status_string[status];
+
+    return unknown;
+}

--- a/module/clock/src/mod_clock.c
+++ b/module/clock/src/mod_clock.c
@@ -191,10 +191,8 @@ static int clock_set_rate(fwk_id_t clock_id, uint64_t rate,
     status = ctx->api->set_rate(ctx->config->driver_id, rate, round_mode);
     if (status == FWK_PENDING)
         return create_async_request(ctx, clock_id);
-    else if (status == FWK_SUCCESS)
-        return FWK_SUCCESS;
-    else
-        return status;
+
+    return status;
 }
 
 static int clock_get_rate(fwk_id_t clock_id, uint64_t *rate)
@@ -216,10 +214,8 @@ static int clock_get_rate(fwk_id_t clock_id, uint64_t *rate)
     status = ctx->api->get_rate(ctx->config->driver_id, rate);
     if (status == FWK_PENDING)
         return create_async_request(ctx, clock_id);
-    else if (status == FWK_SUCCESS)
-        return FWK_SUCCESS;
-    else
-        return status;
+
+    return status;
 }
 
 static int clock_get_rate_from_index(fwk_id_t clock_id, unsigned int rate_index,
@@ -255,10 +251,8 @@ static int clock_set_state(fwk_id_t clock_id, enum mod_clock_state state)
     status = ctx->api->set_state(ctx->config->driver_id, state);
     if (status == FWK_PENDING)
         return create_async_request(ctx, clock_id);
-    else if (status == FWK_SUCCESS)
-        return FWK_SUCCESS;
-    else
-        return status;
+
+    return status;
 }
 
 static int clock_get_state(fwk_id_t clock_id, enum mod_clock_state *state)
@@ -280,10 +274,8 @@ static int clock_get_state(fwk_id_t clock_id, enum mod_clock_state *state)
     status = ctx->api->get_state(ctx->config->driver_id, state);
     if (status == FWK_PENDING)
         return create_async_request(ctx, clock_id);
-    else if (status == FWK_SUCCESS)
-        return FWK_SUCCESS;
-    else
-        return status;
+
+    return status;
 }
 
 static int clock_get_info(fwk_id_t clock_id, struct mod_clock_info *info)

--- a/module/clock/src/mod_clock.c
+++ b/module/clock/src/mod_clock.c
@@ -15,7 +15,7 @@
 #include <fwk_status.h>
 #include <fwk_thread.h>
 #include <mod_power_domain.h>
-#include <clock.h>
+#include "clock.h"
 
 /* Device context */
 struct clock_dev_ctx {
@@ -64,9 +64,9 @@ static int process_response_event(const struct fwk_event *event)
     struct fwk_event resp_event;
     struct clock_dev_ctx *ctx;
     struct mod_clock_driver_resp_params *event_params =
-        (struct mod_clock_driver_resp_params *)event->params;
+        (struct mod_clock_driver_resp_params *)(void *)event->params;
     struct mod_clock_resp_params *resp_params =
-        (struct mod_clock_resp_params *)resp_event.params;
+        (struct mod_clock_resp_params *)(void *)resp_event.params;
 
     ctx = &module_ctx.dev_ctx_table[fwk_id_get_element_idx(event->target_id)];
 
@@ -140,14 +140,14 @@ static int get_ctx(fwk_id_t clock_id, struct clock_dev_ctx **ctx)
  * Driver response API.
  */
 
-void request_complete(fwk_id_t dev_id,
-                      struct mod_clock_driver_resp_params *response)
+static void request_complete(fwk_id_t dev_id,
+                             struct mod_clock_driver_resp_params *response)
 {
     int status;
     struct fwk_event event;
     struct clock_dev_ctx *ctx;
     struct mod_clock_driver_resp_params *event_params =
-        (struct mod_clock_driver_resp_params *)event.params;
+        (struct mod_clock_driver_resp_params *)(void *)event.params;
 
     fwk_assert(fwk_module_is_valid_element_id(dev_id));
 
@@ -626,7 +626,7 @@ static int clock_process_notification(
     else if (fwk_id_is_equal(event->id,
                  module_ctx.config->pd_pre_transition_notification_id))
         return clock_process_pd_pre_transition_notification(ctx, event,
-							    resp_event);
+                                                            resp_event);
     else
         return FWK_E_HANDLER;
 }

--- a/module/log/include/mod_log.h
+++ b/module/log/include/mod_log.h
@@ -146,7 +146,6 @@ struct mod_log_api {
      *      * \%s - string format
      *      * \%u - unsigned 32-bit decimal format
      *      * \%x - 32-bit hexadecimal format
-     *      * \%e - framework error code format
      *
      *      Numeric formats also accept a padding flag '0\<width\>' between the
      *      '\%' and the format specifier where the resulting string number will

--- a/module/log/src/mod_log.c
+++ b/module/log/src/mod_log.c
@@ -25,28 +25,6 @@ static struct mod_log_driver_api *log_driver;
                          MOD_LOG_GROUP_INFO | \
                          MOD_LOG_GROUP_WARNING)
 
-static const char * const errstr[] = {
-    [FWK_SUCCESS]        = "SUCCESS",
-    [-FWK_E_PARAM]       = "E_PARAM",
-    [-FWK_E_ALIGN]       = "E_ALIGN",
-    [-FWK_E_SIZE]        = "E_SIZE",
-    [-FWK_E_HANDLER]     = "E_HANDLER",
-    [-FWK_E_ACCESS]      = "E_ACCESS",
-    [-FWK_E_RANGE]       = "E_RANGE",
-    [-FWK_E_TIMEOUT]     = "E_TIMEOUT",
-    [-FWK_E_NOMEM]       = "E_NOMEM",
-    [-FWK_E_PWRSTATE]    = "E_PWRSTATE",
-    [-FWK_E_SUPPORT]     = "E_SUPPORT",
-    [-FWK_E_DEVICE]      = "E_DEVICE",
-    [-FWK_E_BUSY]        = "E_BUSY",
-    [-FWK_E_OS]          = "E_OS",
-    [-FWK_E_DATA]        = "E_DATA",
-    [-FWK_E_STATE]       = "E_STATE",
-    [-FWK_E_INIT]        = "E_INIT",
-    [-FWK_E_OVERWRITTEN] = "E_OVERWRITTEN",
-    [-FWK_E_PANIC]       = "E_PANIC",
-};
-
 static int do_putchar(char c)
 {
     int status;
@@ -141,23 +119,6 @@ static int do_print(const char *fmt, va_list *args)
 next_symbol:
             /* Check the format specifier */
             switch (*fmt) {
-            case 'e':
-                num = va_arg(*args, int);
-                unum = (uint64_t)(-num);
-                if ((num <= 0) && (unum < FWK_ARRAY_SIZE(errstr))) {
-
-                    status = print_string("FWK_");
-                    if (status != FWK_SUCCESS)
-                        return status;
-
-                    status = print_string(errstr[unum]);
-                } else
-                    status = print_int32(num, 0);
-
-                if (status != FWK_SUCCESS)
-                    return status;
-                break;
-
             case 'i': /* Fall through to next one */
             case 'd':
                 if (bit64)

--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -294,7 +294,7 @@ static const unsigned int mod_pd_cs_level_state_shift[MOD_PD_LEVEL_COUNT] = {
  * Internal variables
  */
 static struct mod_pd_ctx mod_pd_ctx;
-static const char driver_error_msg[] = "[PD] Driver error %e in %s @%d\n";
+static const char driver_error_msg[] = "[PD] Driver error %s (%d) in %s @%d\n";
 
 static const unsigned int tree_pos_level_shift[MOD_PD_LEVEL_COUNT] = {
     MOD_PD_TREE_POS_LEVEL_0_SHIFT,
@@ -711,9 +711,9 @@ static int initiate_power_state_transition(struct pd_ctx *pd)
     status = pd->driver_api->set_state(pd->driver_id, state);
 
     mod_pd_ctx.log_api->log(MOD_LOG_GROUP_DEBUG,
-        "[PD] %s: %s->%s, %e\n", fwk_module_get_name(pd->id),
+        "[PD] %s: %s->%s, %s (%d)\n", fwk_module_get_name(pd->id),
         get_state_name(pd, pd->state_requested_to_driver),
-        get_state_name(pd, state), status);
+        get_state_name(pd, state), fwk_status_str(status), status);
 
     pd->state_requested_to_driver = state;
 
@@ -1208,8 +1208,8 @@ static void process_system_shutdown_request(
 
         if (status != FWK_SUCCESS)
             mod_pd_ctx.log_api->log(MOD_LOG_GROUP_ERROR,
-                "[PD] Shutdown of %s returned %e\n",
-                fwk_module_get_name(pd_id), status);
+                "[PD] Shutdown of %s returned %s (%d)\n",
+                fwk_module_get_name(pd_id), fwk_status_str(status), status);
         else
             mod_pd_ctx.log_api->log(MOD_LOG_GROUP_DEBUG,
                 "[PD] %s shutdown\n", fwk_module_get_name(pd_id));
@@ -1795,7 +1795,7 @@ static int pd_start(fwk_id_t id)
         status = pd->driver_api->get_state(pd->driver_id, &state);
         if (status != FWK_SUCCESS) {
             mod_pd_ctx.log_api->log(MOD_LOG_GROUP_ERROR, driver_error_msg,
-                status, __func__, __LINE__);
+                fwk_status_str(status), status, __func__, __LINE__);
         } else {
             pd->requested_state = pd->state_requested_to_driver = state;
 

--- a/module/scmi/src/mod_scmi.c
+++ b/module/scmi/src/mod_scmi.c
@@ -265,7 +265,8 @@ static void respond(fwk_id_t service_id, const void *payload, size_t size)
     status = ctx->respond(ctx->transport_id, payload, size);
     if (status != FWK_SUCCESS)
         scmi_ctx.log_api->log(MOD_LOG_GROUP_ERROR,
-            "[SCMI] Failed to send response (%e)\n", status);
+            "[SCMI] Failed to send response %s (%d)\n",
+            fwk_status_str(status), status);
 }
 
 static const struct mod_scmi_from_protocol_api mod_scmi_from_protocol_api = {
@@ -790,8 +791,9 @@ static int scmi_process_event(const struct fwk_event *event,
 
     if (status != FWK_SUCCESS) {
         scmi_ctx.log_api->log(MOD_LOG_GROUP_ERROR,
-            "[SCMI] Protocol 0x%x handler error (%e), message_id = 0x%x\n",
-            ctx->scmi_protocol_id, status, ctx->scmi_message_id);
+            "[SCMI] Protocol 0x%x handler error %s (%d), message_id = 0x%x\n",
+            ctx->scmi_protocol_id, fwk_status_str(status), status,
+            ctx->scmi_message_id);
     }
 
     return FWK_SUCCESS;

--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -538,7 +538,9 @@ static int scmi_clock_attributes_handler(fwk_id_t service_id,
 exit:
     response_size = (return_values.status == SCMI_SUCCESS) ?
         sizeof(return_values) : sizeof(return_values.status);
+
     scmi_clock_ctx.scmi_api->respond(service_id, &return_values, response_size);
+
     return status;
 }
 
@@ -991,9 +993,8 @@ static int scmi_clock_init(fwk_id_t module_id, unsigned int element_count,
         return FWK_E_PANIC;
 
     /* Allocate a table of clock operations */
-    scmi_clock_ctx.clock_ops =
-        fwk_mm_calloc((unsigned int)clock_devices,
-        sizeof(struct mod_clock_api));
+    scmi_clock_ctx.clock_ops = fwk_mm_calloc((unsigned int)clock_devices,
+                                             sizeof(struct mod_clock_api));
     if (scmi_clock_ctx.clock_ops == NULL)
         return FWK_E_NOMEM;
 
@@ -1075,10 +1076,8 @@ static int process_request_event(const struct fwk_event *event)
         rate = (uint64_t)set_rate_data.rate[0] +
                (((uint64_t)set_rate_data.rate[1]) << 32);
 
-        status =
-            scmi_clock_ctx.clock_api->set_rate(params->clock_dev_id,
-                                               rate,
-                                               set_rate_data.round_mode);
+        status = scmi_clock_ctx.clock_api->set_rate(params->clock_dev_id, rate,
+                                                    set_rate_data.round_mode);
         if (status != FWK_PENDING) {
             /* Request completed */
             set_request_respond(service_id, status);
@@ -1134,7 +1133,7 @@ static int process_response_event(const struct fwk_event *event)
             clock_state = params->value.state;
 
             get_state_respond(event->source_id, service_id, &clock_state,
-                FWK_SUCCESS);
+                              FWK_SUCCESS);
 
             break;
 

--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -352,7 +352,7 @@ static int create_event_request(fwk_id_t clock_id,
         .target_id = fwk_module_id_scmi_clock,
     };
 
-    params = (struct event_request_params *)event.params;
+    params = (struct event_request_params *)(void *)event.params;
 
     switch (request) {
     case SCMI_CLOCK_REQUEST_GET_STATE:
@@ -366,7 +366,7 @@ static int create_event_request(fwk_id_t clock_id,
     case SCMI_CLOCK_REQUEST_SET_RATE:
         {
         struct event_set_rate_request_data *rate_data =
-            (struct event_set_rate_request_data *)data;
+            (struct event_set_rate_request_data *)(void *)data;
 
         request_data.set_rate_data.rate[0] = rate_data->rate[0];
         request_data.set_rate_data.rate[1] = rate_data->rate[1];
@@ -381,7 +381,7 @@ static int create_event_request(fwk_id_t clock_id,
     case SCMI_CLOCK_REQUEST_SET_STATE:
         {
         struct event_set_state_request_data *state_data =
-            (struct event_set_state_request_data *)data;
+            (struct event_set_state_request_data *)(void *)data;
         request_data.set_state_data.state = state_data->state;
 
         params->request_data = request_data;
@@ -1044,7 +1044,7 @@ static int process_request_event(const struct fwk_event *event)
     struct event_set_state_request_data set_state_data;
     fwk_id_t service_id;
 
-    params = (struct event_request_params *)event->params;
+    params = (struct event_request_params *)(void *)event->params;
     clock_dev_idx = fwk_id_get_element_idx(params->clock_dev_id);
     service_id = clock_ops_get_service(clock_dev_idx);
 
@@ -1113,7 +1113,7 @@ static int process_request_event(const struct fwk_event *event)
 static int process_response_event(const struct fwk_event *event)
 {
     struct mod_clock_resp_params *params =
-        (struct mod_clock_resp_params *)event->params;
+        (struct mod_clock_resp_params *)(void *)event->params;
     unsigned int clock_dev_idx;
     fwk_id_t service_id;
     enum scmi_clock_request_type request;

--- a/module/scmi_power_domain/src/mod_scmi_power_domain.c
+++ b/module/scmi_power_domain/src/mod_scmi_power_domain.c
@@ -290,8 +290,8 @@ static int scmi_power_scp_set_core_state(fwk_id_t pd_id,
                                                            composite_state);
     if (status != FWK_SUCCESS) {
         scmi_pd_ctx.log_api->log(MOD_LOG_GROUP_ERROR,
-            "[SCMI:power] Failed to send core set request (error %e)\n",
-            status);
+            "[SCMI:power] Failed to send core set request (error %s (%d))\n",
+            fwk_status_str(status), status);
     }
 
     return status;


### PR DESCRIPTION
This P-R presents change proposals in modules that are needed to build the SCP-firmware as a SCMI server library embedded in OP-TEE core, or that are trivial, as indentation fixes.

`BUILD_OPTEE` is expected defined in C source files scope when SCP-firmware builds for OP-TEE OS.

Please feel free to give your feedback on this proposal.

Alone, this P-R does not build a OP-TEE SCMI server library. P-R #132 (**todo**) proposes other required changes. One can get the full picture of the SCP-firmware changes in the PoC branch [optee-stm32mp1 for this repo](https://github.com/etienne-lms/SCP-firmware/commits/optee-stm32mp1).