### PR TITLE
n1sdp: fix timer sync random failures in multichip mode

### DIFF
--- a/product/n1sdp/module/n1sdp_timer_sync/src/mod_n1sdp_timer_sync.c
+++ b/product/n1sdp/module/n1sdp_timer_sync/src/mod_n1sdp_timer_sync.c
@@ -29,6 +29,12 @@
 #define SYNC_CHECK_INTERVAL_US UINT32_C(100000)
 #define SYNC_RETRIES           100
 
+#define CNTCTL_CR_OFFSET        UINT32_C(0x0)
+#define CNTCTL_CVL_OFFSET       UINT32_C(0x8)
+#define CNTCTL_CVH_OFFSET       UINT32_C(0xC)
+#define CNTCONTROL_CR_EN        UINT32_C(0x00000001)
+#define CNTCONTROL_CR_FCREQ     UINT32_C(0x00000100)
+
 /* N1SDP timer synchronization device context */
 struct tsync_device_ctx {
     /* Pointer to the device configuration */
@@ -89,11 +95,21 @@ bool is_timer_synced(struct tsync_device_ctx *ctx)
 
     fwk_assert(ctx != NULL);
 
-    low = *(volatile uint32_t *)(ctx->local_cnt_addr);
+    low = *(volatile uint32_t *)(ctx->local_cnt_addr + CNTCTL_CVL_OFFSET);
     tsync_ctx.ap_mem_api->enable_ap_memory_access(ctx->remote_cnt_addr);
     low_r = *(volatile uint32_t *)(SCP_AP_1MB_WINDOW_BASE +
-        (ctx->local_cnt_addr & SCP_AP_1MB_WINDOW_ADDR_MASK));
+        ((ctx->local_cnt_addr + CNTCTL_CVL_OFFSET) &
+         SCP_AP_1MB_WINDOW_ADDR_MASK));
     return (((low_r - low) < COUNTER_DELTA_MAX));
+}
+
+void n1sdp_timer_reset_counter(struct tsync_device_ctx *ctx)
+{
+    *(volatile uint32_t *)(ctx->local_cnt_addr + CNTCTL_CR_OFFSET) = 0;
+    *(volatile uint32_t *)(ctx->local_cnt_addr + CNTCTL_CVH_OFFSET) = 0;
+    *(volatile uint32_t *)(ctx->local_cnt_addr + CNTCTL_CVL_OFFSET) = 0;
+    *(volatile uint32_t *)(ctx->local_cnt_addr + CNTCTL_CR_OFFSET) |=
+        (CNTCONTROL_CR_EN | CNTCONTROL_CR_FCREQ);
 }
 
 /*
@@ -106,6 +122,7 @@ static int n1sdp_sync_master_timer(fwk_id_t id)
 
     device_ctx = &tsync_ctx.device_ctx_table[fwk_id_get_element_idx(id)];
 
+    n1sdp_timer_reset_counter(device_ctx);
     device_ctx->reg->GCNT_TIMEOUT = device_ctx->config->sync_timeout;
     device_ctx->reg->SLVCHIP_GCNT_NW_DELAY = device_ctx->config->ccix_delay;
     device_ctx->reg->MST_GCNT_SYNC_CTRL = MST_GCNT_SYNC_CTRL_EN_MASK;
@@ -136,6 +153,7 @@ static int n1sdp_sync_slave_timer(fwk_id_t id)
 
     device_ctx = &tsync_ctx.device_ctx_table[fwk_id_get_element_idx(id)];
 
+    n1sdp_timer_reset_counter(device_ctx);
     irq = device_ctx->config->irq;
     fwk_interrupt_set_isr_param(irq, &timer_sync_isr, (uintptr_t)device_ctx);
     fwk_interrupt_clear_pending(irq);

--- a/product/n1sdp/scp_ramfw/config_n1sdp_timer_sync.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_timer_sync.c
@@ -20,11 +20,11 @@ static const struct fwk_element n1sdp_tsync_element_table[] = {
         .data = &((struct mod_n1sdp_tsync_config) {
             .irq = TIMER_SYNC_IRQ,
             .reg = SCP_TIMER_SYNC_BASE,
-            .ccix_delay = 90,
+            .ccix_delay = 25,
             .sync_timeout = 0x200,
             .sync_interval = 0x500,
             .off_threshold = 0xF,
-            .target_cnt_base = 0x2A430008,
+            .target_cnt_base = 0x2A430000,
             .local_offset = SCP_SYS1_BASE,
             .remote_offset = (4UL * FWK_TIB),
         })


### PR DESCRIPTION
This patch fixes random boot failures in timer synchronization
between two N1SDP in multichip operation by:
1. Reset the REFCLK counter before starting the sync process.
2. Adjust the CCIX delay close to the board setup.

Change-Id: I3b721a43a68f7ab8695231f8340012122b5f7875
Signed-off-by: Manoj Kumar <manoj.kumar3@arm.com>