### PR TITLE
i2c: Add support for concurrent requests

### DIFF
--- a/framework/include/fwk_thread.h
+++ b/framework/include/fwk_thread.h
@@ -72,7 +72,8 @@ int fwk_thread_put_event(struct fwk_event *event);
  *      delayed response as part of the module or element data internal to the
  *      framework. This function allows to get a copy of such delayed response
  *      event. The event is not removed from the module or element internal
- *      data.
+ *      data. If called from an interrupt handler, the function returns in
+ *      error.
  *
  * \param[in] id Identifier of the module or element that delayed the response.
  * \param[in] cookie Cookie of the event which the response has been delayed
@@ -80,7 +81,7 @@ int fwk_thread_put_event(struct fwk_event *event);
  *      the entity \p id may have delayed.
  * \param[out] event The copy of the response event.
  *
- * \retval ::FWK_SUCCESS The event was queued.
+ * \retval ::FWK_SUCCESS The event was returned.
  * \retval ::FWK_E_PARAM One or more parameters were invalid.
  * \retval ::FWK_E_ACCESS Access violation due to call from interrupt handler.
  *
@@ -89,6 +90,52 @@ int fwk_thread_put_event(struct fwk_event *event);
 int fwk_thread_get_delayed_response(fwk_id_t id, uint32_t cookie,
                                     struct fwk_event *event);
 
+/*!
+ * \brief Check if the list of delayed response events of a given module or
+ *     element is empty.
+ *
+ * \details When a module or element delays a response as part of the processing
+ *      of an event requiring a response, the framework automatically queues the
+ *      delayed response in a list that is part of the module or element data
+ *      internal to the framework. This function checks if such a list is empty
+ *      or not. If called from an interrupt handler, the function returns in
+ *      error.
+ *
+ * \param[in] id Identifier of the module or element.
+ * \param[out] is_empty \c true if the list is empty, \c false otherwise.
+ *
+ * \retval ::FWK_SUCCESS The flag was returned.
+ * \retval ::FWK_E_PARAM One or more parameters were invalid.
+ * \retval ::FWK_E_ACCESS Access violation due to call from interrupt handler.
+ *
+ * \return Status code representing the result of the operation.
+ */
+int fwk_thread_is_delayed_response_list_empty(fwk_id_t id, bool *is_empty);
+
+/*!
+ * \brief Get a copy of the first delayed response event in the list of
+ *     delayed response events of a given module or element.
+ *
+ * \details When a module or element delays a response as part of the processing
+ *      of an event requiring a response, the framework automatically queues
+ *      the delayed response in a list that is part of the module or element
+ *      data internal to the framework. This function allows a copy of the first
+ *      event of such a list to be retrieved. The event is not removed from the
+ *      module or element internal data. This function may be use to process the
+ *      delayed responses in the order they were queued. If called from an
+ *      interrupt handler, the function returns in error.
+ *
+ * \param[in] id Identifier of the module or element that delayed the response.
+ * \param[out] event The copy of the response event.
+ *
+ * \retval ::FWK_SUCCESS The event was returned.
+ * \retval ::FWK_E_STATE The list of delayed response event for \p id is empty.
+ * \retval ::FWK_E_PARAM One or more parameters were invalid.
+ * \retval ::FWK_E_ACCESS Access violation due to call from interrupt handler.
+ *
+ * \return Status code representing the result of the operation.
+ */
+int fwk_thread_get_first_delayed_response(fwk_id_t id, struct fwk_event *event);
 /*!
  * @}
  */

--- a/module/i2c/doc/module_i2c_architecture.md
+++ b/module/i2c/doc/module_i2c_architecture.md
@@ -11,29 +11,35 @@ transactions.
 
 # Architecture                           {#module_i2c_architecture_architecture}
 
-The I2C module provides an interface for modules to transmit data through an I2C
-bus, to receive data from an I2C bus and to perform a transmission followed by a
-reception on the I2C bus.
+The I2C module provides an interface for modules to request transmission of data
+through an I2C bus, reception from an I2C bus and to request a transmission
+followed by a reception on an I2C bus.
 
 The I2C module defines a driver interface on which it relies to transfer/receive
 data to/from the bus.
 
 A response event notifies the caller of the transaction completion.
 
