### PR TITLE
mock_sensor: Add module

### DIFF
--- a/module/mock_sensor/include/mod_mock_sensor.h
+++ b/module/mock_sensor/include/mod_mock_sensor.h
@@ -1,0 +1,45 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOD_MOCK_SENSOR_H
+#define MOD_MOCK_SENSOR_H
+
+#include <stdint.h>
+#include <mod_sensor.h>
+
+/*!
+ * \ingroup GroupModules
+ * \defgroup GroupMockSensor Mock Sensor Driver
+ *
+ * \details The `mock_sensor` module provides a simulated asynchronous driver
+ *      for use alongside the `sensor` HAL interface on systems that do not
+ *      provide a real asynchronous sensor.
+ *
+ *      This mock driver implements the Sensor HAL driver API and always defers
+ *      the 'get_value' request. An example of the execution flow is shown in
+ *      `Deferred Response Architecture`.
+ *
+ * \{
+ */
+
+/*! \brief Element configuration */
+struct mod_mock_sensor_dev_config {
+    /*! Pointer to sensor information */
+    struct mod_sensor_info *info;
+
+    /*! Sensor HAL identifier */
+    fwk_id_t sensor_hal_id;
+
+    /*! Identifier of the alarm assigned to this element */
+    fwk_id_t alarm_id;
+};
+
+/*!
+ * \}
+ */
+
+#endif /* MOD_MOCK_SENSOR_H */

--- a/module/mock_sensor/src/Makefile
+++ b/module/mock_sensor/src/Makefile
@@ -1,0 +1,11 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BS_LIB_NAME := mock_sensor
+BS_LIB_SOURCES := mod_mock_sensor.c
+
+include $(BS_DIR)/lib.mk

--- a/module/mock_sensor/src/mod_mock_sensor.c
+++ b/module/mock_sensor/src/mod_mock_sensor.c
@@ -1,0 +1,148 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdint.h>
+#include <fwk_assert.h>
+#include <fwk_id.h>
+#include <fwk_module.h>
+#include <fwk_status.h>
+#include <mod_mock_sensor.h>
+#include <mod_sensor.h>
+#include <mod_timer.h>
+
+#define MOCK_SENSOR_ALARM_DELAY_MS  10
+
+static struct mod_timer_alarm_api *alarm_api;
+static struct mod_sensor_driver_response_api *driver_response_api;
+
+static void mock_sensor_callback(uintptr_t param)
+{
+    struct mod_sensor_driver_resp_params response;
+
+    response.status = FWK_SUCCESS;
+    response.value = (273 + 25); /* Mimic a comfortable temperature in 'K */
+
+    fwk_id_t sensor_id = fwk_id_build_element_id(fwk_module_id_sensor,
+                                                 (unsigned int)param);
+    driver_response_api->reading_complete(sensor_id, &response);
+
+    return;
+}
+
+/*
+ * Module API
+ */
+
+static int get_value(fwk_id_t id, uint64_t *value)
+{
+    int status;
+    unsigned int sensor_hal_idx;
+    const struct mod_mock_sensor_dev_config *config;
+
+    status = fwk_module_check_call(id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    config = fwk_module_get_data(id);
+
+    sensor_hal_idx = fwk_id_get_element_idx(config->sensor_hal_id);
+    status = alarm_api->start(config->alarm_id,
+                              MOCK_SENSOR_ALARM_DELAY_MS,
+                              MOD_TIMER_ALARM_TYPE_ONCE,
+                              mock_sensor_callback,
+                              (uintptr_t)sensor_hal_idx);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    /* Mock sensor always defers this request */
+    return FWK_PENDING;
+}
+
+static int get_info(fwk_id_t id, struct mod_sensor_info *info)
+{
+    int status;
+    const struct mod_mock_sensor_dev_config *config;
+
+    status = fwk_module_check_call(id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    config = fwk_module_get_data(id);
+
+    if ((info == NULL) || (config == NULL))
+        return FWK_E_PARAM;
+
+    *info = *config->info;
+    return FWK_SUCCESS;
+}
+
+static const struct mod_sensor_driver_api mock_sensor_api = {
+    .get_value = get_value,
+    .get_info = get_info,
+};
+
+/*
+ * Framework handlers
+ */
+static int mock_sensor_init(fwk_id_t module_id,
+                            unsigned int element_count,
+                            const void *data)
+{
+    return FWK_SUCCESS;
+}
+
+static int mock_sensor_element_init(fwk_id_t element_id,
+                                    unsigned int unused,
+                                    const void *data)
+{
+    return FWK_SUCCESS;
+}
+
+static int mock_sensor_bind(fwk_id_t id, unsigned int round)
+{
+    int status;
+    const struct mod_mock_sensor_dev_config *config;
+
+    if ((round > 0) || fwk_id_is_type(id, FWK_ID_TYPE_MODULE)) {
+        /*
+         * Only bind in first round of calls
+         * Nothing to do for module
+         */
+        return FWK_SUCCESS;
+    }
+
+    config = fwk_module_get_data(id);
+
+    status = fwk_module_bind(config->alarm_id,
+                             FWK_ID_API(FWK_MODULE_IDX_TIMER, 1),
+                             &alarm_api);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    return fwk_module_bind(config->sensor_hal_id,
+                           mod_sensor_api_id_driver_response,
+                           &driver_response_api);
+}
+
+static int mock_sensor_process_bind_request(fwk_id_t source_id,
+                                            fwk_id_t target_id,
+                                            fwk_id_t api_type,
+                                            const void **api)
+{
+    *api = &mock_sensor_api;
+    return FWK_SUCCESS;
+}
+
+const struct fwk_module module_mock_sensor = {
+    .name = "Mock Sensor",
+    .api_count = 1,
+    .type = FWK_MODULE_TYPE_DRIVER,
+    .init = mock_sensor_init,
+    .element_init = mock_sensor_element_init,
+    .bind = mock_sensor_bind,
+    .process_bind_request = mock_sensor_process_bind_request,
+};


### PR DESCRIPTION
This patch adds a mocker for sensors.
This module implements the sensor driver API and
defers the get_value requests. This module requires
the timer facilities in order to setup an alarm.
This would emulate a sensor that provides a value
through an ISR and a call to the driver_response API
of the sensor module.

This module can be used to test sensor call flow
in platforms that do not provide asynchronous sensor
drivers.

Change-Id: I37baa428c12d6aa1c3de2f6f534ab5ac158f2352
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>