### PR TITLE
misc: Restore copyright start date

### DIFF
--- a/arch/src/armv7-m/exceptions.h
+++ b/arch/src/armv7-m/exceptions.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/change_log.md
+++ b/change_log.md
@@ -1,7 +1,7 @@
 SCP-firmware Change Log
 =======================
 
-Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 
 SCP-firmware - version 2.5.0
 ============================

--- a/framework/include/internal/fwk_thread_delayed_resp.h
+++ b/framework/include/internal/fwk_thread_delayed_resp.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/framework/src/fwk_status.c
+++ b/framework/src/fwk_status.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/framework/src/fwk_thread_delayed_resp.c
+++ b/framework/src/fwk_thread_delayed_resp.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/module/clock/src/clock.h
+++ b/module/clock/src/clock.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/module/cmn600/include/internal/cmn600_ccix.h
+++ b/module/cmn600/include/internal/cmn600_ccix.h
@@ -1,7 +1,7 @@
 
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/module/cmn600/include/internal/cmn600_ctx.h
+++ b/module/cmn600/include/internal/cmn600_ctx.h
@@ -1,7 +1,7 @@
 
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/module/dw_apb_i2c/src/mod_dw_apb_i2c.c
+++ b/module/dw_apb_i2c/src/mod_dw_apb_i2c.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/module/mock_sensor/include/mod_mock_sensor.h
+++ b/module/mock_sensor/include/mod_mock_sensor.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/module/mock_sensor/src/Makefile
+++ b/module/mock_sensor/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/module/mock_sensor/src/mod_mock_sensor.c
+++ b/module/mock_sensor/src/mod_mock_sensor.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/module/sensor/src/sensor.h
+++ b/module/sensor/src/sensor.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/include/coresight_soc400.h
+++ b/product/juno/include/coresight_soc400.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_alarm_idx.h
+++ b/product/juno/include/juno_alarm_idx.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_clock.h
+++ b/product/juno/include/juno_clock.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/include/juno_id.h
+++ b/product/juno/include/juno_id.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/include/juno_irq.h
+++ b/product/juno/include/juno_irq.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_mhu.h
+++ b/product/juno/include/juno_mhu.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_mmap.h
+++ b/product/juno/include/juno_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_nic400.h
+++ b/product/juno/include/juno_nic400.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_pcie.h
+++ b/product/juno/include/juno_pcie.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_power_domain.h
+++ b/product/juno/include/juno_power_domain.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_ppu_idx.h
+++ b/product/juno/include/juno_ppu_idx.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_scc.h
+++ b/product/juno/include/juno_scc.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_scmi.h
+++ b/product/juno/include/juno_scmi.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_sds.h
+++ b/product/juno/include/juno_sds.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_ssc.h
+++ b/product/juno/include/juno_ssc.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/juno_utils.h
+++ b/product/juno/include/juno_utils.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/include/juno_wdog.h
+++ b/product/juno/include/juno_wdog.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/nic400_gpv.h
+++ b/product/juno/include/nic400_gpv.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/pl35x.h
+++ b/product/juno/include/pl35x.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/scp_config.h
+++ b/product/juno/include/scp_config.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/scp_mmap.h
+++ b/product/juno/include/scp_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/include/software_mmap.h
+++ b/product/juno/include/software_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/system_clock.h
+++ b/product/juno/include/system_clock.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/system_mmap.h
+++ b/product/juno/include/system_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/v2m_sys_regs.h
+++ b/product/juno/include/v2m_sys_regs.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/include/xpressrich3.h
+++ b/product/juno/include/xpressrich3.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/module/juno_adc/include/mod_juno_adc.h
+++ b/product/juno/module/juno_adc/include/mod_juno_adc.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/module/juno_adc/src/Makefile
+++ b/product/juno/module/juno_adc/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/module/juno_adc/src/juno_adc.h
+++ b/product/juno/module/juno_adc/src/juno_adc.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_adc/src/mod_juno_adc.c
+++ b/product/juno/module/juno_adc/src/mod_juno_adc.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/module/juno_cdcel937/include/mod_juno_cdcel937.h
+++ b/product/juno/module/juno_cdcel937/include/mod_juno_cdcel937.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_cdcel937/src/Makefile
+++ b/product/juno/module/juno_cdcel937/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/module/juno_cdcel937/src/juno_cdcel937.h
+++ b/product/juno/module/juno_cdcel937/src/juno_cdcel937.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_cdcel937/src/mod_juno_cdcel937.c
+++ b/product/juno/module/juno_cdcel937/src/mod_juno_cdcel937.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_ddr_phy400/include/mod_juno_ddr_phy400.h
+++ b/product/juno/module/juno_ddr_phy400/include/mod_juno_ddr_phy400.h
@@ -1,6 +1,6 @@
  /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/module/juno_ddr_phy400/src/Makefile
