### PR TITLE
Fix CDCEL Driver

### DIFF
--- a/product/juno/module/juno_cdcel937/src/mod_juno_cdcel937.c
+++ b/product/juno/module/juno_cdcel937/src/mod_juno_cdcel937.c
@@ -417,6 +417,9 @@ static int set_rate_write_pll_config(struct juno_cdcel937_dev_ctx *ctx)
     if (status != FWK_SUCCESS)
         return FWK_E_PARAM;
 
+    /* The first 4 bytes of the PLL config register are not needed */
+    base_address += 0x4;
+
     /* Write back the modified structure */
     status = write_configuration(ctx, base_address, &pll_config);
     if ((status != FWK_PENDING) && (status != FWK_SUCCESS))


### PR DESCRIPTION
The first four bytes of the PLL Config register are not used by Juno, so
we always skip them when reading/writing the PLL configuration. The
address was not incremented for the write after a read when setting the
PLL data in set_rate_from_index() call.

Change-Id: I094d3648168a1142cba4ee90e51aa31b3b93de88
Signed-off-by: Jim Quigley <jim.quigley@arm.com>