### PR TITLE
scmi_sensor: Fix return value from response event

### DIFF
--- a/module/scmi_sensor/src/mod_scmi_sensor.c
+++ b/module/scmi_sensor/src/mod_scmi_sensor.c
@@ -576,10 +576,14 @@ static int scmi_sensor_process_event(const struct fwk_event *event,
             (struct mod_sensor_event_params *)event->params;
 
         return_values = (struct scmi_sensor_protocol_reading_get_p2a) {
-            .status = SCMI_SUCCESS,
             .sensor_value_low = (uint32_t)params->value,
             .sensor_value_high = (uint32_t)(params->value >> 32),
         };
+
+        if (params->status == FWK_SUCCESS)
+            return_values.status = SCMI_SUCCESS;
+        else
+            return_values.status = SCMI_HARDWARE_ERROR;
 
         scmi_sensor_respond(&return_values, event->source_id);
     }


### PR DESCRIPTION
This patch fixes the status returned to scmi when
the result is provided through a response event. In the
case of a hardware failure, the agent is now correctly
informed of such state.

Change-Id: I96c09e3f63afa86bef64da81da346895ea738f22
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>