### PR TITLE
I2c and juno misc

### DIFF
--- a/module/dw_apb_i2c/src/mod_dw_apb_i2c.c
+++ b/module/dw_apb_i2c/src/mod_dw_apb_i2c.c
@@ -162,7 +162,13 @@ static int transmit_as_master(fwk_id_t dev_id,
 
     fwk_interrupt_global_enable();
 
-    return FWK_SUCCESS;
+    /*
+     * The data has been pushed to the I2C FIFO for transmission to the
+     * target device. An interrupt will signal the completion of the
+     * transfer. The i2c_isr() interrupt handler will be invoked to notify
+     * the caller.
+     */
+    return FWK_PENDING;
 }
 
 static int receive_as_master(fwk_id_t dev_id,
@@ -201,7 +207,13 @@ static int receive_as_master(fwk_id_t dev_id,
 
     fwk_interrupt_global_enable();
 
-    return FWK_SUCCESS;
+    /*
+     * The command has been sent to the I2C for requesting data from
+     * the target device. An interrupt will signal the completion of the
+     * transfer. The i2c_isr() interrupt handler will be invoked to notify
+     * the caller.
+     */
+    return FWK_PENDING;
 }
 
 static const struct mod_i2c_driver_api driver_api = {

--- a/module/i2c/doc/module_i2c_architecture.md
+++ b/module/i2c/doc/module_i2c_architecture.md
@@ -30,8 +30,10 @@ The following features are unsupported. Support may be added in the future.
 
 # Flow                                           {#module_i2c_architecture_flow}
 
+## Asynchronous API
+
 The following schematic describes the transaction flow for an I2C master
-transmission. The flow for a reception is similar.
+asynchronous transmission. The flow for an asynchronous reception is similar.
 
     Client             I2C         I2C Driver     I2C ISR (Driver)
       |                 |               |               |

--- a/module/i2c/include/mod_i2c.h
+++ b/module/i2c/include/mod_i2c.h
@@ -106,9 +106,10 @@ struct mod_i2c_driver_api {
      * \param dev_id Identifier of the I2C device
      * \param transmit_request Request information for the I2C transmission
      *
-     * \retval FWK_SUCCESS The request was submitted.
+     * \retval FWK_PENDING The request was submitted.
+     * \retval FWK_SUCCESS The request was successfully completed.
      * \retval FWK_E_PARAM One or more parameters were invalid.
-     * \return One of the standard framework error codes.
+     * \return One of the standard framework status codes.
      */
     int (*transmit_as_master)(
         fwk_id_t dev_id, struct mod_i2c_request *transmit_request);
@@ -124,9 +125,10 @@ struct mod_i2c_driver_api {
      * \param dev_id Identifier of the I2C device
      * \param receive_request Request information for the I2C reception
      *
-     * \retval FWK_SUCCESS The request was submitted.
+     * \retval FWK_PENDING The request was submitted.
+     * \retval FWK_SUCCESS The request was successfully completed.
      * \retval FWK_E_PARAM One or more parameters were invalid.
-     * \return One of the standard framework error codes.
+     * \return One of the standard framework status codes.
      */
     int (*receive_as_master)(
         fwk_id_t dev_id, struct mod_i2c_request *receive_request);
@@ -140,21 +142,21 @@ struct mod_i2c_api {
      * \brief Request transmission of data as Master to a selected slave.
      *
      * \details When the function returns the transmission is not completed,
-     *      not even started. The data buffer must stay allocated and its
-     *      content must not be modified until the transmission is completed or
-     *      aborted. When the transmission operation has finished a response
-     *      event is sent to the client.
+     *      possibly not even started. The data buffer must stay allocated
+     *      and its content must not be modified until the transmission is
+     *      completed or aborted. When the transmission operation has finished
+     *      a response event is sent to the client.
      *
      * \param dev_id Identifier of the I2C device
      * \param slave_address Address of the slave on the I2C bus
      * \param data Pointer to the data bytes to transmit to the slave
      * \param byte_count Number of data bytes to transmit
      *
-     * \retval FWK_SUCCESS The request was submitted.
+     * \retval FWK_PENDING The request was submitted.
      * \retval FWK_E_PARAM One or more parameters were invalid.
      * \retval FWK_E_BUSY An I2C transaction is already on-going.
      * \retval FWK_E_DEVICE The transmission is aborted due to a device error.
-     * \return One of the standard framework error codes.
+     * \return One of the standard framework status codes.
      */
     int (*transmit_as_master)(fwk_id_t dev_id, uint8_t slave_address,
         uint8_t *data, uint8_t byte_count);
@@ -163,21 +165,21 @@ struct mod_i2c_api {
      * \brief Request reception of data as Master from a selected slave.
      *
      * \details When the function returns the reception is not completed,
-     *      not even started. The data buffer must stay allocated and its
-     *      content must not be modified until the reception is completed or
-     *      aborted. When the reception operation has finished a response event
-     *      is sent to the client.
+     *      possibly not even started. The data buffer must stay allocated
+     *      and its content must not be modified until the reception is
+     *      completed or aborted. When the reception operation has finished
+     *      a response event is sent to the client.
      *
      * \param dev_id Identifier of the I2C device
      * \param slave_address Address of the slave on the I2C bus
      * \param data Pointer to the buffer to receive data from the slave
      * \param byte_count Number of data bytes to receive
      *
-     * \retval FWK_SUCCESS The request was submitted.
+     * \retval FWK_PENDING The request was submitted.
      * \retval FWK_E_PARAM One or more parameters were invalid.
      * \retval FWK_E_BUSY An I2C transaction is already on-going.
      * \retval FWK_E_DEVICE The reception is aborted due to a device error.
-     * \return One of the standard framework error codes.
+     * \return One of the standard framework status codes.
      */
     int (*receive_as_master)(fwk_id_t dev_id, uint8_t slave_address,
         uint8_t *data, uint8_t byte_count);
@@ -186,11 +188,11 @@ struct mod_i2c_api {
      * \brief Request the transmission followed by the reception of data as
      *      Master to/from a selected slave.
      *
-     * \details When the function returns the transaction is not completed, not
-     *      even started. The data buffers must stay allocated and their content
-     *      must not be modified until the transaction is completed or aborted.
-     *      When the transaction has finished a response event is sent to the
-     *      client.
+     * \details When the function returns the transaction is not completed,
+     *      possibly not even started. The data buffer must stay allocated
+     *      and its content must not be modified until the transaction is
+     *      completed or aborted. When the transaction operation has finished
+     *      a response event is sent to the client.
      *
      * \param dev_id Identifier of the I2C device
      * \param slave_address Address of the slave on the I2C bus
@@ -199,15 +201,15 @@ struct mod_i2c_api {
      * \param receive_data Pointer to the buffer to receive the data in the
      *      second phase.
      * \param transmit_byte_count Number of data bytes to transmit in the first
-     *      phase
+     *      phase.
      * \param receive_byte_count Number of data bytes to receive in the second
-     *      phase
+     *      phase.
      *
-     * \retval FWK_SUCCESS The request was submitted.
+     * \retval FWK_PENDING The request was submitted.
      * \retval FWK_E_PARAM One or more parameters were invalid.
      * \retval FWK_E_BUSY An I2C transaction is already on-going.
      * \retval FWK_E_DEVICE The reception is aborted due to a device error.
-     * \return One of the standard framework error codes.
+     * \return One of the standard framework status codes.
      */
     int (*transmit_then_receive_as_master)(fwk_id_t dev_id,
         uint8_t slave_address, uint8_t *transmit_data, uint8_t *receive_data,
@@ -258,18 +260,23 @@ static const fwk_id_t mod_i2c_api_id_driver_response =
  * \brief Event indices
  */
 enum mod_i2c_event_idx {
-    MOD_I2C_EVENT_IDX_REQUEST,
-    MOD_I2C_EVENT_IDX_REQUEST_COMPLETED,
+    MOD_I2C_EVENT_IDX_REQUEST_TRANSMIT,
+    MOD_I2C_EVENT_IDX_REQUEST_RECEIVE,
+    MOD_I2C_EVENT_IDX_REQUEST_TRANSMIT_THEN_RECEIVE,
     MOD_I2C_EVENT_IDX_COUNT,
 };
 
-/*! Request event identifier */
-static const fwk_id_t mod_i2c_event_id_request = FWK_ID_EVENT_INIT(
-    FWK_MODULE_IDX_I2C, MOD_I2C_EVENT_IDX_REQUEST);
+/*! Transmit request event identifier */
+static const fwk_id_t mod_i2c_event_id_request_tx = FWK_ID_EVENT_INIT(
+    FWK_MODULE_IDX_I2C, MOD_I2C_EVENT_IDX_REQUEST_TRANSMIT);
 
-/*! Request completed event identifier */
-static const fwk_id_t mod_i2c_event_id_request_completed = FWK_ID_EVENT_INIT(
-    FWK_MODULE_IDX_I2C, MOD_I2C_EVENT_IDX_REQUEST_COMPLETED);
+/*! Receive request event identifier */
+static const fwk_id_t mod_i2c_event_id_request_rx = FWK_ID_EVENT_INIT(
+    FWK_MODULE_IDX_I2C, MOD_I2C_EVENT_IDX_REQUEST_RECEIVE);
+
+/*! Transmit then receive request event identifier */
+static const fwk_id_t mod_i2c_event_id_request_tx_rx = FWK_ID_EVENT_INIT(
+    FWK_MODULE_IDX_I2C, MOD_I2C_EVENT_IDX_REQUEST_TRANSMIT_THEN_RECEIVE);
 
 /*!
  * \}

--- a/module/i2c/include/mod_i2c.h
+++ b/module/i2c/include/mod_i2c.h
@@ -260,7 +260,6 @@ static const fwk_id_t mod_i2c_api_id_driver_response =
 enum mod_i2c_event_idx {
     MOD_I2C_EVENT_IDX_REQUEST,
     MOD_I2C_EVENT_IDX_REQUEST_COMPLETED,
-    MOD_I2C_EVENT_IDX_RESTART,
     MOD_I2C_EVENT_IDX_COUNT,
 };
 
@@ -271,11 +270,6 @@ static const fwk_id_t mod_i2c_event_id_request = FWK_ID_EVENT_INIT(
 /*! Request completed event identifier */
 static const fwk_id_t mod_i2c_event_id_request_completed = FWK_ID_EVENT_INIT(
     FWK_MODULE_IDX_I2C, MOD_I2C_EVENT_IDX_REQUEST_COMPLETED);
-
-/*! Restart event identifier */
-static const fwk_id_t mod_i2c_event_id_restart = FWK_ID_EVENT_INIT(
-    FWK_MODULE_IDX_I2C, MOD_I2C_EVENT_IDX_RESTART);
-
 
 /*!
  * \}

--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -993,7 +993,7 @@ static int scmi_clock_init(fwk_id_t module_id, unsigned int element_count,
     /* Allocate a table of clock operations */
     scmi_clock_ctx.clock_ops =
         fwk_mm_calloc((unsigned int)clock_devices,
-        sizeof(struct mod_clock_api));
+        sizeof(struct clock_operations));
     if (scmi_clock_ctx.clock_ops == NULL)
         return FWK_E_NOMEM;
 

--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -570,7 +570,7 @@ static int scmi_clock_rate_get_handler(fwk_id_t service_id,
     }
 
     status = check_service_permission(clock_device,
-        MOD_SCMI_CLOCK_PERM_ATTRIBUTES, &service_permission_granted);
+        MOD_SCMI_CLOCK_PERM_GET_RATE, &service_permission_granted);
     if (status != FWK_SUCCESS)
         goto exit;
 
@@ -635,7 +635,7 @@ static int scmi_clock_rate_set_handler(fwk_id_t service_id,
     }
 
     status = check_service_permission(clock_device,
-        MOD_SCMI_CLOCK_PERM_ATTRIBUTES, &service_permission_granted);
+        MOD_SCMI_CLOCK_PERM_SET_RATE, &service_permission_granted);
     if (status != FWK_SUCCESS)
         goto exit;
 
@@ -712,7 +712,7 @@ static int scmi_clock_config_set_handler(fwk_id_t service_id,
     }
 
     status = check_service_permission(clock_device,
-        MOD_SCMI_CLOCK_PERM_ATTRIBUTES, &service_permission_granted);
+        MOD_SCMI_CLOCK_PERM_SET_CONFIG, &service_permission_granted);
     if (status != FWK_SUCCESS)
         goto exit;
 
@@ -786,7 +786,7 @@ static int scmi_clock_describe_rates_handler(fwk_id_t service_id,
     }
 
     status = check_service_permission(clock_device,
-        MOD_SCMI_CLOCK_PERM_ATTRIBUTES, &service_permission_granted);
+        MOD_SCMI_CLOCK_PERM_DESCRIBE_RATES, &service_permission_granted);
     if (status != FWK_SUCCESS)
         goto exit;
 

--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -1122,7 +1122,6 @@ static int process_response_event(const struct fwk_event *event)
     uint64_t rate;
 
     clock_dev_idx = fwk_id_get_element_idx(event->source_id);
-    request = scmi_clock_ctx.clock_ops[clock_dev_idx].request;
     request = clock_ops_get_request(clock_dev_idx);
     service_id = clock_ops_get_service(clock_dev_idx);
 

--- a/product/juno/include/juno_alarm_idx.h
+++ b/product/juno/include/juno_alarm_idx.h
@@ -1,0 +1,23 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     Timer sub-element (alarm) indices.
+ */
+
+#ifndef JUNO_ALARM_IDX_H
+#define JUNO_ALARM_IDX_H
+
+/* Alarm indices for XRP7724 */
+enum juno_xrp7724_alarm_idx {
+    JUNO_XRP7724_ALARM_IDX,
+    JUNO_XRP7724_ALARM_IDX_COUNT,
+};
+
+/* Total count of alarms */
+#define JUNO_ALARM_IDX_COUNT    JUNO_XRP7724_ALARM_IDX_COUNT
+
+#endif /* JUNO_ALARM_IDX_H */

--- a/product/juno/module/juno_xrp7724/src/mod_juno_xrp7724.c
+++ b/product/juno/module/juno_xrp7724/src/mod_juno_xrp7724.c
@@ -100,10 +100,12 @@ static int set_gpio(fwk_id_t id, struct juno_xrp7724_dev_ctx *ctx)
     status = module_ctx.i2c_api->transmit_as_master(
         module_ctx.config->i2c_hal_id, module_ctx.config->slave_address,
         ctx->transmit_data, GPIO_WRITE_TRANSMIT_LENGTH);
-    if (status != FWK_SUCCESS)
-        return FWK_E_DEVICE;
+    if (status == FWK_PENDING)
+        status = FWK_SUCCESS;
+    else
+        status = FWK_E_DEVICE;
 
-    return FWK_SUCCESS;
+    return status;
 }
 
 /* Helper function for the sensor API */
@@ -456,8 +458,8 @@ static int juno_xrp7724_sensor_process_request(fwk_id_t id, int status)
                 module_config->i2c_hal_id, module_config->slave_address,
                 ctx->transmit_data, ctx->receive_data, SENSOR_WRITE_LENGTH,
                 SENSOR_READ_LENGTH);
-        if (request_status == FWK_SUCCESS)
-            return FWK_SUCCESS;
+            if (request_status == FWK_PENDING)
+                return FWK_SUCCESS;
 
         break;
 

--- a/product/juno/scp_ramfw/config_timer.c
+++ b/product/juno/scp_ramfw/config_timer.c
@@ -12,6 +12,7 @@
 #include <mod_clock.h>
 #include <mod_gtimer.h>
 #include <mod_timer.h>
+#include <juno_alarm_idx.h>
 #include <juno_irq.h>
 #include <system_clock.h>
 #include <system_mmap.h>
@@ -42,6 +43,7 @@ struct fwk_module_config config_gtimer = {
 static const struct fwk_element timer_element_table[] = {
     [0] = {
         .name = "REFCLK",
+        .sub_element_count = JUNO_ALARM_IDX_COUNT,
         .data = &(struct mod_timer_dev_config) {
             .id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_GTIMER, 0),
             .timer_irq = TIMREFCLK_IRQ,


### PR DESCRIPTION
This PR aims to:
- clean-up & update the i2c module to support sync/async drivers
- fix mistakes for scmi_clock module
- add alarms count for the juno board in preparation for future support