### PR TITLE
juno/cdcel937: Fix output index for HDLCD0 & 1

### DIFF
--- a/product/juno/scp_ramfw/config_juno_cdcel937.c
+++ b/product/juno/scp_ramfw/config_juno_cdcel937.c
@@ -113,7 +113,7 @@ static const struct fwk_element juno_cdcel937_element_table[] = {
             .max_rate = 120 * FWK_MHZ,
             .min_step = 250 * FWK_KHZ,
             .rate_type = MOD_CLOCK_RATE_TYPE_CONTINUOUS,
-            .output_id = MOD_JUNO_CDCEL937_OUTPUT_ID_Y2,
+            .output_id = MOD_JUNO_CDCEL937_OUTPUT_ID_Y6,
         }
     },
     [JUNO_CLOCK_CDCEL937_IDX_HDLCD1] = {
@@ -129,7 +129,7 @@ static const struct fwk_element juno_cdcel937_element_table[] = {
             .max_rate = 120 * FWK_MHZ,
             .min_step = 250 * FWK_KHZ,
             .rate_type = MOD_CLOCK_RATE_TYPE_CONTINUOUS,
-            .output_id = MOD_JUNO_CDCEL937_OUTPUT_ID_Y2,
+            .output_id = MOD_JUNO_CDCEL937_OUTPUT_ID_Y6,
         }
     },
     [JUNO_CLOCK_CDCEL937_IDX_COUNT] = { 0 },


### PR DESCRIPTION
This patch is to fix the output identifier for the
two HDLCD logical clocks which are set through the output
Y6 of one of the CDCEL937 drivers available on the board.

Change-Id: Idbec3725a2760eeee211c6c22248d547a73e6794
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>