### PR TITLE
juno/pvt: Fix notification response parameter

### DIFF
--- a/product/juno/module/juno_pvt/src/mod_juno_pvt.c
+++ b/product/juno/module/juno_pvt/src/mod_juno_pvt.c
@@ -739,11 +739,11 @@ static int pvt_process_event(const struct fwk_event *event,
                 if (status != FWK_SUCCESS)
                     return FWK_E_PANIC;
 
+                pd_resp_params->status = FWK_SUCCESS;
+
                 status = fwk_thread_put_event(&resp_notif);
                 if (status != FWK_SUCCESS)
                     return FWK_E_PANIC;
-
-                pd_resp_params->status = FWK_SUCCESS;
             }
 
             return FWK_SUCCESS;


### PR DESCRIPTION
The status to be returned to the response notification
needs to be assign before the put_event.
This patch fixes this.

Change-Id: Ie517a941b75d5d085247cf245cbeac84b26ae20c
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>