+The I2C module provides support for concurrent accesses to an I2C bus. If a
+I2C transaction is requested on an I2C bus while the bus is busy processing
+another transaction, the transaction request is queued. The queuing and
+processing of I2C transaction requests follow a FIFO logic. When a transaction
+is completed, the processing of the transaction request at the head of the
+queue, if any, is initiated.
+
 # Restriction                             {#module_i2c_architecture_restriction}
 
 The following features are unsupported. Support may be added in the future.
 
 - Acting like a slave.
-- Concurrent accesses over the bus.
 - 10-bit slave addressing.
 
 # Flow                                           {#module_i2c_architecture_flow}
 
-## Asynchronous API
-
 The following schematic describes the transaction flow for an I2C master
-asynchronous transmission. The flow for an asynchronous reception is similar.
+transmission. It is assumed that all the sequence occurs without any
+concurrent access and that the driver handles the transmission asynchonously.
+The flow for a reception is similar.
 
     Client             I2C         I2C Driver     I2C ISR (Driver)
       |                 |               |               |
@@ -84,3 +90,69 @@ In the case of *transmit_then_receive_as_master*, the I2C HAL does not send a
 event at the end of the transmission. Instead it starts the reception by calling
 *receive_as_master* driver function. The event is then sent when the reception
 has completed.
+
+# Concurrent accesses             {#module_i2c_architecture_concurrent_accesses}
+
+In case of concurrent access, transaction requests are queued using the
+framework delayed response facility. When the transaction request event is
+processed, the transaction is not initiated and its response delayed. This is
+illustrated by the following schematic:
+
+    Client             I2C
+      |                 |
+      |    transmit_    |
+     +-+   as_master    |
+     | +-------------->+-+
+     | |               | +- - +
+     | +<--------------+-+    |process_
+     +-+                |     |event E1
+      |                 |     |
+      |                +-+<- -+
+      |                | |
+      |                | | Request response delayed
+      |                | |
+      |                +-+
+      |                 |
+      |                 |
+
+    E1 : Request event
+
+When a transaction is completed on an I2C bus, the delayed response queue of
+the associated I2C module element is checked. If it is not empty, the processing
+of the request associated to the head of the queue is then initiated. This is
+illustrated in the following schematic where the pending request which is
+initiated is a reception request.
+
+    Client             I2C         I2C Driver     I2C ISR (Driver)
+                             ...
+      |                 |               |               |
+      |                 |               |  transaction +-+
+      |                 |               |  _completed  | |
+      |                +-+<-------------+--------------+ |
+      |            +- -+ |              |              | |
+      |  process_  |   +-+--------------+------------->+ |
+      |  event E1  |    |               |              | |
+      |            +- >+-+              |              +-+
+      |                | |              |               |
+      |                | |  receive_    |               |
+      |                | |  as_master   |               |
+      |                | +------------>+-+              |
+      |                | +<------------+-+              |
+     +-+<- - - - - - - + |              |               |
+     | |  process_     | |              |               |
+     | |  event R1     | |              |               |
+     +-+               +-+              |               |
+      |                 |               |               |
+                             ...
+
+    E1   : Request completed event
+    R1   : Response to the completed request
+    ---> : Function call/return
+    - -> : Asynchronous call via the event/notification interface
+
+Finally, in the case where the processing of the pending request completes
+immediately (synchronous handling by the driver) and another transaction request
+is pending, the processing of this last transaction request is not initiated
+immediately to avoid multiple transactions being processed within the same event
+processing. A reload event is then sent and the processing of the next pending
+request is initiated as part of the processing of the reload event.

--- a/module/i2c/src/mod_i2c.c
+++ b/module/i2c/src/mod_i2c.c
@@ -20,6 +20,7 @@ enum mod_i2c_dev_state {
     MOD_I2C_DEV_TX,
     MOD_I2C_DEV_RX,
     MOD_I2C_DEV_TX_RX,
+    MOD_I2C_DEV_RELOAD,
     MOD_I2C_DEV_PANIC,
 };
 