+++ b/product/juno/module/juno_ddr_phy400/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/module/juno_ddr_phy400/src/mod_juno_ddr_phy400.c
+++ b/product/juno/module/juno_ddr_phy400/src/mod_juno_ddr_phy400.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/module/juno_dmc400/include/mod_juno_dmc400.h
+++ b/product/juno/module/juno_dmc400/include/mod_juno_dmc400.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/module/juno_dmc400/src/Makefile
+++ b/product/juno/module/juno_dmc400/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/module/juno_dmc400/src/juno_dmc400.h
+++ b/product/juno/module/juno_dmc400/src/juno_dmc400.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_dmc400/src/mod_juno_dmc400.c
+++ b/product/juno/module/juno_dmc400/src/mod_juno_dmc400.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/module/juno_hdlcd/include/mod_juno_hdlcd.h
+++ b/product/juno/module/juno_hdlcd/include/mod_juno_hdlcd.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_hdlcd/src/Makefile
+++ b/product/juno/module/juno_hdlcd/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/module/juno_hdlcd/src/mod_juno_hdlcd.c
+++ b/product/juno/module/juno_hdlcd/src/mod_juno_hdlcd.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_ppu/include/mod_juno_ppu.h
+++ b/product/juno/module/juno_ppu/include/mod_juno_ppu.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_ppu/src/Makefile
+++ b/product/juno/module/juno_ppu/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/module/juno_ppu/src/juno_ppu.h
+++ b/product/juno/module/juno_ppu/src/juno_ppu.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_ppu/src/mod_juno_ppu.c
+++ b/product/juno/module/juno_ppu/src/mod_juno_ppu.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_ram/include/juno_wdog_ram.h
+++ b/product/juno/module/juno_ram/include/juno_wdog_ram.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_ram/include/mod_juno_ram.h
+++ b/product/juno/module/juno_ram/include/mod_juno_ram.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_ram/src/Makefile
+++ b/product/juno/module/juno_ram/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/module/juno_ram/src/juno_wdog_ram.c
+++ b/product/juno/module/juno_ram/src/juno_wdog_ram.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_ram/src/mod_juno_ram.c
+++ b/product/juno/module/juno_ram/src/mod_juno_ram.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_rom/include/juno_debug_rom.h
+++ b/product/juno/module/juno_rom/include/juno_debug_rom.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_rom/include/juno_wdog_rom.h
+++ b/product/juno/module/juno_rom/include/juno_wdog_rom.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_rom/include/mod_juno_rom.h
+++ b/product/juno/module/juno_rom/include/mod_juno_rom.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_rom/src/Makefile
+++ b/product/juno/module/juno_rom/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/module/juno_rom/src/juno_debug_rom.c
+++ b/product/juno/module/juno_rom/src/juno_debug_rom.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_rom/src/juno_wdog_rom.c
+++ b/product/juno/module/juno_rom/src/juno_wdog_rom.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_rom/src/mod_juno_rom.c
+++ b/product/juno/module/juno_rom/src/mod_juno_rom.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_soc_clock/include/mod_juno_soc_clock.h
+++ b/product/juno/module/juno_soc_clock/include/mod_juno_soc_clock.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/module/juno_soc_clock/src/Makefile
+++ b/product/juno/module/juno_soc_clock/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/module/juno_soc_clock/src/mod_juno_soc_clock.c
+++ b/product/juno/module/juno_soc_clock/src/mod_juno_soc_clock.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/module/juno_soc_clock_ram/include/mod_juno_soc_clock_ram.h
+++ b/product/juno/module/juno_soc_clock_ram/include/mod_juno_soc_clock_ram.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_soc_clock_ram/src/Makefile
+++ b/product/juno/module/juno_soc_clock_ram/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/module/juno_soc_clock_ram/src/juno_soc_clock_ram_pll.c
+++ b/product/juno/module/juno_soc_clock_ram/src/juno_soc_clock_ram_pll.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/module/juno_soc_clock_ram/src/juno_soc_clock_ram_pll.h
+++ b/product/juno/module/juno_soc_clock_ram/src/juno_soc_clock_ram_pll.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_soc_clock_ram/src/mod_juno_soc_clock_ram.c
+++ b/product/juno/module/juno_soc_clock_ram/src/mod_juno_soc_clock_ram.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_system/include/mod_juno_system.h
+++ b/product/juno/module/juno_system/include/mod_juno_system.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/module/juno_system/src/Makefile
+++ b/product/juno/module/juno_system/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/module/juno_system/src/mod_juno_system.c
+++ b/product/juno/module/juno_system/src/mod_juno_system.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/product.mk
+++ b/product/juno/product.mk
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/scp_ramfw/config_clock.c
+++ b/product/juno/scp_ramfw/config_clock.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_i2c.c
+++ b/product/juno/scp_ramfw/config_i2c.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_juno_adc.c
+++ b/product/juno/scp_ramfw/config_juno_adc.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_juno_cdcel937.c
+++ b/product/juno/scp_ramfw/config_juno_cdcel937.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_juno_ddr_phy400.c
+++ b/product/juno/scp_ramfw/config_juno_ddr_phy400.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_juno_dmc400.c
+++ b/product/juno/scp_ramfw/config_juno_dmc400.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_juno_hdlcd.c
+++ b/product/juno/scp_ramfw/config_juno_hdlcd.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_juno_ppu.c
+++ b/product/juno/scp_ramfw/config_juno_ppu.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_juno_ram.c
+++ b/product/juno/scp_ramfw/config_juno_ram.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_juno_soc_clock_ram.c
+++ b/product/juno/scp_ramfw/config_juno_soc_clock_ram.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_juno_xrp7724.c
+++ b/product/juno/scp_ramfw/config_juno_xrp7724.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_juno_xrp7724.h
+++ b/product/juno/scp_ramfw/config_juno_xrp7724.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_log.c
+++ b/product/juno/scp_ramfw/config_log.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_mhu.c
+++ b/product/juno/scp_ramfw/config_mhu.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_mock_psu.c
+++ b/product/juno/scp_ramfw/config_mock_psu.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_power_domain.c
+++ b/product/juno/scp_ramfw/config_power_domain.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_power_domain.h
+++ b/product/juno/scp_ramfw/config_power_domain.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_psu.c
+++ b/product/juno/scp_ramfw/config_psu.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_psu.h
+++ b/product/juno/scp_ramfw/config_psu.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_reg_sensor.c
+++ b/product/juno/scp_ramfw/config_reg_sensor.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_scmi.c
+++ b/product/juno/scp_ramfw/config_scmi.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_scmi_system_power.c
+++ b/product/juno/scp_ramfw/config_scmi_system_power.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_sds.c
+++ b/product/juno/scp_ramfw/config_sds.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_sensor.c
+++ b/product/juno/scp_ramfw/config_sensor.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_sensor.h
+++ b/product/juno/scp_ramfw/config_sensor.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_smt.c
+++ b/product/juno/scp_ramfw/config_smt.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/config_timer.c
+++ b/product/juno/scp_ramfw/config_timer.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_ramfw/firmware.mk
+++ b/product/juno/scp_ramfw/firmware.mk
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/scp_ramfw/fmw_memory.ld.S
+++ b/product/juno/scp_ramfw/fmw_memory.ld.S
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw/config_bootloader.c
+++ b/product/juno/scp_romfw/config_bootloader.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw/config_clock.c
+++ b/product/juno/scp_romfw/config_clock.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw/config_juno_ppu.c
+++ b/product/juno/scp_romfw/config_juno_ppu.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw/config_juno_rom.c
+++ b/product/juno/scp_romfw/config_juno_rom.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw/config_juno_soc_clock.c
+++ b/product/juno/scp_romfw/config_juno_soc_clock.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/scp_romfw/config_log.c
+++ b/product/juno/scp_romfw/config_log.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw/config_sds.c
+++ b/product/juno/scp_romfw/config_sds.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw/config_timer.c
+++ b/product/juno/scp_romfw/config_timer.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw/firmware.mk
+++ b/product/juno/scp_romfw/firmware.mk
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/scp_romfw/fmw_memory.ld.S
+++ b/product/juno/scp_romfw/fmw_memory.ld.S
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw_bypass/config_bootloader.c
+++ b/product/juno/scp_romfw_bypass/config_bootloader.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw_bypass/config_clock.c
+++ b/product/juno/scp_romfw_bypass/config_clock.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw_bypass/config_juno_ppu.c
+++ b/product/juno/scp_romfw_bypass/config_juno_ppu.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw_bypass/config_juno_rom.c
+++ b/product/juno/scp_romfw_bypass/config_juno_rom.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw_bypass/config_juno_soc_clock.c
+++ b/product/juno/scp_romfw_bypass/config_juno_soc_clock.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/scp_romfw_bypass/config_log.c
+++ b/product/juno/scp_romfw_bypass/config_log.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw_bypass/config_sds.c
+++ b/product/juno/scp_romfw_bypass/config_sds.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw_bypass/config_timer.c
+++ b/product/juno/scp_romfw_bypass/config_timer.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw_bypass/firmware.mk
+++ b/product/juno/scp_romfw_bypass/firmware.mk
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/juno/scp_romfw_bypass/fmw_memory.ld.S
+++ b/product/juno/scp_romfw_bypass/fmw_memory.ld.S
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/scp_romfw_bypass/juno_pll_workaround.c
+++ b/product/juno/scp_romfw_bypass/juno_pll_workaround.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/juno/src/juno_id.c
+++ b/product/juno/src/juno_id.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/juno/src/juno_utils.c
+++ b/product/juno/src/juno_utils.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_c2c/include/mod_n1sdp_c2c_i2c.h
+++ b/product/n1sdp/module/n1sdp_c2c/include/mod_n1sdp_c2c_i2c.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_c2c/src/Makefile
+++ b/product/n1sdp/module/n1sdp_c2c/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/n1sdp/module/n1sdp_c2c/src/mod_n1sdp_c2c_i2c.c
+++ b/product/n1sdp/module/n1sdp_c2c/src/mod_n1sdp_c2c_i2c.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_ddr_phy/include/internal/n1sdp_ddr_phy.h
+++ b/product/n1sdp/module/n1sdp_ddr_phy/include/internal/n1sdp_ddr_phy.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_ddr_phy/include/mod_n1sdp_ddr_phy.h
+++ b/product/n1sdp/module/n1sdp_ddr_phy/include/mod_n1sdp_ddr_phy.h
@@ -1,6 +1,6 @@
  /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_ddr_phy/src/Makefile
