### PR TITLE
juno/module: Add thermal protection

### DIFF
--- a/product/juno/include/juno_alarm_idx.h
+++ b/product/juno/include/juno_alarm_idx.h
@@ -34,7 +34,13 @@ enum juno_ppu_alarm_idx {
     JUNO_PPU_ALARM_IDX_COUNT,
 };
 
+/* Alarm indices for Thermal Protection */
+enum juno_thermal_alarm_idx {
+    JUNO_THERMAL_ALARM_IDX = JUNO_PPU_ALARM_IDX_COUNT,
+    JUNO_THERMAL_ALARM_IDX_COUNT,
+};
+
 /* Total count of alarms */
-#define JUNO_ALARM_IDX_COUNT    JUNO_PPU_ALARM_IDX_COUNT
+#define JUNO_ALARM_IDX_COUNT    JUNO_THERMAL_ALARM_IDX_COUNT
 
 #endif /* JUNO_ALARM_IDX_H */

--- a/product/juno/module/juno_thermal/include/mod_juno_thermal.h
+++ b/product/juno/module/juno_thermal/include/mod_juno_thermal.h
@@ -1,0 +1,50 @@
+ /*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     Juno Thermal Protection
+ */
+#ifndef MOD_JUNO_THERMAL_H
+#define MOD_JUNO_THERMAL_H
+
+#include <fwk_id.h>
+
+/*!
+ * \ingroup GroupJunoModule Juno Product Modules
+ * \defgroup GroupThermalProtection Thermal Protection
+ * \{
+ */
+
+/*!
+ * \brief Element configuration.
+ */
+struct mod_juno_thermal_element_config {
+    /*!
+     * \brief The temperature threshold in millidegrees celsius.
+     */
+    uint64_t thermal_threshold_mdc;
+
+    /*!
+     * \brief The alarm interval in milliseconds.
+     */
+    unsigned int period_ms;
+
+    /*!
+     * \brief Identifier of the sensor element to read the temperature from.
+     */
+    fwk_id_t sensor_id;
+
+    /*!
+     * \brief Identifier of the alarm for reading the temperature periodically.
+     */
+    fwk_id_t alarm_id;
+};
+
+/*!
+ * \}
+ */
+
+#endif /* MOD_JUNO_THERMAL_H */

--- a/product/juno/module/juno_thermal/src/Makefile
+++ b/product/juno/module/juno_thermal/src/Makefile
@@ -1,0 +1,11 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BS_LIB_NAME := JUNO THERMAL PROTECTION
+BS_LIB_SOURCES += mod_juno_thermal.c
+
+include $(BS_DIR)/lib.mk

