### PR TITLE
juno: Remove -Os/-flto for debug mode

### DIFF
--- a/tools/build_system/rules.mk
+++ b/tools/build_system/rules.mk
@@ -44,16 +44,7 @@ endif
 # GCC-specific optimization levels for debug and release modes
 #
 
-ifeq ($(PRODUCT)-$(FIRMWARE),juno-scp_ramfw)
-    # Enable link-time optimization
-    CFLAGS_GCC += -flto
-    LDFLAGS_GCC += -Wl,-flto
-
-    DEFAULT_OPT_GCC_DEBUG := s
-else
-    DEFAULT_OPT_GCC_DEBUG := g
-endif
-
+DEFAULT_OPT_GCC_DEBUG := g
 DEFAULT_OPT_GCC_RELEASE := 2
 
 #


### PR DESCRIPTION
New adjustments to the maximum size of the SCP_BL2 image in Trusted
Firmware-A means we now have far greater room for expansion.

Change-Id: I9bc4791e5a2347f2d30bdcb3a482b5a3e6801e0a
Signed-off-by: Chris Kay <chris.kay@arm.com>