### PR TITLE
juno_ppu: Don't trap when attempt to turn off DBGSYS

### DIFF
--- a/product/juno/module/juno_ppu/src/mod_juno_ppu.c
+++ b/product/juno/module/juno_ppu/src/mod_juno_ppu.c
@@ -331,7 +331,7 @@ static int dbgsys_set_state(fwk_id_t ppu_id, unsigned int state)
     if (status != FWK_SUCCESS)
         return status;
 
-    if (!fwk_expect(state == MOD_PD_STATE_ON))
+    if (state != MOD_PD_STATE_ON)
         return FWK_E_PWRSTATE;
 
     status = ppu_set_state_and_wait(ppu_ctx, PPU_MODE_ON);


### PR DESCRIPTION
This patch removes the trap when attempting to set
the PPU for the DBGSYS to OFF. This allows debugging
SCP to continue.

Change-Id: I3abb69319605cc2fe5766e339e386e01d2207e16
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>