### PR TITLE
fwk/fwk_mm_alloc: panic if memory allocation failed

### DIFF
--- a/arch/src/arm_nvic.c
+++ b/arch/src/arm_nvic.c
@@ -282,8 +282,7 @@ int arm_nvic_init(const struct fwk_arch_interrupt_driver **driver)
      * corresponding parameters.
      */
     callback = fwk_mm_calloc(isr_count, sizeof(callback[0]));
-    if (callback == NULL)
-        return FWK_E_NOMEM;
+
     /*
      * The base address for the vector table must align on the number of
      * entries in the table, corresponding to a word boundary rounded up to the
@@ -300,9 +299,6 @@ int arm_nvic_init(const struct fwk_arch_interrupt_driver **driver)
     align_word = align_entries * sizeof(vector[0]);
 
     vector = fwk_mm_alloc_aligned(isr_count, sizeof(vector[0]), align_word);
-
-    if (vector == NULL)
-        return FWK_E_NOMEM;
 
     /*
      * Initialize all exception entries to point to the arm_exception_invalid()

--- a/arch/src/host_thread.c
+++ b/arch/src/host_thread.c
@@ -171,12 +171,8 @@ osThreadId_t osThreadNew(osThreadFunc_t func, void *argument,
     pthread_t *pthread_id;
 
     thread_data = fwk_mm_calloc(1, sizeof(struct thread_data));
-    if (thread_data == NULL)
-        return NULL;
 
     pthread_id = fwk_mm_calloc(1, sizeof(pthread_t));
-    if (pthread_id == NULL)
-        return NULL;
 
     status = pthread_cond_init(&thread_data->cond, NULL);
     if (status != 0)

--- a/framework/src/fwk_mm.c
+++ b/framework/src/fwk_mm.c
@@ -93,8 +93,7 @@ void *fwk_mm_alloc_aligned(size_t num, size_t size, unsigned int alignment)
     return (void *)start;
 
 error:
-    fwk_expect(false);
-    return NULL;
+    fwk_trap();
 }
 
 void *fwk_mm_calloc(size_t num, size_t size)

--- a/framework/src/fwk_module.c
+++ b/framework/src/fwk_module.c
@@ -75,10 +75,6 @@ static int init_notification_dlist_table(size_t count,
     unsigned int dlist_idx;
 
     dlist_table = fwk_mm_calloc(count, sizeof(struct fwk_dlist));
-    if (dlist_table == NULL) {
-        FWK_HOST_PRINT(err_msg_line, FWK_E_NOMEM, __func__, __LINE__);
-        return FWK_E_NOMEM;
-    }
     *notification_dlist_table = dlist_table;
 
     for (dlist_idx = 0; dlist_idx < count; dlist_idx++)
@@ -105,8 +101,6 @@ static int init_elements(struct fwk_module_ctx *module_ctx,
     module_ctx->element_ctx_table =
         fwk_mm_calloc(module_ctx->element_count,
                       sizeof(struct fwk_element_ctx));
-    if (module_ctx->element_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     for (element_idx = 0; element_idx < module_ctx->element_count;
          element_idx++) {
@@ -229,10 +223,6 @@ static int init_modules(void)
 
     ctx.module_ctx_table = fwk_mm_calloc(ctx.module_count,
                                          sizeof(struct fwk_module_ctx));
-    if (ctx.module_ctx_table == NULL) {
-        FWK_HOST_PRINT(err_msg_line, FWK_E_NOMEM, __func__, __LINE__);
-        return FWK_E_NOMEM;
-    }
 
     for (module_idx = 0; module_idx < ctx.module_count; module_idx++) {
         module_ctx = &ctx.module_ctx_table[module_idx];

--- a/framework/src/fwk_multi_thread.c
+++ b/framework/src/fwk_multi_thread.c
@@ -52,13 +52,9 @@ static int init_thread_attr(osThreadAttr_t *attr)
     attr->attr_bits = osThreadDetached;
     attr->cb_size = osRtxThreadCbSize;
     attr->cb_mem = fwk_mm_calloc(1, attr->cb_size);
-    if (attr->cb_mem == NULL)
-        return FWK_E_NOMEM;
 
     attr->stack_size = 256 * 4;
     attr->stack_mem = fwk_mm_calloc(1, attr->stack_size);
-    if (attr->stack_mem == NULL)
-        return FWK_E_NOMEM;
 
     attr->priority = osPriorityNormal;
 
@@ -596,10 +592,6 @@ int __fwk_thread_init(size_t event_count)
     }
 
     event_table = fwk_mm_calloc(event_count, sizeof(struct fwk_event));
-    if (event_table == NULL) {
-        status = FWK_E_NOMEM;
-        goto error;
-    }
 
     /* All the event structures are free to be used. */
     fwk_list_init(&ctx.event_free_queue);
@@ -714,6 +706,7 @@ int fwk_thread_create(fwk_id_t id)
     thread_ctx->id = id;
     thread_ctx->os_thread_id = osThreadNew(specific_thread_function, thread_ctx,
                                            &thread_attr);
