### PR TITLE
n1sdp: fix host_ra_count which gets passed to End Point

### DIFF
--- a/module/cmn600/src/mod_cmn600.c
+++ b/module/cmn600/src/mod_cmn600.c
@@ -538,10 +538,11 @@ static int cmn600_ccix_config_get(
     if (status != FWK_SUCCESS)
         return status;
 
-    if (ctx->external_rnsam_count == 0)
+    if (ctx->internal_rnsam_count == 0)
         return FWK_E_DATA;
 
-    ctx->ccix_host_info.host_ra_count = ctx->external_rnsam_count - 1;
+    ctx->ccix_host_info.host_ra_count =
+        ctx->internal_rnsam_count + ctx->external_rnsam_count - 1;
     ctx->ccix_host_info.host_sa_count = ctx->config->sa_count;
 
     memcpy((void *)config, (void *)&ctx->ccix_host_info,


### PR DESCRIPTION
Number of Host RA has been modified to include RN-D's as also
Requesting Agents. Modify the host_ra_count to pass the correct
information for Endpoint programming.
Also, there can be topologies where external RNSAM count is 0.
So remove the check for external_rnsam_count.
