### PR TITLE
juno/cdcel937: Low precision should mean low precision when calculating

### DIFF
--- a/product/juno/module/juno_cdcel937/src/mod_juno_cdcel937.c
+++ b/product/juno/module/juno_cdcel937/src/mod_juno_cdcel937.c
@@ -201,12 +201,15 @@ static int read_configuration_y1(struct juno_cdcel937_dev_ctx *ctx,
 static int get_preset_low_precision(uint64_t rate,
                                     struct juno_clock_preset *preset)
 {
-    float freq;
+    uint32_t freq;
 
     fwk_assert(preset != NULL);
 
-    freq = rate / FWK_MHZ;
-    preset->PDIV = 230 / freq;
+    freq = (uint32_t)rate / (uint32_t)FWK_MHZ;
+
+    fwk_assert(freq <= 230);
+
+    preset->PDIV = UINT32_C(230) / freq;
     preset->N = freq * preset->PDIV;
     preset->M = 24;
 


### PR DESCRIPTION
preset.

If the preset is not found in the lookup table it is calculated using
the rate in MHz. To avoid floating point arithmetic and the associated
memory cost we will simplify the (rate / MHz) calculation to be a
uint32_t operation.

This results in a memory saving of approximately 1.5kb. As we should
usually get a hit in the lookup table this is an acceptable trade-off.

Change-Id: I2e2a78f85bdb3cd9e35149a324000935d3d8ebb5
Signed-off-by: Jim Quigley <jim.quigley@arm.com>