### PR TITLE
ccix: change to CCUV

### DIFF
--- a/module/cmn600/include/internal/cmn600_ccix.h
+++ b/module/cmn600/include/internal/cmn600_ccix.h
@@ -244,6 +244,6 @@ struct cxg_wait_condition_data {
 #define SAM_ADDR_REG_VALID_MASK                   UINT64_C(0x8000000000000000)
 #define PCIE_OPT_HDR_MASK                         (0x1ULL << 6)
 #define CTL_NUM_SNPCRDS_MASK                      (0xF << 4)
-#define CCIX_VENDER_ID                            (0x2692)
+#define CCIX_VENDER_ID                            (0x1E2C)
 
 #endif /* INTERNAL_CMN600_CCIX_H */

--- a/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.h
+++ b/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.h
@@ -118,7 +118,7 @@
  * This value is same as what Xilinx Hood FPGA expects.
  * To be revisited after consortium finalizes the value.
  */
-#define CCIX_VENDER_ID                 (0x2692)
+#define CCIX_VENDER_ID                 (0x1E2C)
 
 /* PCIe LM root complex bar configuration register bit masks */
 #define TYPE1_PREF_MEM_BAR_ENABLE_MASK      (1U << 17)


### PR DESCRIPTION
Change the CCIX_VENDER_ID to a CCUV value.

Change-Id: I061f7f980c5c1f7f81f484d087ff6d81136b466a
Signed-off-by: Chandni Cherukuri <chandni.cherukuri@arm.com>