--- a/product/juno/module/juno_thermal/src/mod_juno_thermal.c
+++ b/product/juno/module/juno_thermal/src/mod_juno_thermal.c
@@ -1,0 +1,245 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     Juno Thermal Protection
+ */
+
+#include <fwk_assert.h>
+#include <fwk_id.h>
+#include <fwk_mm.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+#include <fwk_thread.h>
+#include <fwk_status.h>
+#include <mod_juno_thermal.h>
+#include <mod_log.h>
+#include <mod_power_domain.h>
+#include <mod_sensor.h>
+#include <mod_timer.h>
+#include <config_juno_thermal.h>
+#include <juno_alarm_idx.h>
+#include <juno_id.h>
+
+enum mod_juno_thermal_event_idx {
+    MOD_JUNO_THERMAL_EVENT_IDX_TIMER,
+    MOD_JUNO_THERMAL_EVENT_IDX_COUNT,
+};
+
+static const struct mod_log_api *log_api;
+static const struct mod_pd_restricted_api *pd_api;
+
+/*
+ * The sensor used for monitoring the temperature is available only on the real
+ * board, thus when running on FVP this module does not need to provide
+ * protection.
+ */
+static bool is_platform_fvp;
+
+struct thermal_dev_ctx {
+    const struct mod_juno_thermal_element_config *config;
+    const struct mod_sensor_api *sensor_api;
+    const struct mod_timer_alarm_api *alarm_api;
+};
+
+static const fwk_id_t mod_juno_thermal_event_id_timer =
+    FWK_ID_EVENT_INIT(FWK_MODULE_IDX_JUNO_THERMAL,
+                      MOD_JUNO_THERMAL_EVENT_IDX_TIMER);
+
+static struct thermal_dev_ctx *ctx_table;
+
+/*
+ * Periodical alarm callback
+ */
+
+static void juno_thermal_alarm_callback(uintptr_t param)
+{
+    int status;
+    unsigned int elem_idx = (unsigned int)param;
+
+    struct fwk_event event = {
+        .source_id = FWK_ID_MODULE(FWK_MODULE_IDX_JUNO_THERMAL),
+        .target_id = fwk_id_build_element_id(
+            fwk_module_id_juno_thermal,
+            elem_idx),
+        .id = mod_juno_thermal_event_id_timer,
+    };
+
+    status = fwk_thread_put_event(&event);
+    fwk_assert(status == FWK_SUCCESS);
+}
+
+/*
+ * Framework handlers
+ */
+
+static int juno_thermal_init(
+    fwk_id_t module_id,
+    unsigned int element_count,
+    const void *config)
+{
+    int status;
+    enum juno_idx_platform platform_id = JUNO_IDX_PLATFORM_COUNT;
+
+    fwk_assert(element_count == 1);
+
+    status = juno_id_get_platform(&platform_id);
+    if (!fwk_expect(status == FWK_SUCCESS))
+        return FWK_E_PANIC;
+
+    is_platform_fvp = (platform_id == JUNO_IDX_PLATFORM_FVP);
+
+    if (is_platform_fvp)
+        return FWK_SUCCESS;
+
+    ctx_table = fwk_mm_calloc(element_count, sizeof(struct thermal_dev_ctx));
+    if (ctx_table == NULL)
+        return FWK_E_NOMEM;
+
+    return FWK_SUCCESS;
+}
+
+static int juno_thermal_element_init(
+    fwk_id_t element_id,
+    unsigned int unused,
+    const void *data)
+{
+    struct thermal_dev_ctx *ctx;
+    fwk_id_t sensor_id;
+
+    if (is_platform_fvp)
+        return FWK_SUCCESS;
+
+    ctx = &ctx_table[fwk_id_get_element_idx(element_id)];
+    ctx->config = (struct mod_juno_thermal_element_config *)data;
+
+    sensor_id = ctx->config->sensor_id;
+
+    /* Validate identifiers */
+    if (fwk_id_get_module_idx(sensor_id) != FWK_MODULE_IDX_SENSOR)
+        return FWK_E_DATA;
+    else
+        return FWK_SUCCESS;
+}
+
+static int juno_thermal_bind(fwk_id_t id, unsigned int round)
+{
+    int status;
+    struct thermal_dev_ctx *ctx;
+
+    if ((round > 0) || is_platform_fvp)
+        return FWK_SUCCESS;
+
+    if (fwk_id_is_type(id, FWK_ID_TYPE_MODULE)) {
+        /* Bind to power domain - only binding to module is allowed */
+        status = fwk_module_bind(
+            fwk_module_id_power_domain,
+            mod_pd_api_id_restricted,
+            &pd_api);
+        if (status != FWK_SUCCESS)
+            return FWK_E_PANIC;
+
+        return fwk_module_bind(fwk_module_id_log, MOD_LOG_API_ID, &log_api);
+    }
+
+    ctx = &ctx_table[fwk_id_get_element_idx(id)];
+
+    status = fwk_module_bind(
+        ctx->config->alarm_id,
+        MOD_TIMER_API_ID_ALARM,
+        &ctx->alarm_api);
+    if (status != FWK_SUCCESS)
+        return FWK_E_PANIC;
+
+    status = fwk_module_bind(
+        ctx->config->sensor_id,
+        mod_sensor_api_id_sensor,
+        &ctx->sensor_api);
+    if (status != FWK_SUCCESS)
+        return FWK_E_PANIC;
+
+    return FWK_SUCCESS;
+}
+
+static int juno_thermal_start(fwk_id_t id)
+{
+    int status;
+    struct thermal_dev_ctx *ctx;
+
+    /* Nothing to start for module */
+    if (fwk_id_is_type(id, FWK_ID_TYPE_MODULE) || is_platform_fvp)
+        return FWK_SUCCESS;
+
+    ctx = &ctx_table[fwk_id_get_element_idx(id)];
+
+    status = ctx->alarm_api->start(
+        ctx->config->alarm_id,
+        ctx->config->period_ms,
+        MOD_TIMER_ALARM_TYPE_PERIODIC,
+        juno_thermal_alarm_callback,
+        (uintptr_t)fwk_id_get_element_idx(id));
+
+    return status;
+}
+
+static int check_threshold_breach(uint64_t temperature, uint64_t threshold)
+{
+    if (temperature > threshold) {
+        log_api->log(MOD_LOG_GROUP_WARNING, "[THERMAL] system shutdown\n");
+
+        return pd_api->system_shutdown(MOD_PD_SYSTEM_FORCED_SHUTDOWN);
+    }
+
+    return FWK_SUCCESS;
+}
+
+static int juno_thermal_process_event(
+    const struct fwk_event *event,
+    struct fwk_event *resp_event)
+{
+    struct thermal_dev_ctx *ctx;
+    int status;
+    uint64_t value;
+
+    ctx = &ctx_table[fwk_id_get_element_idx(event->target_id)];
+
+    /* Event from timer callback */
+    if (fwk_id_is_equal(event->id, mod_juno_thermal_event_id_timer)) {
+        status = ctx->sensor_api->get_value(ctx->config->sensor_id, &value);
+        if (status == FWK_SUCCESS) {
+            status = check_threshold_breach(
+                value,
+                ctx->config->thermal_threshold_mdc);
+        } else if (status == FWK_PENDING)
+            return FWK_SUCCESS;
+
+    /* Response event from sensor HAL */
+    } else if (fwk_id_is_equal(event->id, mod_sensor_event_id_read_request)) {
+        struct mod_sensor_event_params *params =
+        (struct mod_sensor_event_params *)event->params;
+
+        if (params->status != FWK_SUCCESS)
+            return params->status;
+        status = check_threshold_breach(
+            params->value,
+            ctx->config->thermal_threshold_mdc);
+
+    } else
+        return FWK_E_PARAM;
+
+    return status;
+}
+
+const struct fwk_module module_juno_thermal = {
+    .name = "JUNO THERMAL",
+    .type = FWK_MODULE_TYPE_SERVICE,
+    .event_count = MOD_JUNO_THERMAL_EVENT_IDX_COUNT,
+    .init = juno_thermal_init,
+    .element_init = juno_thermal_element_init,
+    .bind = juno_thermal_bind,
+    .start = juno_thermal_start,
+    .process_event = juno_thermal_process_event,
+};

