### PR TITLE
cmn600: fix host ha count

### DIFF
--- a/module/cmn600/src/mod_cmn600.c
+++ b/module/cmn600/src/mod_cmn600.c
@@ -250,7 +250,7 @@ static int cmn600_discovery(void)
      * RN-SAM count minus the total RN-D, RN-I and CXHA count combined.
      */
     ctx->rnf_count = ctx->internal_rnsam_count + ctx->external_rnsam_count -
-        (ctx->rnd_count + ctx->rni_count + ctx->ccix_host_info.host_ha_count++);
+        (ctx->rnd_count + ctx->rni_count + ctx->ccix_host_info.host_ha_count);
 
     if (ctx->rnf_count > MAX_RNF_COUNT) {
         ctx->log_api->log(MOD_LOG_GROUP_ERROR,
@@ -272,7 +272,7 @@ static int cmn600_discovery(void)
         MOD_NAME "Total external RN-SAM nodes: %d\n"
         MOD_NAME "Total HN-F nodes: %d\n"
         MOD_NAME "Total RN-D nodes: %d\n"
-        MOD_NAME "Total RN-F nodes: %d\n",
+        MOD_NAME "Total RN-F nodes: %d\n"
         MOD_NAME "Total RN-I nodes: %d\n",
         ctx->internal_rnsam_count,
         ctx->external_rnsam_count,


### PR DESCRIPTION
Host HA count in the CCIX Host configuration data will be passed to the
next stage of bootloader (typically UEFI) to help the CCIX configuration
driver to start assigning the Remote AgentIDs. While calculating the
RN-F count, Host HA count is incorrectly incremented resulting in wrong
assignment of Remote AgentIDs. Due to this Remote RA to Remote HA memory
test failed. Fix this by removing the incorrect increment of Host HA
count while calculating RN-F count. While at it, remove a redundant
comma when displaying the number of nodes discovered.

Change-Id: I2a02035617ed4e0576fb05e41534edbf8e42b0a1
Signed-off-by: Vijayenthiran Subramaniam <vijayenthiran.subramaniam@arm.com>