@@ -35,12 +36,17 @@ static struct mod_i2c_dev_ctx *ctx_table;
 
 enum mod_i2c_internal_event_idx {
     MOD_I2C_EVENT_IDX_REQUEST_COMPLETED = MOD_I2C_EVENT_IDX_COUNT,
+    MOD_I2C_EVENT_IDX_RELOAD,
     MOD_I2C_EVENT_IDX_TOTAL_COUNT,
 };
 
 /*! Request completed event identifier */
 static const fwk_id_t mod_i2c_event_id_request_completed = FWK_ID_EVENT_INIT(
     FWK_MODULE_IDX_I2C, MOD_I2C_EVENT_IDX_REQUEST_COMPLETED);
+
+/*! Reload event identifier */
+static const fwk_id_t mod_i2c_event_id_reload = FWK_ID_EVENT_INIT(
+    FWK_MODULE_IDX_I2C, MOD_I2C_EVENT_IDX_RELOAD);
 
 /*
  * Static helpers
@@ -57,23 +63,13 @@ static int create_i2c_request(fwk_id_t dev_id,
 {
     int status;
     struct fwk_event event;
-    struct mod_i2c_dev_ctx *ctx;
     struct mod_i2c_request *event_param =
         (struct mod_i2c_request *)event.params;
-
-    get_ctx(dev_id, &ctx);
 
     /* The slave address should be on 7 bits */
     if (!fwk_expect(request->slave_address < 0x80))
         return FWK_E_PARAM;
 