--- a/product/juno/scp_ramfw/config_juno_thermal.c
+++ b/product/juno/scp_ramfw/config_juno_thermal.c
@@ -1,0 +1,44 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <fwk_element.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+#include <juno_alarm_idx.h>
+#include <mod_juno_thermal.h>
+#include <config_juno_thermal.h>
+#include <config_sensor.h>
+
+static struct fwk_element juno_thermal_element_table[] = {
+    [MOD_JUNO_THERMAL_ELEMENT_IDX_CRITICAL] = {
+        .name = "Soc",
+        .data = &(struct mod_juno_thermal_element_config) {
+            .thermal_threshold_mdc = UINT64_C(70 * 1000),
+            .period_ms = (2 * 1000),
+            .sensor_id =
+                FWK_ID_ELEMENT_INIT(
+                    FWK_MODULE_IDX_SENSOR,
+                    MOD_JUNO_PVT_SENSOR_TEMP_SOC),
+            .alarm_id =
+                FWK_ID_SUB_ELEMENT_INIT(
+                    FWK_MODULE_IDX_TIMER,
+                    0,
+                    JUNO_THERMAL_ALARM_IDX),
+        }
+    },
+    [MOD_JUNO_THERMAL_ELEMENT_IDX_COUNT] = { 0 },
+};
+
+static const struct fwk_element *juno_thermal_get_element_table(
+    fwk_id_t module_id)
+{
+    return juno_thermal_element_table;
+}
+
+const struct fwk_module_config config_juno_thermal = {
+    .get_element_table = juno_thermal_get_element_table,
+};

--- a/product/juno/scp_ramfw/config_juno_thermal.h
+++ b/product/juno/scp_ramfw/config_juno_thermal.h
@@ -1,0 +1,17 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef CONFIG_JUNO_THERMAL_H
+#define CONFIG_JUNO_THERMAL_H
+
+/* Element indices for Juno thermal */
+enum mod_juno_thermal_element_idx {
+    MOD_JUNO_THERMAL_ELEMENT_IDX_CRITICAL,
+    MOD_JUNO_THERMAL_ELEMENT_IDX_COUNT
+};
+
+#endif /* CONFIG_JUNO_THERMAL_H */

--- a/product/juno/scp_ramfw/firmware.mk
+++ b/product/juno/scp_ramfw/firmware.mk
@@ -48,7 +48,8 @@ BS_FIRMWARE_MODULES := \
     reg_sensor \
     psu \
     mock_psu \
-    juno_pvt
+    juno_pvt \
+    juno_thermal
 
 BS_FIRMWARE_SOURCES := \
     rtx_config.c \
@@ -81,6 +82,7 @@ BS_FIRMWARE_SOURCES := \
     config_reg_sensor.c \
     config_psu.c \
     config_mock_psu.c \
-    config_juno_pvt.c
+    config_juno_pvt.c \
+    config_juno_thermal.c
 
 include $(BS_DIR)/firmware.mk


### PR DESCRIPTION
This patch adds a single threshold thermal protection
for the Juno platform. Once the temperature exceeds the
threshold the module will request a forced shutdown.

Change-Id: I4704195e52cdba9f2d94d334e3a347e07c6e0726
Signed-off-by: Tarek El-Sherbiny <tarek.el-sherbiny@arm.com>
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>