### PR TITLE
juno/reg_sensor: Change the type of the fake_register to uint64_t

### DIFF
--- a/product/juno/scp_ramfw/config_reg_sensor.c
+++ b/product/juno/scp_ramfw/config_reg_sensor.c
@@ -11,7 +11,7 @@
 #include <mod_sensor.h>
 #include <system_mmap.h>
 
-static uint32_t fake_register = 0x00001234;
+static uint64_t fake_register = UINT64_C(0x1234);
 
 /*
  * Register Sensor driver config


### PR DESCRIPTION
The value read when doing a get_value is 64-bit so we need to store a
64-bit value in the fake register.

Change-Id: I3cf451e2659436106cc93605928fde527045ac23
Signed-off-by: Raphael Gault <raphael.gault@arm.com>