### PR TITLE
n1sdp: enable non-secure coresight debug access

### DIFF
--- a/product/n1sdp/module/n1sdp_system/include/mod_n1sdp_system.h
+++ b/product/n1sdp/module/n1sdp_system/include/mod_n1sdp_system.h
@@ -54,6 +54,12 @@
 #define BL33_SIZE                     UINT32_C(0x00200000)
 
 /*!
+ * Offset of NIC-400 security 0 register for
+ * non-secure CoreSight debug access
+ */
+#define NIC_400_SEC_0_CSAPBM_OFFSET   UINT32_C(0x2A10001C)
+
+/*!
  * \brief API indices.
  */
 enum mod_n1sdp_system_api_idx {

--- a/product/n1sdp/module/n1sdp_system/src/mod_n1sdp_system.c
+++ b/product/n1sdp/module/n1sdp_system/src/mod_n1sdp_system.c
@@ -476,6 +476,12 @@ static int n1sdp_system_init_primary_core(void)
         if (status != FWK_SUCCESS)
             return status;
 
+        /* Enable non-secure CoreSight debug access */
+        n1sdp_system_ctx.log_api->log(MOD_LOG_GROUP_INFO,
+            "[N1SDP SYSTEM] Enabling CoreSight debug non-secure access\n");
+        *(volatile uint32_t *)(AP_SCP_SRAM_OFFSET +
+                               NIC_400_SEC_0_CSAPBM_OFFSET) = 0xFFFFFFFF;
+
         mod_pd_restricted_api = n1sdp_system_ctx.mod_pd_restricted_api;
 
         n1sdp_system_ctx.log_api->log(MOD_LOG_GROUP_DEBUG,


### PR DESCRIPTION
This patch enables non-secure world to access CoreSight debug
address space by configuring the NIC-400 registers.

Change-Id: Ib15868a91c80da54f655aa3f23c35695c9362419
Signed-off-by: Manoj Kumar <manoj.kumar3@arm.com>