### PR TITLE
build: Disable LTO for Juno ROM

### DIFF
--- a/tools/build_system/rules.mk
+++ b/tools/build_system/rules.mk
@@ -40,7 +40,7 @@ endif
 # GCC-specific optimization levels for debug and release modes
 #
 
-ifeq ($(PRODUCT),juno)
+ifeq ($(PRODUCT)-$(FIRMWARE),juno-scp_ramfw)
     # Enable link-time optimization
     CFLAGS_GCC += -flto
     LDFLAGS_GCC += -Wl,-flto


### PR DESCRIPTION
The Juno ROM is not pressured for size, and a bug in binutils currently
prevents LD from wrapping functions when LTO is enabled.

Change-Id: If0a0f22e22bb96a5a6d07f0fbd3b0ef980c6ea39
Signed-off-by: Chris Kay <chris.kay@arm.com>