### PR TITLE
doc: Fix link location for Cppcheck suppression list

### DIFF
--- a/doc/code_rules.md
+++ b/doc/code_rules.md
@@ -48,7 +48,7 @@ error output.
 
 Certain checks have been manually suppressed. Checks are generally only
 disabled if they have been triaged as false positives. The list of suppressed
-checks can be found [here](tools/cppcheck_suppress_list.txt).
+checks can be found [here](../tools/cppcheck_suppress_list.txt).
 
 C Standard Library
 ------------------


### PR DESCRIPTION
The link pointing to the Cppcheck suppression list used was broken. This
patch corrects it.

Change-Id: Ibb512df1e61f5aa76c56804e13ea368294b0b973
Signed-off-by: Raphael Gault <raphael.gault@arm.com>