+++ b/product/n1sdp/module/n1sdp_ddr_phy/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/n1sdp/module/n1sdp_ddr_phy/src/ddr_phy_values_1200.c
+++ b/product/n1sdp/module/n1sdp_ddr_phy/src/ddr_phy_values_1200.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_ddr_phy/src/ddr_phy_values_1333.c
+++ b/product/n1sdp/module/n1sdp_ddr_phy/src/ddr_phy_values_1333.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_ddr_phy/src/ddr_phy_values_800.c
+++ b/product/n1sdp/module/n1sdp_ddr_phy/src/ddr_phy_values_800.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_ddr_phy/src/mod_n1sdp_ddr_phy.c
+++ b/product/n1sdp/module/n1sdp_ddr_phy/src/mod_n1sdp_ddr_phy.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_ddr_phy/src/n1sdp_ddr_phy_values.h
+++ b/product/n1sdp/module/n1sdp_ddr_phy/src/n1sdp_ddr_phy_values.h
@@ -1,6 +1,6 @@
  /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_dmc620/include/mod_n1sdp_dmc620.h
+++ b/product/n1sdp/module/n1sdp_dmc620/include/mod_n1sdp_dmc620.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_dmc620/src/Makefile
+++ b/product/n1sdp/module/n1sdp_dmc620/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c
+++ b/product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_i2c/include/internal/n1sdp_i2c.h
+++ b/product/n1sdp/module/n1sdp_i2c/include/internal/n1sdp_i2c.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_i2c/include/mod_n1sdp_i2c.h
+++ b/product/n1sdp/module/n1sdp_i2c/include/mod_n1sdp_i2c.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_i2c/src/Makefile
+++ b/product/n1sdp/module/n1sdp_i2c/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/n1sdp/module/n1sdp_i2c/src/mod_n1sdp_i2c.c
+++ b/product/n1sdp/module/n1sdp_i2c/src/mod_n1sdp_i2c.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_remote_pd/include/mod_n1sdp_remote_pd.h
+++ b/product/n1sdp/module/n1sdp_remote_pd/include/mod_n1sdp_remote_pd.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_remote_pd/src/Makefile
+++ b/product/n1sdp/module/n1sdp_remote_pd/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/n1sdp/module/n1sdp_remote_pd/src/mod_n1sdp_remote_pd.c
+++ b/product/n1sdp/module/n1sdp_remote_pd/src/mod_n1sdp_remote_pd.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_scp2pcc/include/internal/n1sdp_scp2pcc.h
+++ b/product/n1sdp/module/n1sdp_scp2pcc/include/internal/n1sdp_scp2pcc.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_scp2pcc/include/mod_n1sdp_scp2pcc.h
+++ b/product/n1sdp/module/n1sdp_scp2pcc/include/mod_n1sdp_scp2pcc.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_scp2pcc/src/Makefile
+++ b/product/n1sdp/module/n1sdp_scp2pcc/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/n1sdp/module/n1sdp_scp2pcc/src/mod_n1sdp_scp2pcc.c
+++ b/product/n1sdp/module/n1sdp_scp2pcc/src/mod_n1sdp_scp2pcc.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_sensor/include/mod_n1sdp_sensor.h
+++ b/product/n1sdp/module/n1sdp_sensor/include/mod_n1sdp_sensor.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/n1sdp/module/n1sdp_timer_sync/include/internal/timer_sync.h
+++ b/product/n1sdp/module/n1sdp_timer_sync/include/internal/timer_sync.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/n1sdp/module/n1sdp_timer_sync/include/mod_n1sdp_timer_sync.h
+++ b/product/n1sdp/module/n1sdp_timer_sync/include/mod_n1sdp_timer_sync.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/n1sdp_timer_sync/src/Makefile
+++ b/product/n1sdp/module/n1sdp_timer_sync/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/n1sdp/module/n1sdp_timer_sync/src/mod_n1sdp_timer_sync.c
+++ b/product/n1sdp/module/n1sdp_timer_sync/src/mod_n1sdp_timer_sync.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/scmi_ccix_config/include/internal/mod_scmi_ccix_config.h
+++ b/product/n1sdp/module/scmi_ccix_config/include/internal/mod_scmi_ccix_config.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/module/scmi_ccix_config/src/Makefile
+++ b/product/n1sdp/module/scmi_ccix_config/src/Makefile
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #

--- a/product/n1sdp/module/scmi_ccix_config/src/mod_scmi_ccix_config.c
+++ b/product/n1sdp/module/scmi_ccix_config/src/mod_scmi_ccix_config.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *

--- a/product/n1sdp/scp_ramfw/config_n1sdp_c2c_i2c.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_c2c_i2c.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/n1sdp/scp_ramfw/config_n1sdp_ddr_phy.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_ddr_phy.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/n1sdp/scp_ramfw/config_n1sdp_dmc620.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_dmc620.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/n1sdp/scp_ramfw/config_n1sdp_i2c.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_i2c.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/n1sdp/scp_ramfw/config_n1sdp_remote_pd.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_remote_pd.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/n1sdp/scp_ramfw/config_n1sdp_scp2pcc.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_scp2pcc.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/n1sdp/scp_ramfw/config_n1sdp_timer_sync.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_timer_sync.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/n1sdp/scp_ramfw/config_sensor.c
+++ b/product/n1sdp/scp_ramfw/config_sensor.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/sgm775/scp_ramfw/config_mock_psu.h
+++ b/product/sgm775/scp_ramfw/config_mock_psu.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/sgm775/scp_ramfw/config_psu.h
+++ b/product/sgm775/scp_ramfw/config_psu.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/product/sgm775/scp_ramfw/config_timer.h
+++ b/product/sgm775/scp_ramfw/config_timer.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/tools/check_api.py
+++ b/tools/check_api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #


### PR DESCRIPTION
The previous commit lost the start date of some of the copyright
headers, so this commit restores them.

Change-Id: Id3d87ddaf382d3151118a1c2ba51c56fdfdc00ea
Signed-off-by: Chris Kay <chris.kay@arm.com>