### PR TITLE
scmi: Add extended logs

### DIFF
--- a/module/scmi/include/internal/mod_scmi.h
+++ b/module/scmi/include/internal/mod_scmi.h
@@ -53,6 +53,9 @@ struct scmi_service_ctx {
     /* Copy of the pointer to the 'respond' function within the transport API */
     int (*respond)(fwk_id_t transport_id, const void *payload, size_t size);
 
+    /* SCMI message token, used by the agent to identify individual messages */
+    uint16_t scmi_token;
+
     /* SCMI identifier of the protocol processing the current message */
     unsigned int scmi_protocol_id;
 

--- a/product/juno/scp_ramfw/config_scmi.c
+++ b/product/juno/scp_ramfw/config_scmi.c
@@ -33,7 +33,7 @@ static const struct fwk_element element_table[] = {
     },
 
     [JUNO_SCMI_SERVICE_IDX_OSPM_0] = {
-        .name = "OSPM 0",
+        .name = "OSPM-0",
         .data = &(struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(
                 FWK_MODULE_IDX_SMT,
@@ -49,7 +49,7 @@ static const struct fwk_element element_table[] = {
     },
 
     [JUNO_SCMI_SERVICE_IDX_OSPM_1] = {
-        .name = "OSPM 1",
+        .name = "OSPM-1",
         .data = &(struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(
                 FWK_MODULE_IDX_SMT,

--- a/product/rdn1e1/scp_ramfw/config_scmi.c
+++ b/product/rdn1e1/scp_ramfw/config_scmi.c
@@ -17,7 +17,7 @@
 
 static const struct fwk_element service_table[] = {
     [SCP_RDN1E1_SCMI_SERVICE_IDX_PSCI] = {
-        .name = "SERVICE0",
+        .name = "PSCI",
         .data = &((struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(
                 FWK_MODULE_IDX_SMT,
@@ -32,7 +32,7 @@ static const struct fwk_element service_table[] = {
         }),
     },
     [SCP_RDN1E1_SCMI_SERVICE_IDX_OSPM] = {
-        .name = "SERVICE1",
+        .name = "OSPM",
         .data = &((struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(
                 FWK_MODULE_IDX_SMT,

--- a/product/sgi575/scp_ramfw/config_scmi.c
+++ b/product/sgi575/scp_ramfw/config_scmi.c
@@ -17,7 +17,7 @@
 
 static const struct fwk_element service_table[] = {
     [SCP_SGI575_SCMI_SERVICE_IDX_PSCI] = {
-        .name = "SERVICE0",
+        .name = "PSCI",
         .data = &((struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(
                 FWK_MODULE_IDX_SMT,
@@ -32,7 +32,7 @@ static const struct fwk_element service_table[] = {
         }),
     },
     [SCP_SGI575_SCMI_SERVICE_IDX_OSPM] = {
-        .name = "SERVICE1",
+        .name = "OSPM",
         .data = &((struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(
                 FWK_MODULE_IDX_SMT,

--- a/product/sgm775/scp_ramfw/config_scmi.c
+++ b/product/sgm775/scp_ramfw/config_scmi.c
@@ -17,7 +17,7 @@
 
 static const struct fwk_element service_table[] = {
     [SGM775_SCMI_SERVICE_IDX_PSCI] = {
-        .name = "SERVICE0",
+        .name = "PSCI",
         .data = &((struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_SMT,
                                                 SGM775_SCMI_SERVICE_IDX_PSCI),
@@ -30,7 +30,7 @@ static const struct fwk_element service_table[] = {
         }),
     },
     [SGM775_SCMI_SERVICE_IDX_OSPM_0] = {
-        .name = "SERVICE1",
+        .name = "OSPM-0",
         .data = &((struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_SMT,
                                                 SGM775_SCMI_SERVICE_IDX_OSPM_0),
@@ -43,7 +43,7 @@ static const struct fwk_element service_table[] = {
         }),
     },
     [SGM775_SCMI_SERVICE_IDX_OSPM_1] = {
-        .name = "SERVICE2",
+        .name = "OSPM-1",
         .data = &((struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_SMT,
                                                 SGM775_SCMI_SERVICE_IDX_OSPM_1),

--- a/product/sgm776/scp_ramfw/config_scmi.c
+++ b/product/sgm776/scp_ramfw/config_scmi.c
@@ -17,7 +17,7 @@
 
 static const struct fwk_element service_table[] = {
     [SGM776_SCMI_SERVICE_IDX_PSCI] = {
-        .name = "SERVICE0",
+        .name = "PSCI",
         .data = &((struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_SMT,
                                                 SGM776_SCMI_SERVICE_IDX_PSCI),
@@ -30,7 +30,7 @@ static const struct fwk_element service_table[] = {
         }),
     },
     [SGM776_SCMI_SERVICE_IDX_OSPM_0] = {
-        .name = "SERVICE1",
+        .name = "OSPM-0",
         .data = &((struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_SMT,
                                                 SGM776_SCMI_SERVICE_IDX_OSPM_0),
@@ -43,7 +43,7 @@ static const struct fwk_element service_table[] = {
         }),
     },
     [SGM776_SCMI_SERVICE_IDX_OSPM_1] = {
-        .name = "SERVICE2",
+        .name = "OSPM-1",
         .data = &((struct mod_scmi_service_config) {
             .transport_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_SMT,
                                                 SGM776_SCMI_SERVICE_IDX_OSPM_1),


### PR DESCRIPTION
This commit expands the detail of the log output of the SCMI module in
order to aid in debugging. Details that were previously missing,
including the message token and the service name, are now included.

Change-Id: I00075b3e4474328f27dc7f6be5b0df21c18c0cfb
Signed-off-by: Chris Kay <chris.kay@arm.com>