-    /* Check whether an I2C request is already on-going */
-    if (ctx->state != MOD_I2C_DEV_IDLE) {
-        return (ctx->state == MOD_I2C_DEV_PANIC) ?
-               FWK_E_PANIC : FWK_E_BUSY;
-    }
-
-    /* Create the request */
     event = (struct fwk_event) {
         .target_id = dev_id,
         .response_requested = true,
@@ -83,13 +79,10 @@ static int create_i2c_request(fwk_id_t dev_id,
 
     if ((request->transmit_byte_count > 0) &&
         (request->receive_byte_count > 0)) {
-        ctx->state = MOD_I2C_DEV_TX_RX;
         event.id = mod_i2c_event_id_request_tx_rx;
     } else if (request->transmit_byte_count > 0) {
-        ctx->state = MOD_I2C_DEV_TX;
         event.id = mod_i2c_event_id_request_tx;
     } else if (request->receive_byte_count > 0) {
-        ctx->state = MOD_I2C_DEV_RX;
         event.id = mod_i2c_event_id_request_rx;
     }
 
@@ -102,8 +95,6 @@ static int create_i2c_request(fwk_id_t dev_id,
          */
         return FWK_PENDING;
     }
-
-    ctx->state = MOD_I2C_DEV_IDLE;
 
     return status;
 }
@@ -295,8 +286,6 @@ static int respond_to_caller(
     struct mod_i2c_event_param *param =
         (struct mod_i2c_event_param *)resp.params;
 
-    ctx->state = MOD_I2C_DEV_IDLE;
-
     status = fwk_thread_get_delayed_response(dev_id, ctx->cookie, &resp);
     if (status != FWK_SUCCESS)
         return status;
@@ -314,30 +303,90 @@ static int process_request(struct mod_i2c_dev_ctx *ctx, fwk_id_t event_id)
 
     switch (fwk_id_get_event_idx(event_id)) {
     case MOD_I2C_EVENT_IDX_REQUEST_TRANSMIT:
+        ctx->state = MOD_I2C_DEV_TX;
         drv_status = driver_api->transmit_as_master(driver_id, &ctx->request);
         break;
 
     case MOD_I2C_EVENT_IDX_REQUEST_TRANSMIT_THEN_RECEIVE:
+        ctx->state = MOD_I2C_DEV_TX_RX;
         drv_status = driver_api->transmit_as_master(driver_id, &ctx->request);
 
         if (drv_status != FWK_SUCCESS) {
             /* The request has failed or been acknowledged */
             break;
-        } else {
-            /*
-             * The TX request has succeeded, update state and proceed to the RX
-             * request.
-             */
-            ctx->state = MOD_I2C_DEV_RX;
         }
         /* fall through */
 
     case MOD_I2C_EVENT_IDX_REQUEST_RECEIVE:
+        ctx->state = MOD_I2C_DEV_RX;
         drv_status = driver_api->receive_as_master(driver_id, &ctx->request);
         break;
     }
 
     return drv_status;
+}
+
+static int reload(fwk_id_t dev_id, struct mod_i2c_dev_ctx *ctx)
+{
+    int status;
+    bool is_empty;
+    struct fwk_event event;
+
+    status = fwk_thread_is_delayed_response_list_empty(dev_id, &is_empty);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    if (is_empty)
+        ctx->state = MOD_I2C_DEV_IDLE;
+    else {
+        ctx->state = MOD_I2C_DEV_RELOAD;
+        event = (struct fwk_event) {
+            .target_id = dev_id,
+            .id = mod_i2c_event_id_reload,
+        };
+        status = fwk_thread_put_event(&event);
+   }
+
+   return status;
+}
+
+static int process_next_request(fwk_id_t dev_id, struct mod_i2c_dev_ctx *ctx)
+{
+    int status, drv_status;
+    bool is_empty;
+    struct fwk_event delayed_response;
+    struct mod_i2c_request *request;
+    struct mod_i2c_event_param *event_param;
+
+    status = fwk_thread_is_delayed_response_list_empty(dev_id, &is_empty);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    if (is_empty) {
+        ctx->state = MOD_I2C_DEV_IDLE;
+        return FWK_SUCCESS;
+    }
+
+    status = fwk_thread_get_first_delayed_response(
+        dev_id, &delayed_response);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    request = (struct mod_i2c_request *)delayed_response.params;
+    ctx->request = *request;
+
+    drv_status = process_request(ctx, delayed_response.id);
+    if (drv_status != FWK_PENDING) {
+        event_param = (struct mod_i2c_event_param *)delayed_response.params;
+        event_param->status = drv_status;
+
+        status = fwk_thread_put_event(&delayed_response);
+        if (status == FWK_SUCCESS)
+            status = reload(dev_id, ctx);
+    } else
+        ctx->cookie = delayed_response.cookie;
+
+    return status;
 }
 
 static int mod_i2c_process_event(const struct fwk_event *event,
@@ -359,6 +408,10 @@ static int mod_i2c_process_event(const struct fwk_event *event,
         if (ctx->state == MOD_I2C_DEV_PANIC) {
             event_param = (struct mod_i2c_event_param *)resp_event->params;
             event_param->status = FWK_E_PANIC;
+
+            return FWK_SUCCESS;
+        } else if (ctx->state != MOD_I2C_DEV_IDLE) {
+            resp_event->is_delayed_response = true;
 
             return FWK_SUCCESS;
         }
@@ -389,6 +442,9 @@ static int mod_i2c_process_event(const struct fwk_event *event,
 
         if ((ctx->state == MOD_I2C_DEV_TX) || (ctx->state == MOD_I2C_DEV_RX)) {
             status = respond_to_caller(dev_id, ctx, event_param->status);
+            if (status == FWK_SUCCESS)
+                status = process_next_request(dev_id, ctx);
+
         } else if (ctx->state == MOD_I2C_DEV_TX_RX) {
             drv_status = event_param->status;
 
@@ -407,9 +463,15 @@ static int mod_i2c_process_event(const struct fwk_event *event,
             }
 
             status = respond_to_caller(dev_id, ctx, drv_status);
+            if (status == FWK_SUCCESS)
+                status = process_next_request(dev_id, ctx);
         } else
             status = FWK_E_STATE;
 
+        break;
+
+    case MOD_I2C_EVENT_IDX_RELOAD:
+        status = process_next_request(dev_id, ctx);
         break;
 
     default:

--- a/module/i2c/src/mod_i2c.c
+++ b/module/i2c/src/mod_i2c.c
@@ -282,12 +282,12 @@ static int mod_i2c_process_bind_request(fwk_id_t source_id,
     return FWK_SUCCESS;
 }
 
-static int process_request(int status,
+static int process_request(int drv_status,
                            struct mod_i2c_dev_ctx *ctx,
                            const struct fwk_event *event,
                            struct fwk_event *resp_event)
 {
-    if (status == FWK_PENDING) {
+    if (drv_status == FWK_PENDING) {
         /* The request has not completed, respond later */
         ctx->cookie = event->cookie;
         resp_event->is_delayed_response = true;
@@ -298,13 +298,13 @@ static int process_request(int status,
         struct mod_i2c_event_param *resp_param =
             (struct mod_i2c_event_param *)resp_event->params;
 
-        if (status != FWK_SUCCESS)
-            status = FWK_E_DEVICE;
+        if (drv_status != FWK_SUCCESS)
+            drv_status = FWK_E_DEVICE;
 
-        resp_param->status = status;
+        resp_param->status = drv_status;
         ctx->state = MOD_I2C_DEV_IDLE;
 
-        return status;
+        return drv_status;
     }
 }
 
@@ -324,7 +324,7 @@ static int respond_to_caller(
     if (status != FWK_SUCCESS)
         return status;
 
-    param->status = drv_status;
+    param->status = (drv_status == FWK_SUCCESS) ? FWK_SUCCESS : FWK_E_DEVICE;
 
     return fwk_thread_put_event(&resp);
 }

--- a/module/i2c/src/mod_i2c.c
+++ b/module/i2c/src/mod_i2c.c
@@ -332,13 +332,15 @@ static int respond_to_caller(
 static int mod_i2c_process_event(const struct fwk_event *event,
                                  struct fwk_event *resp_event)
 {
+    fwk_id_t dev_id;
     int status, drv_status;
     struct mod_i2c_dev_ctx *ctx;
     struct mod_i2c_event_param *event_param =
         (struct mod_i2c_event_param *)event->params;
     struct mod_i2c_request *request = (struct mod_i2c_request *)event->params;
 
-    get_ctx(event->target_id, &ctx);
+    dev_id = event->target_id;
+    get_ctx(dev_id, &ctx);
 
     switch (fwk_id_get_event_idx(event->id)) {
     case MOD_I2C_EVENT_IDX_REQUEST_TRANSMIT:
@@ -382,8 +384,7 @@ static int mod_i2c_process_event(const struct fwk_event *event,
 
     case MOD_I2C_EVENT_IDX_REQUEST_COMPLETED:
         if ((ctx->state == MOD_I2C_DEV_TX) || (ctx->state == MOD_I2C_DEV_RX)) {
-            status = respond_to_caller(
-                event->target_id, ctx, event_param->status);
+            status = respond_to_caller(dev_id, ctx, event_param->status);
         } else if (ctx->state == MOD_I2C_DEV_TX_RX) {
             if (event_param->status == FWK_SUCCESS) {
                 /* The TX request succeeded, proceed with the RX */
@@ -395,12 +396,10 @@ static int mod_i2c_process_event(const struct fwk_event *event,
                 if (drv_status == FWK_PENDING)
                     status = FWK_SUCCESS;
                 else
-                    status = respond_to_caller(
-                        event->target_id, ctx, drv_status);
+                    status = respond_to_caller(dev_id, ctx, drv_status);
             } else {
                 /* The request failed, respond */
-                status = respond_to_caller(
-                    event->target_id, ctx, event_param->status);
+                status = respond_to_caller(dev_id, ctx, event_param->status);
             }
         } else
             status = FWK_E_STATE;

--- a/module/i2c/src/mod_i2c.c
+++ b/module/i2c/src/mod_i2c.c
@@ -333,8 +333,7 @@ static int respond_to_caller(int event_status,
 static int mod_i2c_process_event(const struct fwk_event *event,
                                  struct fwk_event *resp_event)
 {
-    int status = FWK_E_PARAM;
-    int drv_status;
+    int status, drv_status;
     struct mod_i2c_dev_ctx *ctx;
     struct mod_i2c_event_param *event_param =
         (struct mod_i2c_event_param *)event->params;
@@ -405,6 +404,10 @@ static int mod_i2c_process_event(const struct fwk_event *event,
         } else
             status = FWK_E_STATE;
 
+        break;
+
+    default:
+        status = FWK_E_PANIC;
         break;
     }
 


### PR DESCRIPTION
On a system, it is usual for several I2C slaves to be attached to the same I2C bus. This results in possible concurrent accesses to the I2C bus as a firmware entity may want to access a device it controls through the I2C bus while the bus is busy communicating with another device.

This series adds support for concurrent requests on an I2C bus. That way, users of this module don't have to take into account that they may share an I2C bus.
