### PR TITLE
DVFS: Event processing returns incorrect status

### DIFF
--- a/module/dvfs/src/mod_dvfs.c
+++ b/module/dvfs/src/mod_dvfs.c
@@ -885,8 +885,11 @@ static int mod_dvfs_process_event(const struct fwk_event *event,
         /*
          * Handle get_voltage() synchronously
          */
-        return dvfs_handle_psu_get_voltage_resp(ctx,
+        status = dvfs_handle_psu_get_voltage_resp(ctx,
             resp_event, status, ctx->request.new_opp.voltage);
+        if (status == FWK_PENDING)
+            return FWK_SUCCESS;
+        return status;
     }
 
     /*
@@ -906,8 +909,11 @@ static int mod_dvfs_process_event(const struct fwk_event *event,
         /*
          * Handle get_voltage() synchronously
          */
-        return dvfs_handle_psu_get_voltage_resp(ctx, NULL,
+        status = dvfs_handle_psu_get_voltage_resp(ctx, NULL,
             status, voltage);
+        if (status == FWK_PENDING)
+            return FWK_SUCCESS;
+        return status;
     }
 
     /*
@@ -933,8 +939,11 @@ static int mod_dvfs_process_event(const struct fwk_event *event,
          * above so we can safely discard the resp_event.
          */
         psu_response = (struct mod_psu_driver_response *)event->params;
-        return dvfs_handle_psu_get_voltage_resp(ctx, NULL,
+        status = dvfs_handle_psu_get_voltage_resp(ctx, NULL,
             psu_response->status, psu_response->voltage);
+        if (status == FWK_PENDING)
+            return FWK_SUCCESS;
+        return status;
     }
 
     /*
@@ -945,7 +954,10 @@ static int mod_dvfs_process_event(const struct fwk_event *event,
          * Handle set_voltage() asynchronously, no response required for
          * a SET_OPP() request so resp_event discarded.
          */
-        return dvfs_handle_psu_set_voltage_resp(ctx, event);
+        status = dvfs_handle_psu_set_voltage_resp(ctx, event);
+        if (status == FWK_PENDING)
+            return FWK_SUCCESS;
+        return status;
     }
 
     /*
@@ -956,7 +968,10 @@ static int mod_dvfs_process_event(const struct fwk_event *event,
          * Handle set_frequency() asynchronously, no response required for
          * a SET_OPP() request so resp_event discarded.
          */
-        return dvfs_handle_clk_set_freq_resp(ctx, event);
+        status = dvfs_handle_clk_set_freq_resp(ctx, event);
+        if (status == FWK_PENDING)
+            return FWK_SUCCESS;
+        return status;
     }
 
     return FWK_E_PARAM;


### PR DESCRIPTION
FWK_PENDING should be returned as FWK_SUCCESS from the
event handler.

Change-Id: Ibb56750f79d3b4f2f6ca82e655667f140563eede
Signed-off-by: Jim Quigley <jim.quigley@arm.com>