+
     if (thread_ctx->os_thread_id == NULL) {
         status = FWK_E_OS;
         goto error;

--- a/framework/src/fwk_notification.c
+++ b/framework/src/fwk_notification.c
@@ -151,10 +151,6 @@ int __fwk_notification_init(size_t notification_count)
 
     subscription_table = fwk_mm_calloc(
         notification_count, sizeof(struct __fwk_notification_subscription));
-    if (subscription_table == NULL) {
-        FWK_HOST_PRINT(err_msg_func, FWK_E_NOMEM, __func__);
-        return FWK_E_NOMEM;
-    }
 
     /* All the subscription structures are free to be used. */
     fwk_list_init(&ctx.free_subscription_dlist);

--- a/framework/src/fwk_thread.c
+++ b/framework/src/fwk_thread.c
@@ -186,14 +186,9 @@ static void process_isr(void)
 
 int __fwk_thread_init(size_t event_count)
 {
-    int status;
     struct fwk_event *event_table, *event;
 
     event_table = fwk_mm_calloc(event_count, sizeof(struct fwk_event));
-    if (event_table == NULL) {
-        status = FWK_E_NOMEM;
-        goto error;
-    }
 
     /* All the event structures are free to be used. */
     fwk_list_init(&ctx.free_event_queue);
@@ -208,10 +203,6 @@ int __fwk_thread_init(size_t event_count)
     ctx.initialized = true;
 
     return FWK_SUCCESS;
-
-error:
-    FWK_HOST_PRINT(err_msg_func, status, __func__);
-    return status;
 }
 
 noreturn void __fwk_thread_run(void)

--- a/framework/test/test_fwk_mm.c
+++ b/framework/test/test_fwk_mm.c
@@ -25,22 +25,18 @@
 #define MEM_PATTERN         0x0A
 #define ALIGN_MASK          (ALLOC_ALIGN - 1)
 
-static void test_fwk_mm_alloc_before_init(void);
 static void test_fwk_mm_init(void);
 static void test_fwk_mm_alloc(void);
 static void test_fwk_mm_alloc_aligned(void);
 static void test_fwk_mm_calloc(void);
 static void test_fwk_mm_calloc_aligned(void);
-static void test_fwk_mm_lock(void);
 
 static const struct fwk_test_case_desc test_case_table[] = {
-    FWK_TEST_CASE(test_fwk_mm_alloc_before_init),
     FWK_TEST_CASE(test_fwk_mm_init),
     FWK_TEST_CASE(test_fwk_mm_alloc),
     FWK_TEST_CASE(test_fwk_mm_alloc_aligned),
     FWK_TEST_CASE(test_fwk_mm_calloc),
-    FWK_TEST_CASE(test_fwk_mm_calloc_aligned),
-    FWK_TEST_CASE(test_fwk_mm_lock)
+    FWK_TEST_CASE(test_fwk_mm_calloc_aligned)
 };
 
 struct fwk_test_suite_desc test_suite = {
@@ -53,26 +49,6 @@ extern int fwk_mm_init(uintptr_t start, size_t size);
 extern void fwk_mm_lock(void);
 
 static int start[SIZE_MEM];
-
-static void test_fwk_mm_alloc_before_init(void)
-{
-    void *result;
-    size_t num = ALLOC_NUM;
-    size_t size = ALLOC_SIZE;
-    unsigned int alignment = ALLOC_ALIGN;
-
-    result = fwk_mm_alloc(num, size);
-    assert(result == NULL);
-
-    result = fwk_mm_alloc_aligned(num, size, alignment);
-    assert(result == NULL);
-
-    result = fwk_mm_calloc(num, size);
-    assert(result == NULL);
-
-    result = fwk_mm_calloc_aligned(num, size, alignment);
-    assert(result == NULL);
-}
 
 static void test_fwk_mm_init(void)
 {
@@ -96,21 +72,6 @@ static void test_fwk_mm_alloc(void)
 {
     int i;
     char *result;
-
-    /* Bad parameters */
-    result = fwk_mm_alloc(0, ALLOC_SIZE);
-    assert(result == NULL);
-
-    result = fwk_mm_alloc(ALLOC_NUM, 0);
-    assert(result == NULL);
-
-    /* Allocate a memory block larger than the memory */
-    result = fwk_mm_alloc(ALLOC_NUM, SIZE_MEM + 1);
-    assert(result == NULL);
-
-    /* Num and size overflowed when multiplied */
-    result = fwk_mm_alloc(SIZE_MAX, SIZE_MAX);
-    assert(result == NULL);
 
     /* Allocate a memory block with an odd size */
     result = fwk_mm_alloc(ALLOC_NUM, ALLOC_ODD_SIZE);
@@ -141,28 +102,6 @@ static void test_fwk_mm_alloc_aligned(void)
     int i;
     char *result;
 
-    /* Bad parameters */
-    result = fwk_mm_alloc_aligned(0, ALLOC_SIZE, ALLOC_ALIGN);
-    assert(result == NULL);
-
-    result = fwk_mm_alloc_aligned(ALLOC_NUM, 0, ALLOC_ALIGN);
-    assert(result == NULL);
-
-    result = fwk_mm_alloc_aligned(ALLOC_NUM, ALLOC_SIZE, 0);
-    assert(result == NULL);
-
-    /* Allocate with a non power of two alignment */
-    result = fwk_mm_alloc_aligned(ALLOC_NUM, ALLOC_SIZE, ALLOC_BAD_ALIGN);
-    assert(result == NULL);
-
-    /* Allocate a memory block larger than the memory */
-    result = fwk_mm_alloc_aligned(ALLOC_NUM, SIZE_MEM + 1, ALLOC_ALIGN);
-    assert(result == NULL);
-
-    /* Num and size overflowed when multiplied */
-    result = fwk_mm_alloc_aligned(SIZE_MAX, SIZE_MAX, ALLOC_ALIGN);
-    assert(result == NULL);
-
     /* Allocate a memory block with an odd size */
     result = fwk_mm_alloc_aligned(ALLOC_NUM, ALLOC_ODD_SIZE, ALLOC_ALIGN);
     assert(result != NULL);
@@ -191,21 +130,6 @@ static void test_fwk_mm_calloc(void)
 {
     int i;
     char *result;
-
-    /* Bad parameters */
-    result = fwk_mm_calloc(0, ALLOC_SIZE);
-    assert(result == NULL);
-
-    result = fwk_mm_calloc(ALLOC_NUM, 0);
-    assert(result == NULL);
-
-    /* Allocate a memory block larger than the memory */
-    result = fwk_mm_calloc(ALLOC_NUM, SIZE_MEM + 1);
-    assert(result == NULL);
-
-    /* Num and size overflowed when multiplied */
-    result = fwk_mm_calloc(SIZE_MAX, SIZE_MAX);
-    assert(result == NULL);
 
     /* Allocate a memory block with an odd size */
     result = fwk_mm_calloc(ALLOC_NUM, ALLOC_ODD_SIZE);
@@ -240,28 +164,6 @@ static void test_fwk_mm_calloc_aligned(void)
     int i;
     char *result;
 
-    /* Bad parameters */
-    result = fwk_mm_alloc_aligned(0, ALLOC_SIZE, ALLOC_ALIGN);
-    assert(result == NULL);
-
-    result = fwk_mm_alloc_aligned(ALLOC_NUM, 0, ALLOC_ALIGN);
-    assert(result == NULL);
-
-    result = fwk_mm_alloc_aligned(ALLOC_NUM, ALLOC_SIZE, 0);
-    assert(result == NULL);
-
-    /* Allocate with a non power of two alignment */
-    result = fwk_mm_alloc_aligned(ALLOC_NUM, ALLOC_SIZE, ALLOC_BAD_ALIGN);
-    assert(result == NULL);
-
-    /* Allocate a memory block larger than the memory */
-    result = fwk_mm_alloc_aligned(ALLOC_NUM, SIZE_MEM + 1, ALLOC_ALIGN);
-    assert(result == NULL);
-
-    /* Num and size overflowed when multiplied */
-    result = fwk_mm_alloc_aligned(SIZE_MAX, SIZE_MAX, ALLOC_ALIGN);
-    assert(result == NULL);
-
     /* Allocate a memory block with an odd size */
     result = fwk_mm_alloc_aligned(ALLOC_NUM, ALLOC_ODD_SIZE, ALLOC_ALIGN);
     assert(result != NULL);
@@ -289,43 +191,4 @@ static void test_fwk_mm_calloc_aligned(void)
     for (i = 0; i < ALLOC_TOTAL_SIZE; i++)
         assert(result[i] == MEM_PATTERN);
 
-}
-
-static void test_fwk_mm_lock(void)
-{
-    void *result;
-
-    /*
-     * Make sure that memory allocation works properly before the
-     * component is locked.
-     */
-    result = fwk_mm_alloc(ALLOC_NUM, ALLOC_SIZE);
-    assert(result != NULL);
-
-    result = fwk_mm_alloc_aligned(ALLOC_NUM, ALLOC_SIZE, ALLOC_ALIGN);
-    assert(result != NULL);
-
-    result = fwk_mm_calloc(ALLOC_NUM, ALLOC_SIZE);
-    assert(result != NULL);
-
-    result = fwk_mm_calloc_aligned(ALLOC_NUM, ALLOC_SIZE, ALLOC_ALIGN);
-    assert(result != NULL);
-
-    fwk_mm_lock();
-
-    /*
-     * After the component has been locked the allocation attempt that
-     * succeeded previously should now fail.
-     */
-    result = fwk_mm_alloc(ALLOC_NUM, ALLOC_SIZE);
-    assert(result == NULL);
-
-    result = fwk_mm_alloc_aligned(ALLOC_NUM, ALLOC_SIZE, ALLOC_ALIGN);
-    assert(result == NULL);
-
-    result = fwk_mm_calloc(ALLOC_NUM, ALLOC_SIZE);
-    assert(result == NULL);
-
-    result = fwk_mm_calloc_aligned(ALLOC_NUM, ALLOC_SIZE, ALLOC_ALIGN);
-    assert(result == NULL);
 }

--- a/framework/test/test_fwk_module.c
+++ b/framework/test/test_fwk_module.c
@@ -294,80 +294,6 @@ static void test_case_setup(void)
     __fwk_module_init();
 }
 
-static void test___fwk_module_init_memory_allocation_failure(void)
-{
-    int result;
-    struct fwk_dlist *subscription_dlist_table;
-
-    /* Memory allocation for the modules failed */
-    fwk_mm_calloc_return = 5;
-    __fwk_module_reset();
-    result = __fwk_module_init();
-    assert(result == FWK_E_NOMEM);
-
-    /*
-     * Memory allocation for the module 0 notification subscription lists
-     * failed
-     */
-    fwk_mm_calloc_return = 4;
-    __fwk_module_reset();
-    result = __fwk_module_init();
-    assert(result == FWK_E_NOMEM);
-
-    /* Memory allocation for the elements failed */
-    init_return_val = FWK_SUCCESS;
-    fwk_mm_calloc_return = 3;
-    __fwk_module_reset();
-    result = __fwk_module_init();
-    assert(result == FWK_E_NOMEM);
-
-    /*
-     * Memory allocation for the module 0 element 1 notification subscription
-     * lists failed
-     */
-    init_return_val = FWK_SUCCESS;
-    fwk_mm_calloc_return = 1;
-    __fwk_module_reset();
-    result = __fwk_module_init();
-    assert(result == FWK_E_NOMEM);
-
-    assert(__fwk_module_get_ctx(MODULE0_ID)->desc == &fake_module_desc0);
-    assert(__fwk_module_get_ctx(MODULE0_ID)->element_count == 2);
-    assert(__fwk_module_get_ctx(MODULE0_ID)->state == 0);
-    assert(__fwk_module_get_ctx(MODULE0_ID)->element_ctx_table != NULL);
-    subscription_dlist_table =
-        __fwk_module_get_ctx(MODULE0_ID)->subscription_dlist_table;
-    assert(subscription_dlist_table != NULL);
-    assert(subscription_dlist_table[0].head ==
-           (struct fwk_dlist_node *)subscription_dlist_table[0].head);
-    assert(subscription_dlist_table[0].tail ==
-           (struct fwk_dlist_node *)subscription_dlist_table[0].head);
-    assert(subscription_dlist_table[1].head ==
-           (struct fwk_dlist_node *)subscription_dlist_table[1].head);
-    assert(subscription_dlist_table[1].tail ==
-           (struct fwk_dlist_node *)subscription_dlist_table[1].head);
-    subscription_dlist_table = __fwk_module_get_ctx(MODULE0_ID)->
-        element_ctx_table[0].subscription_dlist_table;
-    assert(subscription_dlist_table != NULL);
-    assert(subscription_dlist_table[0].head ==
-           (struct fwk_dlist_node *)subscription_dlist_table[0].head);
-    assert(subscription_dlist_table[0].tail ==
-           (struct fwk_dlist_node *)subscription_dlist_table[0].head);
-    assert(subscription_dlist_table[1].head ==
-           (struct fwk_dlist_node *)subscription_dlist_table[1].head);
-    assert(subscription_dlist_table[1].tail ==
-           (struct fwk_dlist_node *)subscription_dlist_table[1].head);
-    subscription_dlist_table = __fwk_module_get_ctx(MODULE0_ID)->
-        element_ctx_table[1].subscription_dlist_table;
-    assert(subscription_dlist_table == NULL);
-
-    assert(__fwk_module_get_ctx(MODULE1_ID)->desc == NULL);
-    assert(__fwk_module_get_ctx(MODULE1_ID)->element_count == 0);
-    assert(__fwk_module_get_ctx(MODULE1_ID)->state == 0);
-    assert(__fwk_module_get_ctx(MODULE1_ID)->element_ctx_table == NULL);
-    assert(__fwk_module_get_ctx(MODULE1_ID)->subscription_dlist_table == NULL);
-}
-
 static void test___fwk_module_init_module_desc_bad_params(void)
 {
     int result;
@@ -1086,7 +1012,6 @@ static void test_fwk_module_bind(void)
 }
 
 static const struct fwk_test_case_desc test_case_table[] = {
-    FWK_TEST_CASE(test___fwk_module_init_memory_allocation_failure),
     FWK_TEST_CASE(test___fwk_module_init_module_desc_bad_params),
     FWK_TEST_CASE(test___fwk_module_init_failure),
     FWK_TEST_CASE(test___fwk_module_init_bind_failure),

--- a/framework/test/test_fwk_multi_thread_create.c
+++ b/framework/test/test_fwk_multi_thread_create.c
@@ -239,26 +239,6 @@ static void test_create_thread_invalid(void)
     assert(status == FWK_E_STATE);
 }
 
-static void test_create_cb_memory_allocation_failed(void)
-{
-    int status;
-    fwk_id_t id = FWK_ID_MODULE(0x1);
-    /* CB memory allocation failed */
-    fwk_mm_calloc_return_null = 1;
-    status = fwk_thread_create(id);
-    assert(status == FWK_E_NOMEM);
-}
-
-static void test_create_stack_memory_allocation_failed(void)
-{
-    int status;
-    fwk_id_t id = FWK_ID_MODULE(0x1);
-    /* CB memory allocation failed */
-    fwk_mm_calloc_return_null = 2;
-    status = fwk_thread_create(id);
-    assert(status == FWK_E_NOMEM);
-}
-
 static void test_create_thread_memory_allocation_failed(void)
 {
     int status;
@@ -312,8 +292,6 @@ static const struct fwk_test_case_desc test_case_table[] = {
     FWK_TEST_CASE(test_create_id_invalid),
     FWK_TEST_CASE(test_create_not_initialized),
     FWK_TEST_CASE(test_create_thread_invalid),
-    FWK_TEST_CASE(test_create_cb_memory_allocation_failed),
-    FWK_TEST_CASE(test_create_stack_memory_allocation_failed),
     FWK_TEST_CASE(test_create_thread_memory_allocation_failed),
     FWK_TEST_CASE(test_create_thread_creation_failed),
     FWK_TEST_CASE(test_create_element_thread),

--- a/framework/test/test_fwk_multi_thread_init.c
+++ b/framework/test/test_fwk_multi_thread_init.c
@@ -157,42 +157,6 @@ static void test_case_setup(void)
     osThreadNew_return_val = (osThreadId_t)COMMON_THREAD_ID;
     osKernelInitailize_return_val = osOK;
 }
-static void test_kernel_initialization_failed(void)
-{
-    int result;
-
-    osKernelInitailize_return_val = osError;
-    result = __fwk_thread_init(2);
-    assert(result == FWK_E_OS);
-}
-
-static void test_init_memory_allocation_failed(void)
-{
-    int result;
-
-    /* Memory allocation failed */
-    fwk_mm_calloc_failed_call = 0;
-    result = __fwk_thread_init(2);
-    assert(result == FWK_E_NOMEM);
-}
-
-static void test_init_common_thread_cb_allocation_failed(void)
-{
-    int result;
-
-    fwk_mm_calloc_failed_call = 1;
-    result = __fwk_thread_init(2);
-    assert(result == FWK_E_NOMEM);
-}
-
-static void test_init_common_thread_stack_allocation_failed(void)
-{
-    int result;
-
-    fwk_mm_calloc_failed_call = 2;
-    result = __fwk_thread_init(2);
-    assert(result == FWK_E_NOMEM);
-}
 
 static void test_init_common_thread_failed(void)
 {
@@ -215,10 +179,6 @@ static void test_init_succeed(void)
 }
 
 static const struct fwk_test_case_desc test_case_table[] = {
-    FWK_TEST_CASE(test_kernel_initialization_failed),
-    FWK_TEST_CASE(test_init_memory_allocation_failed),
-    FWK_TEST_CASE(test_init_common_thread_cb_allocation_failed),
-    FWK_TEST_CASE(test_init_common_thread_stack_allocation_failed),
     FWK_TEST_CASE(test_init_common_thread_failed),
     FWK_TEST_CASE(test_init_succeed),
 };

--- a/framework/test/test_fwk_notification.c
+++ b/framework/test/test_fwk_notification.c
@@ -128,10 +128,6 @@ static void test___fwk_notification_init(void)
     int result;
     size_t notification_count = 4;
 
-    /* Memory allocation failed */
-    fwk_mm_calloc_return_val = false;
-    result = __fwk_notification_init(notification_count);
-    assert(result == FWK_E_NOMEM);
     fwk_mm_calloc_return_val = true;
 
     /* Insert 2 events in the list */

--- a/framework/test/test_fwk_thread.c
+++ b/framework/test/test_fwk_thread.c
@@ -146,10 +146,6 @@ static void test___fwk_thread_init(void)
     int result;
     size_t event_count = 2;
 
-    /* Memory allocation failed */
-    fwk_mm_calloc_return_val = false;
-    result = __fwk_thread_init(event_count);
-    assert(result == FWK_E_NOMEM);
     fwk_mm_calloc_return_val = true;
 
     /* Insert 2 events in the list */

--- a/module/clock/src/mod_clock.c
+++ b/module/clock/src/mod_clock.c
@@ -320,9 +320,6 @@ static int clock_init(fwk_id_t module_id, unsigned int element_count,
     module_ctx.config = config;
     module_ctx.dev_ctx_table = fwk_mm_calloc(element_count,
                                              sizeof(struct clock_dev_ctx));
-    if (module_ctx.dev_ctx_table == NULL)
-        return FWK_E_NOMEM;
-
     return FWK_SUCCESS;
 }
 

--- a/module/cmn600/src/mod_cmn600.c
+++ b/module/cmn600/src/mod_cmn600.c
@@ -556,16 +556,12 @@ static int cmn600_setup(void)
         if (ctx->internal_rnsam_count != 0) {
             ctx->internal_rnsam_table = fwk_mm_calloc(
                 ctx->internal_rnsam_count, sizeof(*ctx->internal_rnsam_table));
-            if (ctx->internal_rnsam_table == NULL)
-                return FWK_E_NOMEM;
         }
 
         /* Tuples for the external RN-RAM nodes (including their node IDs) */
         if (ctx->external_rnsam_count != 0) {
             ctx->external_rnsam_table = fwk_mm_calloc(
                 ctx->external_rnsam_count, sizeof(*ctx->external_rnsam_table));
-            if (ctx->external_rnsam_table == NULL)
-                return FWK_E_NOMEM;
         }
 
         /* Cache groups */
@@ -577,8 +573,6 @@ static int cmn600_setup(void)
             ctx->hnf_cache_group = fwk_mm_calloc(
                 ctx->hnf_count / CMN600_HNF_CACHE_GROUP_ENTRIES_PER_GROUP,
                 sizeof(*ctx->hnf_cache_group));
-            if (ctx->hnf_cache_group == NULL)
-                return FWK_E_NOMEM;
         }
     }
 
@@ -717,8 +711,6 @@ static int cmn600_init(fwk_id_t module_id, unsigned int element_count,
 
     /* Allocate space for the context */
     ctx = fwk_mm_calloc(1, sizeof(*ctx));
-    if (ctx == NULL)
-        return FWK_E_NOMEM;
 
     if (config->base == 0)
         return FWK_E_DATA;

--- a/module/cmn_rhodes/src/mod_cmn_rhodes.c
+++ b/module/cmn_rhodes/src/mod_cmn_rhodes.c
@@ -410,16 +410,12 @@ static int cmn_rhodes_setup(void)
         if (ctx->internal_rnsam_count != 0) {
             ctx->internal_rnsam_table = fwk_mm_calloc(
                 ctx->internal_rnsam_count, sizeof(*ctx->internal_rnsam_table));
-            if (ctx->internal_rnsam_table == NULL)
-                return FWK_E_NOMEM;
         }
 
         /* Tuples for the external RN-RAM nodes (including their node IDs) */
         if (ctx->external_rnsam_count != 0) {
             ctx->external_rnsam_table = fwk_mm_calloc(
                 ctx->external_rnsam_count, sizeof(*ctx->external_rnsam_table));
-            if (ctx->external_rnsam_table == NULL)
-                return FWK_E_NOMEM;
         }
 
         /* Cache groups */
@@ -431,14 +427,10 @@ static int cmn_rhodes_setup(void)
             ctx->hnf_cache_group = fwk_mm_calloc(
                 ctx->hnf_count / CMN_RHODES_HNF_CACHE_GROUP_ENTRIES_PER_GROUP,
                 sizeof(*ctx->hnf_cache_group));
-            if (ctx->hnf_cache_group == NULL)
-                return FWK_E_NOMEM;
             ctx->sn_nodeid_group = fwk_mm_calloc(
                 ctx->hnf_count /
                 CMN_RHODES_RNSAM_SYS_CACHE_GRP_SN_NODEID_ENTRIES_PER_GROUP,
                 sizeof(*ctx->sn_nodeid_group));
-            if (ctx->sn_nodeid_group == NULL)
-                return FWK_E_NOMEM;
         }
     }
 
@@ -499,8 +491,6 @@ static int cmn_rhodes_init(fwk_id_t module_id, unsigned int element_count,
 
     /* Allocate space for the context */
     ctx = fwk_mm_calloc(1, sizeof(*ctx));
-    if (ctx == NULL)
-        return FWK_E_NOMEM;
 
     if (config->base == 0)
         return FWK_E_DATA;

--- a/module/css_clock/src/mod_css_clock.c
+++ b/module/css_clock/src/mod_css_clock.c
@@ -338,9 +338,6 @@ static int css_clock_init(fwk_id_t module_id, unsigned int element_count,
 
     module_ctx.dev_ctx_table = fwk_mm_calloc(element_count,
                                              sizeof(struct css_clock_dev_ctx));
-    if (module_ctx.dev_ctx_table == NULL)
-        return FWK_E_NOMEM;
-
     return FWK_SUCCESS;
 }
 

--- a/module/dvfs/src/mod_dvfs.c
+++ b/module/dvfs/src/mod_dvfs.c
@@ -994,8 +994,6 @@ static int dvfs_init(fwk_id_t module_id, unsigned int element_count,
 {
     dvfs_ctx.domain_ctx = fwk_mm_calloc(element_count,
         sizeof((*dvfs_ctx.domain_ctx)[0]));
-    if (dvfs_ctx.domain_ctx == NULL)
-        return FWK_E_NOMEM;
 
     dvfs_ctx.dvfs_domain_element_count = element_count;
 

--- a/module/dw_apb_i2c/src/mod_dw_apb_i2c.c
+++ b/module/dw_apb_i2c/src/mod_dw_apb_i2c.c
@@ -224,9 +224,6 @@ static int dw_apb_i2c_init(fwk_id_t module_id,
 {
     ctx_table = fwk_mm_calloc(element_count, sizeof(*ctx_table));
 
-    if (ctx_table == NULL)
-        return FWK_E_NOMEM;
-
     return FWK_SUCCESS;
 }
 

--- a/module/gtimer/src/mod_gtimer.c
+++ b/module/gtimer/src/mod_gtimer.c
@@ -166,9 +166,6 @@ static int gtimer_init(fwk_id_t module_id,
 {
     ctx_table = fwk_mm_alloc(element_count, sizeof(struct dev_ctx));
 
-    if (ctx_table == NULL)
-        return FWK_E_NOMEM;
-
     return FWK_SUCCESS;
 }
 

--- a/module/i2c/src/mod_i2c.c
+++ b/module/i2c/src/mod_i2c.c
@@ -206,9 +206,6 @@ static int mod_i2c_init(fwk_id_t module_id,
 {
     ctx_table = fwk_mm_calloc(element_count, sizeof(ctx_table[0]));
 
-    if (ctx_table == NULL)
-        return FWK_E_NOMEM;
-
     return FWK_SUCCESS;
 }
 

--- a/module/mhu/src/mod_mhu.c
+++ b/module/mhu/src/mod_mhu.c
@@ -137,8 +137,6 @@ static int mhu_init(fwk_id_t module_id, unsigned int device_count,
 
     mhu_ctx.device_ctx_table = fwk_mm_calloc(device_count,
         sizeof(mhu_ctx.device_ctx_table[0]));
-    if (mhu_ctx.device_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     mhu_ctx.device_count = device_count;
 
@@ -158,8 +156,6 @@ static int mhu_device_init(fwk_id_t device_id, unsigned int slot_count,
 
     device_ctx->smt_channel_table = fwk_mm_calloc(slot_count,
         sizeof(device_ctx->smt_channel_table[0]));
-    if (device_ctx->smt_channel_table == NULL)
-        return FWK_E_NOMEM;
 
     device_ctx->config = config;
     device_ctx->slot_count = slot_count;

--- a/module/mhu2/src/mod_mhu2.c
+++ b/module/mhu2/src/mod_mhu2.c
@@ -131,11 +131,6 @@ static int mhu2_init(fwk_id_t module_id,
 
     ctx.channel_ctx_table = fwk_mm_calloc(channel_count,
         sizeof(ctx.channel_ctx_table[0]));
-    if (ctx.channel_ctx_table == NULL) {
-        /* Unable to allocate memory for channel context table */
-        assert(false);
-        return FWK_E_NOMEM;
-    }
 
     ctx.channel_count = channel_count;
 
@@ -171,10 +166,6 @@ static int mhu2_channel_init(fwk_id_t channel_id,
 
     channel_ctx->smt_channel_table =
         fwk_mm_calloc(slot_count, sizeof(channel_ctx->smt_channel_table[0]));
-    if (channel_ctx->smt_channel_table == NULL) {
-        assert(false);
-        return FWK_E_NOMEM;
-    }
 
     return FWK_SUCCESS;
 }

--- a/module/mock_psu/src/mod_mock_psu.c
+++ b/module/mock_psu/src/mod_mock_psu.c
@@ -306,8 +306,6 @@ static int mod_mock_psu_init(
 
     mod_mock_psu_ctx.elements =
         fwk_mm_calloc(element_count, sizeof(mod_mock_psu_ctx.elements[0]));
-    if (mod_mock_psu_ctx.elements == NULL)
-        return FWK_E_NOMEM;
 
     return FWK_SUCCESS;
 }

--- a/module/pik_clock/src/mod_pik_clock.c
+++ b/module/pik_clock/src/mod_pik_clock.c
@@ -627,8 +627,6 @@ static int pik_clock_init(fwk_id_t module_id, unsigned int element_count,
 
     module_ctx.dev_ctx_table = fwk_mm_calloc(element_count,
                                              sizeof(struct pik_clock_dev_ctx));
-    if (module_ctx.dev_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     return FWK_SUCCESS;
 }

--- a/module/pl011/src/mod_pl011.c
+++ b/module/pl011/src/mod_pl011.c
@@ -155,8 +155,6 @@ static int pl011_init(fwk_id_t module_id, unsigned int element_count,
         return FWK_E_DATA;
 
     dev_ctx_table = fwk_mm_calloc(element_count, sizeof(dev_ctx_table[0]));
-    if (dev_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     return FWK_SUCCESS;
 }

--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -1640,8 +1640,6 @@ static int pd_init(fwk_id_t module_id, unsigned int dev_count,
         return FWK_E_PARAM;
 
     mod_pd_ctx.pd_ctx_table = fwk_mm_calloc(dev_count, sizeof(struct pd_ctx));
-    if (mod_pd_ctx.pd_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     mod_pd_ctx.pd_count = dev_count;
     mod_pd_ctx.system_pd_ctx = &mod_pd_ctx.pd_ctx_table[dev_count - 1];

--- a/module/ppu_v0/src/mod_ppu_v0.c
+++ b/module/ppu_v0/src/mod_ppu_v0.c
@@ -170,8 +170,6 @@ static int ppu_v0_mod_init(fwk_id_t module_id, unsigned int pd_count,
 {
     ppu_v0_ctx.pd_ctx_table = fwk_mm_calloc(pd_count,
                                             sizeof(struct ppu_v0_pd_ctx));
-    if (ppu_v0_ctx.pd_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     return FWK_SUCCESS;
 }

--- a/module/ppu_v1/src/mod_ppu_v1.c
+++ b/module/ppu_v1/src/mod_ppu_v1.c
@@ -648,8 +648,6 @@ static int ppu_v1_mod_init(fwk_id_t module_id, unsigned int pd_count,
 {
     ppu_v1_ctx.pd_ctx_table = fwk_mm_calloc(pd_count,
                                             sizeof(struct ppu_v1_pd_ctx));
-    if (ppu_v1_ctx.pd_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     ppu_v1_ctx.pd_ctx_table_size = pd_count;
 
@@ -677,8 +675,6 @@ static int ppu_v1_pd_init(fwk_id_t pd_id, unsigned int unused, const void *data)
 
     if (config->pd_type == MOD_PD_TYPE_CLUSTER) {
         pd_ctx->data = fwk_mm_calloc(1, sizeof(struct ppu_v1_cluster_pd_ctx));
-        if (pd_ctx->data == NULL)
-            return FWK_E_NOMEM;
     }
 
     if (config->default_power_on) {

--- a/module/psu/src/mod_psu.c
+++ b/module/psu/src/mod_psu.c
@@ -275,8 +275,6 @@ static int mod_psu_init(
 
     mod_psu_ctx.elements =
         fwk_mm_calloc(element_count, sizeof(mod_psu_ctx.elements[0]));
-    if (mod_psu_ctx.elements == NULL)
-        return FWK_E_NOMEM;
 
     return FWK_SUCCESS;
 }

--- a/module/reg_sensor/src/mod_reg_sensor.c
+++ b/module/reg_sensor/src/mod_reg_sensor.c
@@ -64,9 +64,6 @@ static int reg_sensor_init(fwk_id_t module_id,
 {
     config_table = fwk_mm_alloc(element_count, sizeof(*config_table));
 
-    if (config_table == NULL)
-        return FWK_E_NOMEM;
-
     return FWK_SUCCESS;
 }
 

--- a/module/scmi/src/mod_scmi.c
+++ b/module/scmi/src/mod_scmi.c
@@ -567,13 +567,9 @@ static int scmi_init(fwk_id_t module_id, unsigned int service_count,
     scmi_ctx.protocol_table = fwk_mm_calloc(
         config->protocol_count_max + PROTOCOL_TABLE_RESERVED_ENTRIES_COUNT,
         sizeof(scmi_ctx.protocol_table[0]));
-    if (scmi_ctx.protocol_table == NULL)
-        return FWK_E_NOMEM;
 
     scmi_ctx.service_ctx_table = fwk_mm_calloc(
         service_count, sizeof(scmi_ctx.service_ctx_table[0]));
-    if (scmi_ctx.service_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     scmi_ctx.protocol_table[PROTOCOL_TABLE_BASE_PROTOCOL_IDX].message_handler =
         scmi_base_message_handler;

--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -983,8 +983,6 @@ static int scmi_clock_init(fwk_id_t module_id, unsigned int element_count,
     scmi_clock_ctx.clock_ops =
         fwk_mm_calloc((unsigned int)clock_devices,
         sizeof(struct clock_operations));
-    if (scmi_clock_ctx.clock_ops == NULL)
-        return FWK_E_NOMEM;
 
     /* Initialize table */
     for (unsigned int i = 0; i < (unsigned int)clock_devices; i++)

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -687,8 +687,6 @@ static int scmi_perf_init(fwk_id_t module_id, unsigned int element_count,
 
     scmi_perf_ctx.perf_ops_table = fwk_mm_calloc(return_val,
         sizeof(struct perf_operations));
-    if (scmi_perf_ctx.perf_ops_table == NULL)
-        return FWK_E_NOMEM;
 
     scmi_perf_ctx.config = config;
     scmi_perf_ctx.domain_count = return_val;

--- a/module/scmi_sensor/src/mod_scmi_sensor.c
+++ b/module/scmi_sensor/src/mod_scmi_sensor.c
@@ -468,8 +468,6 @@ static int scmi_sensor_init(fwk_id_t module_id,
     scmi_sensor_ctx.sensor_ops_table =
         fwk_mm_calloc(scmi_sensor_ctx.sensor_count,
         sizeof(struct sensor_operations));
-    if (scmi_sensor_ctx.sensor_ops_table == NULL)
-        return FWK_E_NOMEM;
 
     /* Initialize the service identifier for each sensor to 'available' */
     for (unsigned int i = 0; i < scmi_sensor_ctx.sensor_count; i++)

--- a/module/sensor/src/mod_sensor.c
+++ b/module/sensor/src/mod_sensor.c
@@ -141,9 +141,6 @@ static int sensor_init(fwk_id_t module_id,
 {
     ctx_table = fwk_mm_calloc(element_count, sizeof(ctx_table[0]));
 
-    if (ctx_table == NULL)
-        return FWK_E_NOMEM;
-
     return FWK_SUCCESS;
 }
 

--- a/module/smt/src/mod_smt.c
+++ b/module/smt/src/mod_smt.c
@@ -334,10 +334,6 @@ static int smt_init(fwk_id_t module_id, unsigned int element_count,
 {
     smt_ctx.channel_ctx_table = fwk_mm_calloc(element_count,
         sizeof(smt_ctx.channel_ctx_table[0]));
-    if (smt_ctx.channel_ctx_table == NULL) {
-        assert(false);
-        return FWK_E_NOMEM;
-    }
     smt_ctx.channel_count = element_count;
 
     return FWK_SUCCESS;
@@ -364,17 +360,8 @@ static int smt_channel_init(fwk_id_t channel_id, unsigned int unused,
     channel_ctx->in = fwk_mm_alloc(1, channel_ctx->config->mailbox_size);
     channel_ctx->out = fwk_mm_alloc(1, channel_ctx->config->mailbox_size);
 
-    if ((channel_ctx->in == NULL) || (channel_ctx->out == NULL))
-        return FWK_E_NOMEM;
-
     channel_ctx->max_payload_size = channel_ctx->config->mailbox_size -
         sizeof(struct mod_smt_memory);
-
-    /* Check memory allocations */
-    if ((channel_ctx->in == NULL) || (channel_ctx->out == NULL)) {
-        assert(false);
-        return FWK_E_NOMEM;
-    }
 
     return FWK_SUCCESS;
 }

--- a/module/system_pll/src/mod_system_pll.c
+++ b/module/system_pll/src/mod_system_pll.c
@@ -278,9 +278,6 @@ static int system_pll_init(fwk_id_t module_id, unsigned int element_count,
 
     module_ctx.dev_ctx_table = fwk_mm_calloc(element_count,
                                              sizeof(struct system_pll_dev_ctx));
-    if (module_ctx.dev_ctx_table == NULL)
-        return FWK_E_NOMEM;
-
     return FWK_SUCCESS;
 }
 

--- a/module/system_power/src/mod_system_power.c
+++ b/module/system_power/src/mod_system_power.c
@@ -381,15 +381,11 @@ static int system_power_mod_init(fwk_id_t module_id,
 
     system_power_ctx.dev_ctx_table =
         fwk_mm_calloc(element_count, sizeof(struct system_power_dev_ctx));
-    if (system_power_ctx.dev_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     if (system_power_ctx.config->ext_ppus_count > 0) {
         system_power_ctx.ext_ppu_apis = fwk_mm_calloc(
             system_power_ctx.config->ext_ppus_count,
             sizeof(system_power_ctx.ext_ppu_apis[0]));
-        if (system_power_ctx.ext_ppu_apis == NULL)
-            return FWK_E_NOMEM;
     }
 
     if (system_power_ctx.config->soc_wakeup_irq != FWK_INTERRUPT_NONE) {

--- a/module/timer/src/mod_timer.c
+++ b/module/timer/src/mod_timer.c
@@ -531,9 +531,6 @@ static int timer_init(fwk_id_t module_id,
 {
     ctx_table = fwk_mm_calloc(element_count, sizeof(struct dev_ctx));
 
-    if (ctx_table == NULL)
-        return FWK_E_NOMEM;
-
     return FWK_SUCCESS;
 }
 
@@ -547,13 +544,8 @@ static int timer_device_init(fwk_id_t element_id, unsigned int alarm_count,
     ctx = ctx_table + fwk_id_get_element_idx(element_id);
     ctx->config = data;
 
-    if (alarm_count > 0) {
+    if (alarm_count > 0)
         ctx->alarm_pool = fwk_mm_calloc(alarm_count, sizeof(struct alarm_ctx));
-        if (ctx->alarm_pool == NULL) {
-            assert(false);
-            return FWK_E_NOMEM;
-        }
-    }
 
     return FWK_SUCCESS;
 }

--- a/product/juno/module/juno_cdcel937/src/mod_juno_cdcel937.c
+++ b/product/juno/module/juno_cdcel937/src/mod_juno_cdcel937.c
@@ -846,9 +846,6 @@ static int juno_cdcel937_init(fwk_id_t module_id,
 {
     ctx_table = fwk_mm_calloc(element_count, sizeof(*ctx_table));
 
-    if (ctx_table == NULL)
-        return FWK_E_NOMEM;
-
     module_config = data;
 
     return FWK_SUCCESS;

--- a/product/juno/module/juno_hdlcd/src/mod_juno_hdlcd.c
+++ b/product/juno/module/juno_hdlcd/src/mod_juno_hdlcd.c
@@ -338,9 +338,6 @@ static int juno_hdlcd_init(fwk_id_t module_id,
 {
     ctx_table = fwk_mm_calloc(element_count, sizeof(*ctx_table));
 
-    if (ctx_table == NULL)
-        return FWK_E_NOMEM;
-
     return FWK_SUCCESS;
 }
 

--- a/product/juno/module/juno_ppu/src/mod_juno_ppu.c
+++ b/product/juno/module/juno_ppu/src/mod_juno_ppu.c
@@ -772,8 +772,6 @@ static int juno_ppu_module_init(fwk_id_t module_id,
 
     juno_ppu_ctx.ppu_ctx_table = fwk_mm_calloc(element_count,
         sizeof(struct ppu_ctx));
-    if (juno_ppu_ctx.ppu_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     juno_ppu_ctx.css_state = MOD_PD_STATE_ON;
 

--- a/product/juno/module/juno_pvt/src/mod_juno_pvt.c
+++ b/product/juno/module/juno_pvt/src/mod_juno_pvt.c
@@ -438,8 +438,6 @@ static int juno_pvt_init(fwk_id_t module_id,
         return FWK_E_PARAM;
 
     dev_ctx = fwk_mm_calloc(element_count, sizeof(struct pvt_dev_ctx));
-    if (dev_ctx == NULL)
-        return FWK_E_NOMEM;
 
     status = juno_id_get_platform(&plat);
     if (status != FWK_SUCCESS)
@@ -472,8 +470,6 @@ static int juno_pvt_element_init(fwk_id_t element_id,
 
     group_ctx->sensor_ctx_table =
         fwk_mm_calloc(sub_element_count, sizeof(struct pvt_sub_dev_ctx));
-    if (group_ctx->sensor_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     group_ctx->sensor_cfg_table = (struct mod_juno_pvt_dev_config *)data;
     group_ctx->sensor_read_id = FWK_ID_NONE;

--- a/product/juno/module/juno_soc_clock_ram/src/mod_juno_soc_clock_ram.c
+++ b/product/juno/module/juno_soc_clock_ram/src/mod_juno_soc_clock_ram.c
@@ -525,8 +525,6 @@ static int juno_soc_clock_init(fwk_id_t module_id,
 
     ctx_table = fwk_mm_calloc(element_count,
         sizeof(struct juno_soc_clock_dev_ctx));
-    if (ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     module_ctx.config = data;
 

--- a/product/juno/module/juno_xrp7724/src/mod_juno_xrp7724.c
+++ b/product/juno/module/juno_xrp7724/src/mod_juno_xrp7724.c
@@ -490,8 +490,6 @@ static int juno_xrp7724_init(fwk_id_t module_id,
 
     ctx_table = fwk_mm_calloc(element_count,
         sizeof(struct juno_xrp7724_dev_ctx));
-    if (ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     status = juno_id_get_platform(&platform_id);
     if (!fwk_expect(status == FWK_SUCCESS))

--- a/product/juno/scp_ramfw/config_sensor.c
+++ b/product/juno/scp_ramfw/config_sensor.c
@@ -326,8 +326,6 @@ static const struct fwk_element *get_sensor_element_table(fwk_id_t module_id)
             element_table = fwk_mm_calloc(
                 (sensor_elem_table_size + 1),
                 sizeof(struct fwk_element));
-            if (element_table == NULL)
-                return NULL;
 
             memcpy(element_table,
                    sensor_element_table_r0,
@@ -340,8 +338,6 @@ static const struct fwk_element *get_sensor_element_table(fwk_id_t module_id)
             element_table = fwk_mm_calloc(
                 (sensor_elem_table_size + pvt_sensor_elem_table_size + 1),
                 sizeof(struct fwk_element));
-            if (element_table == NULL)
-                return NULL;
 
             memcpy(element_table,
                    sensor_element_table_r0,

--- a/product/n1sdp/module/n1sdp_flash/src/mod_n1sdp_flash.c
+++ b/product/n1sdp/module/n1sdp_flash/src/mod_n1sdp_flash.c
@@ -149,8 +149,6 @@ static int n1sdp_fip_parse(uintptr_t n1sdp_fip_base)
     n1sdp_flash_ctx.n1sdp_fip_desc_table = fwk_mm_calloc(
         n1sdp_flash_ctx.n1sdp_fip_desc_count,
         sizeof(struct mod_n1sdp_fip_descriptor));
-    if (n1sdp_flash_ctx.n1sdp_fip_desc_table == NULL)
-        return FWK_E_NOMEM;
 
     for (unsigned int i = 0; i < n1sdp_flash_ctx.n1sdp_fip_desc_count; i++) {
         toc_entry = &n1sdp_fip_toc->entry[i];
@@ -212,9 +210,6 @@ static int n1sdp_flash_parse(uintptr_t address, uintptr_t offset)
     n1sdp_flash_ctx.flash_desc_table = fwk_mm_calloc(
         n1sdp_flash_ctx.flash_desc_count,
         sizeof(struct mod_n1sdp_flash_descriptor));
-
-    if (n1sdp_flash_ctx.flash_desc_table == NULL)
-        return FWK_E_NOMEM;
 
     for (unsigned int i = 0; i < n1sdp_flash_ctx.flash_desc_count; ++i) {
         toc_entry = &toc->entry[i];

--- a/product/n1sdp/module/n1sdp_i2c/src/mod_n1sdp_i2c.c
+++ b/product/n1sdp/module/n1sdp_i2c/src/mod_n1sdp_i2c.c
@@ -497,8 +497,6 @@ static int n1sdp_i2c_init(fwk_id_t module_id, unsigned int element_count,
 
     i2c_ctx.device_ctx_table = fwk_mm_calloc(element_count,
         sizeof(i2c_ctx.device_ctx_table[0]));
-    if (i2c_ctx.device_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     return FWK_SUCCESS;
 }

--- a/product/n1sdp/module/n1sdp_mhu/src/mod_mhu.c
+++ b/product/n1sdp/module/n1sdp_mhu/src/mod_mhu.c
@@ -136,8 +136,6 @@ static int mhu_init(fwk_id_t module_id, unsigned int device_count,
 
     mhu_ctx.device_ctx_table = fwk_mm_calloc(device_count,
         sizeof(mhu_ctx.device_ctx_table[0]));
-    if (mhu_ctx.device_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     mhu_ctx.device_count = device_count;
 
@@ -157,8 +155,6 @@ static int mhu_device_init(fwk_id_t device_id, unsigned int slot_count,
 
     device_ctx->smt_channel_table = fwk_mm_calloc(slot_count,
         sizeof(device_ctx->smt_channel_table[0]));
-    if (device_ctx->smt_channel_table == NULL)
-        return FWK_E_NOMEM;
 
     device_ctx->config = config;
     device_ctx->slot_count = slot_count;

--- a/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
+++ b/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
@@ -621,8 +621,6 @@ static int n1sdp_pcie_init(fwk_id_t module_id, unsigned int element_count,
 
     pcie_ctx.device_ctx_table = fwk_mm_calloc(element_count,
         sizeof(pcie_ctx.device_ctx_table[0]));
-    if (pcie_ctx.device_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     pcie_ctx.pcie_instance_count = element_count;
 

--- a/product/n1sdp/module/n1sdp_pll/src/mod_n1sdp_pll.c
+++ b/product/n1sdp/module/n1sdp_pll/src/mod_n1sdp_pll.c
@@ -272,8 +272,6 @@ static int n1sdp_pll_init(fwk_id_t module_id, unsigned int element_count,
 
     module_ctx.dev_ctx_table = fwk_mm_calloc(element_count,
                                              sizeof(struct n1sdp_pll_dev_ctx));
-    if (module_ctx.dev_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     module_ctx.mod_config = config;
     /* Validate custom frequency table entries */

--- a/product/n1sdp/module/n1sdp_remote_pd/src/mod_n1sdp_remote_pd.c
+++ b/product/n1sdp/module/n1sdp_remote_pd/src/mod_n1sdp_remote_pd.c
@@ -179,8 +179,6 @@ static int remote_pd_init(fwk_id_t module_id, unsigned int device_count,
 
     remote_pd_ctx.dev_ctx_table = fwk_mm_calloc(device_count,
         sizeof(remote_pd_ctx.dev_ctx_table[0]));
-    if (remote_pd_ctx.dev_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     remote_pd_ctx.pd_count = device_count;
 

--- a/product/n1sdp/module/n1sdp_smt/src/mod_smt.c
+++ b/product/n1sdp/module/n1sdp_smt/src/mod_smt.c
@@ -351,10 +351,6 @@ static int smt_init(fwk_id_t module_id, unsigned int element_count,
 {
     smt_ctx.channel_ctx_table = fwk_mm_calloc(element_count,
         sizeof(smt_ctx.channel_ctx_table[0]));
-    if (smt_ctx.channel_ctx_table == NULL) {
-        assert(false);
-        return FWK_E_NOMEM;
-    }
     smt_ctx.channel_count = element_count;
 
     return FWK_SUCCESS;
@@ -381,17 +377,8 @@ static int smt_channel_init(fwk_id_t channel_id, unsigned int unused,
     channel_ctx->in = fwk_mm_alloc(1, channel_ctx->config->mailbox_size);
     channel_ctx->out = fwk_mm_alloc(1, channel_ctx->config->mailbox_size);
 
-    if ((channel_ctx->in == NULL) || (channel_ctx->out == NULL))
-        return FWK_E_NOMEM;
-
     channel_ctx->max_payload_size = channel_ctx->config->mailbox_size -
         sizeof(struct mod_smt_memory);
-
-    /* Check memory allocations */
-    if ((channel_ctx->in == NULL) || (channel_ctx->out == NULL)) {
-        assert(false);
-        return FWK_E_NOMEM;
-    }
 
     return FWK_SUCCESS;
 }

--- a/product/n1sdp/module/n1sdp_timer_sync/src/mod_n1sdp_timer_sync.c
+++ b/product/n1sdp/module/n1sdp_timer_sync/src/mod_n1sdp_timer_sync.c
@@ -186,8 +186,6 @@ static int n1sdp_timer_sync_init(fwk_id_t module_id, unsigned int device_count,
 
     tsync_ctx.device_ctx_table = fwk_mm_calloc(device_count,
         sizeof(tsync_ctx.device_ctx_table[0]));
-    if (tsync_ctx.device_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     return FWK_SUCCESS;
 }

--- a/product/n1sdp/module/scmi_agent/src/mod_scmi_agent.c
+++ b/product/n1sdp/module/scmi_agent/src/mod_scmi_agent.c
@@ -183,8 +183,6 @@ static int scmi_agent_init(fwk_id_t module_id, unsigned int agent_count,
 {
     ctx.agent_ctx_table = fwk_mm_calloc(agent_count,
                                         sizeof(ctx.agent_ctx_table[0]));
-    if (ctx.agent_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     return FWK_SUCCESS;
 }

--- a/product/n1sdp/scp_ramfw/config_ppu_v1.c
+++ b/product/n1sdp/scp_ramfw/config_ppu_v1.c
@@ -84,13 +84,9 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
     element_table = fwk_mm_calloc(core_count + cluster_count +
         FWK_ARRAY_SIZE(ppu_v1_system_element_table) + 1,
         sizeof(struct fwk_element));
-    if (element_table == NULL)
-        return NULL;
 
     pd_config_table = fwk_mm_calloc(core_count + cluster_count,
                                     sizeof(struct mod_ppu_v1_pd_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     for (cluster_idx = 0; cluster_idx < cluster_count; cluster_idx++) {
         for (core_idx = 0;
@@ -100,8 +96,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
             pd_config = &pd_config_table[core_element_count];
 
             element->name = fwk_mm_alloc(PPU_CORE_NAME_SIZE, 1);
-            if (element->name == NULL)
-                return NULL;
 
             snprintf((char *)element->name, PPU_CORE_NAME_SIZE, "CLUS%uCORE%u",
                 (uint8_t)cluster_idx, (uint8_t)core_idx);
@@ -122,8 +116,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
         pd_config = &pd_config_table[core_count + cluster_idx];
 
         element->name = fwk_mm_alloc(PPU_CLUS_NAME_SIZE, 1);
-        if (element->name == NULL)
-            return NULL;
 
         snprintf((char *)element->name, PPU_CLUS_NAME_SIZE, "CLUS%u",
             (uint8_t)cluster_idx);

--- a/product/rddaniel/scp_ramfw/config_power_domain.c
+++ b/product/rddaniel/scp_ramfw/config_power_domain.c
@@ -311,13 +311,9 @@ static const struct fwk_element *rddaniel_power_domain_get_element_table
         + FWK_ARRAY_SIZE(rddaniel_power_domain_static_element_table)
         + 1, /* Terminator */
         sizeof(struct fwk_element));
-    if (element_table == NULL)
-        return NULL;
 
     pd_config_table = fwk_mm_calloc(core_count,
         sizeof(struct mod_power_domain_element_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     for (cluster_idx = 0; cluster_idx < cluster_count; cluster_idx++) {
         for (core_idx = 0;
@@ -328,8 +324,6 @@ static const struct fwk_element *rddaniel_power_domain_get_element_table
             pd_config = &pd_config_table[core_element_count];
 
             element->name = fwk_mm_alloc(PD_NAME_SIZE, 1);
-            if (element->name == NULL)
-                return NULL;
 
             snprintf((char *)element->name, PD_NAME_SIZE, "CLUS%uCORE%u",
                 cluster_idx, core_idx);

--- a/product/rddaniel/scp_ramfw/config_ppu_v1.c
+++ b/product/rddaniel/scp_ramfw/config_ppu_v1.c
@@ -75,13 +75,9 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
     element_table = fwk_mm_calloc(core_count + cluster_count +
         FWK_ARRAY_SIZE(ppu_v1_system_element_table) + 1,
         sizeof(struct fwk_element));
-    if (element_table == NULL)
-        return NULL;
 
     pd_config_table = fwk_mm_calloc(core_count + cluster_count,
                                     sizeof(struct mod_ppu_v1_pd_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     for (cluster_idx = 0; cluster_idx < cluster_count; cluster_idx++) {
         for (core_idx = 0;
@@ -91,8 +87,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
             pd_config = &pd_config_table[core_element_count];
 
             element->name = fwk_mm_alloc(PPU_CORE_NAME_SIZE, 1);
-            if (element->name == NULL)
-                return NULL;
 
             snprintf((char *)element->name, PPU_CORE_NAME_SIZE, "CLUS%uCORE%u",
                 cluster_idx, core_idx);
@@ -113,8 +107,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
         pd_config = &pd_config_table[core_count + cluster_idx];
 
         element->name = fwk_mm_alloc(PPU_CLUS_NAME_SIZE, 1);
-        if (element->name == NULL)
-            return NULL;
 
         snprintf((char *)element->name, PPU_CLUS_NAME_SIZE, "CLUS%u",
             cluster_idx);

--- a/product/rdn1e1/scp_ramfw/config_power_domain.c
+++ b/product/rdn1e1/scp_ramfw/config_power_domain.c
@@ -153,13 +153,9 @@ static const struct fwk_element *rdn1e1_power_domain_get_element_table
         + FWK_ARRAY_SIZE(rdn1e1_power_domain_static_element_table)
         + 1, /* Terminator */
         sizeof(struct fwk_element));
-    if (element_table == NULL)
-        return NULL;
 
     pd_config_table = fwk_mm_calloc(core_count,
         sizeof(struct mod_power_domain_element_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     for (cluster_idx = 0; cluster_idx < cluster_count; cluster_idx++) {
         for (core_idx = 0;
@@ -170,8 +166,6 @@ static const struct fwk_element *rdn1e1_power_domain_get_element_table
             pd_config = &pd_config_table[core_element_count];
 
             element->name = fwk_mm_alloc(PD_NAME_SIZE, 1);
-            if (element->name == NULL)
-                return NULL;
 
             snprintf((char *)element->name, PD_NAME_SIZE, "CLUS%uCORE%u",
                 cluster_idx, core_idx);

--- a/product/rdn1e1/scp_ramfw/config_ppu_v1.c
+++ b/product/rdn1e1/scp_ramfw/config_ppu_v1.c
@@ -81,13 +81,9 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
     element_table = fwk_mm_calloc(core_count + cluster_count +
         FWK_ARRAY_SIZE(ppu_v1_system_element_table) + 1,
         sizeof(struct fwk_element));
-    if (element_table == NULL)
-        return NULL;
 
     pd_config_table = fwk_mm_calloc(core_count + cluster_count,
                                     sizeof(struct mod_ppu_v1_pd_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     for (cluster_idx = 0; cluster_idx < cluster_count; cluster_idx++) {
         for (core_idx = 0;
@@ -97,8 +93,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
             pd_config = &pd_config_table[core_element_count];
 
             element->name = fwk_mm_alloc(PPU_CORE_NAME_SIZE, 1);
-            if (element->name == NULL)
-                return NULL;
 
             snprintf((char *)element->name, PPU_CORE_NAME_SIZE, "CLUS%uCORE%u",
                 cluster_idx, core_idx);
@@ -119,8 +113,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
         pd_config = &pd_config_table[core_count + cluster_idx];
 
         element->name = fwk_mm_alloc(PPU_CLUS_NAME_SIZE, 1);
-        if (element->name == NULL)
-            return NULL;
 
         snprintf((char *)element->name, PPU_CLUS_NAME_SIZE, "CLUS%u",
             cluster_idx);

--- a/product/sgi575/scp_ramfw/config_power_domain.c
+++ b/product/sgi575/scp_ramfw/config_power_domain.c
@@ -157,8 +157,6 @@ static const struct fwk_element *sgi575_power_domain_get_element_table
 
     pd_config_table = fwk_mm_calloc(core_count,
         sizeof(struct mod_power_domain_element_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     for (cluster_idx = 0; cluster_idx < cluster_count; cluster_idx++) {
         for (core_idx = 0;
@@ -169,8 +167,6 @@ static const struct fwk_element *sgi575_power_domain_get_element_table
             pd_config = &pd_config_table[core_element_count];
 
             element->name = fwk_mm_alloc(PD_NAME_SIZE, 1);
-            if (element->name == NULL)
-                return NULL;
 
             snprintf((char *)element->name, PD_NAME_SIZE, "CLUS%uCORE%u",
                 cluster_idx, core_idx);

--- a/product/sgi575/scp_ramfw/config_ppu_v1.c
+++ b/product/sgi575/scp_ramfw/config_ppu_v1.c
@@ -81,13 +81,9 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
     element_table = fwk_mm_calloc(core_count + cluster_count +
         FWK_ARRAY_SIZE(ppu_v1_system_element_table) + 1,
         sizeof(struct fwk_element));
-    if (element_table == NULL)
-        return NULL;
 
     pd_config_table = fwk_mm_calloc(core_count + cluster_count,
                                     sizeof(struct mod_ppu_v1_pd_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     for (cluster_idx = 0; cluster_idx < cluster_count; cluster_idx++) {
         for (core_idx = 0;
@@ -97,8 +93,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
             pd_config = &pd_config_table[core_element_count];
 
             element->name = fwk_mm_alloc(PPU_CORE_NAME_SIZE, 1);
-            if (element->name == NULL)
-                return NULL;
 
             snprintf((char *)element->name, PPU_CORE_NAME_SIZE, "CLUS%uCORE%u",
                 cluster_idx, core_idx);
@@ -119,8 +113,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
         pd_config = &pd_config_table[core_count + cluster_idx];
 
         element->name = fwk_mm_alloc(PPU_CLUS_NAME_SIZE, 1);
-        if (element->name == NULL)
-            return NULL;
 
         snprintf((char *)element->name, PPU_CLUS_NAME_SIZE, "CLUS%u",
             cluster_idx);

--- a/product/sgm775/scp_ramfw/config_power_domain.c
+++ b/product/sgm775/scp_ramfw/config_power_domain.c
@@ -208,13 +208,9 @@ static const struct fwk_element *sgm775_power_domain_get_element_table
         + FWK_ARRAY_SIZE(sgm775_power_domain_static_element_table)
         + 1, /* Terminator */
         sizeof(struct fwk_element));
-    if (element_table == NULL)
-        return NULL;
 
     pd_config_table = fwk_mm_calloc(sgm775_core_get_count(),
         sizeof(struct mod_power_domain_element_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     for (core_idx = 0; core_idx < sgm775_core_get_count(); core_idx++) {
         element = &element_table[core_idx];

--- a/product/sgm775/scp_ramfw/config_ppu_v1.c
+++ b/product/sgm775/scp_ramfw/config_ppu_v1.c
@@ -55,13 +55,9 @@ static const struct fwk_element *sgm775_ppu_v1_get_element_table
      */
     element_table = fwk_mm_calloc(sgm775_core_get_count() + 2,
                                   sizeof(struct fwk_element));
-    if (element_table == NULL)
-        return NULL;
 
     pd_config_table = fwk_mm_calloc(sgm775_core_get_count() + 1,
                                     sizeof(struct mod_ppu_v1_pd_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     for (core_idx = 0; core_idx < sgm775_core_get_count(); core_idx++) {
         element = &element_table[core_idx];

--- a/product/sgm776/scp_ramfw/config_power_domain.c
+++ b/product/sgm776/scp_ramfw/config_power_domain.c
@@ -195,13 +195,9 @@ static const struct fwk_element *sgm776_power_domain_get_element_table
         + FWK_ARRAY_SIZE(sgm776_power_domain_static_element_table)
         + 1, /* Terminator */
         sizeof(struct fwk_element));
-    if (element_table == NULL)
-        return NULL;
 
     pd_config_table = fwk_mm_calloc(sgm776_core_get_count(),
         sizeof(struct mod_power_domain_element_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     for (core_idx = 0; core_idx < sgm776_core_get_count(); core_idx++) {
         element = &element_table[core_idx];

--- a/product/sgm776/scp_ramfw/config_ppu_v1.c
+++ b/product/sgm776/scp_ramfw/config_ppu_v1.c
@@ -119,14 +119,10 @@ static const struct fwk_element *sgm776_ppu_v1_get_element_table(
      */
     table_size = FWK_ARRAY_SIZE(static_ppu_table) + sgm776_core_get_count() + 2;
     element_table = fwk_mm_calloc(table_size, sizeof(struct fwk_element));
-    if (element_table == NULL)
-        return NULL;
 
     /* Table to hold configs for all cores and the cluster */
     pd_config_table = fwk_mm_calloc(sgm776_core_get_count() + 1,
                                     sizeof(struct mod_ppu_v1_pd_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     /* Cores */
     for (core_idx = 0; core_idx < sgm776_core_get_count(); core_idx++) {

--- a/product/synquacer/module/f_uart3/src/mod_f_uart3.c
+++ b/product/synquacer/module/f_uart3/src/mod_f_uart3.c
@@ -134,8 +134,6 @@ static int f_uart3_init(
      */
     device_config_table =
         fwk_mm_calloc(element_count, sizeof(*device_config_table));
-    if (device_config_table == NULL)
-        return FWK_E_NOMEM;
 
     return FWK_SUCCESS;
 }

--- a/product/synquacer/module/ppu_v0_synquacer/src/mod_ppu_v0.c
+++ b/product/synquacer/module/ppu_v0_synquacer/src/mod_ppu_v0.c
@@ -226,8 +226,6 @@ static int ppu_v0_mod_init(
 {
     ppu_v0_ctx.pd_ctx_table =
         fwk_mm_calloc(pd_count, sizeof(struct ppu_v0_pd_ctx));
-    if (ppu_v0_ctx.pd_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     return FWK_SUCCESS;
 }

--- a/product/synquacer/module/synquacer_pik_clock/src/mod_synquacer_pik_clock.c
+++ b/product/synquacer/module/synquacer_pik_clock/src/mod_synquacer_pik_clock.c
@@ -649,8 +649,6 @@ static int pik_clock_init(
 
     module_ctx.dev_ctx_table =
         fwk_mm_calloc(element_count, sizeof(struct pik_clock_dev_ctx));
-    if (module_ctx.dev_ctx_table == NULL)
-        return FWK_E_NOMEM;
 
     return FWK_SUCCESS;
 }

--- a/product/synquacer/scp_ramfw/config_power_domain.c
+++ b/product/synquacer/scp_ramfw/config_power_domain.c
@@ -147,14 +147,10 @@ static const struct fwk_element *synquacer_power_domain_get_element_table(
             FWK_ARRAY_SIZE(synquacer_power_domain_static_element_table) +
             1, /* Terminator */
         sizeof(struct fwk_element));
-    if (element_table == NULL)
-        return NULL;
 
     pd_config_table = fwk_mm_calloc(
         (cluster_count + core_count),
         sizeof(struct mod_power_domain_element_config));
-    if (pd_config_table == NULL)
-        return NULL;
 
     /*
      * power domain element table should follow the ascending order
@@ -169,8 +165,6 @@ static const struct fwk_element *synquacer_power_domain_get_element_table(
             pd_config = &pd_config_table[element_count];
 
             element->name = fwk_mm_alloc(PD_NAME_SIZE, 1);
-            if (element->name == NULL)
-                return NULL;
 
             snprintf(
                 (char *)element->name,
@@ -201,8 +195,6 @@ static const struct fwk_element *synquacer_power_domain_get_element_table(
         pd_config = &pd_config_table[element_count];
 
         element->name = fwk_mm_alloc(PD_NAME_SIZE, 1);
-        if (element->name == NULL)
-            return NULL;
 
         snprintf((char *)element->name, PD_NAME_SIZE, "CLUS%u", cluster_idx);
 

--- a/product/synquacer/scp_ramfw/config_ppu_v0_synquacer.c
+++ b/product/synquacer/scp_ramfw/config_ppu_v0_synquacer.c
@@ -92,8 +92,6 @@ static const struct fwk_element *ppu_v0_get_element_table(fwk_id_t module_id)
 
     ppu_v0_config_table = fwk_mm_calloc(
         (cluster_count + core_count), sizeof(struct mod_ppu_v0_pd_config));
-    if (ppu_v0_config_table == NULL)
-        return NULL;
 
     element_count = 0;
 
@@ -104,8 +102,6 @@ static const struct fwk_element *ppu_v0_get_element_table(fwk_id_t module_id)
             ppu_v0_config = &ppu_v0_config_table[element_count];
 
             element->name = fwk_mm_alloc(PPU_V0_NAME_SIZE, 1);
-            if (element->name == NULL)
-                return NULL;
 
             snprintf(
                 (char *)element->name,
@@ -130,8 +126,6 @@ static const struct fwk_element *ppu_v0_get_element_table(fwk_id_t module_id)
 
         /* prepare cluster config table */
         element->name = fwk_mm_alloc(PPU_V0_NAME_SIZE, 1);
-        if (element->name == NULL)
-            return NULL;
 
         snprintf(
             (char *)element->name, PPU_V0_NAME_SIZE, "CLUS%u", cluster_idx);


### PR DESCRIPTION
Currently the framework will return NULL if the memory allocation
fails. As the system will ultimately fail on receiving the error
we could just panic instead, saving the memory used for the NULL
checks.

Change-Id: I731b87b7acb19d30df84936b07c76cbfe0d0726e
Signed-off-by: Jim Quigley <jim.quigley@arm.com>