### PR TITLE
ci: Add -j flag

### DIFF
--- a/tools/ci.py
+++ b/tools/ci.py
@@ -50,21 +50,21 @@ def main():
     cmd = \
         'CC=gcc ' \
         'BS_FIRMWARE_CPU=host ' \
-        'make clean lib-framework'
+        'make clean lib-framework -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Framework build (Host, GCC)', result))
 
     cmd = \
         'CC=arm-none-eabi-gcc ' \
         'BS_FIRMWARE_CPU=cortex-m3 ' \
-        'make clean lib-framework'
+        'make clean lib-framework -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Framework build (Cortex-M3, GCC)', result))
 
     cmd = \
         'CC=armclang ' \
         'BS_FIRMWARE_CPU=cortex-m3 ' \
-        'make clean lib-framework'
+        'make clean lib-framework -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Framework build (Cortex-M3, ARM)', result))
 
@@ -73,14 +73,14 @@ def main():
     cmd = \
         'CC=arm-none-eabi-gcc ' \
         'BS_FIRMWARE_CPU=cortex-m3 ' \
-        'make clean lib-arch'
+        'make clean lib-arch -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Arch build (Cortex-M3, GCC)', result))
 
     cmd = \
         'CC=armclang ' \
         'BS_FIRMWARE_CPU=cortex-m3 ' \
-        'make clean lib-arch'
+        'make clean lib-arch -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Arch build (Cortex-M3, ARM)', result))
 
@@ -89,7 +89,7 @@ def main():
     cmd = \
         'CC=gcc ' \
         'PRODUCT=host ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product host build (GCC)', result))
 
@@ -99,7 +99,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=sgm775 ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgm775 release build (GCC)', result))
 
@@ -107,7 +107,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=sgm775 ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgm775 release build (ARM)', result))
 
@@ -115,7 +115,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=sgm775 ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgm775 debug build (GCC)', result))
 
@@ -123,7 +123,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=sgm775 ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgm775 debug build (ARM)', result))
 
@@ -133,7 +133,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=sgi575 ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgi575 release build (GCC)', result))
 
@@ -141,7 +141,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=sgi575 ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgi575 release build (ARM)', result))
 
@@ -149,7 +149,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=sgi575 ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgi575 debug build (GCC)', result))
 
@@ -157,7 +157,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=sgi575 ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgi575 debug build (ARM)', result))
 
@@ -167,7 +167,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=n1sdp ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product n1sdp debug build (GCC)', result))
 
@@ -175,7 +175,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=n1sdp ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product n1sdp debug build (ARM)', result))
 
@@ -183,7 +183,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=n1sdp ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product n1sdp release build (GCC)', result))
 
@@ -191,7 +191,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=n1sdp ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product n1sdp release build (ARM)', result))
 
@@ -201,7 +201,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=rdn1e1 ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product rdn1e1 release build (GCC)', result))
 
@@ -209,7 +209,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=rdn1e1 ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product rdn1e1 release build (ARM)', result))
 
@@ -217,7 +217,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=rdn1e1 ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product rdn1e1 debug build (GCC)', result))
 
@@ -225,7 +225,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=rdn1e1 ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product rdn1e1 debug build (ARM)', result))
 
@@ -235,7 +235,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=juno ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product Juno debug build (GCC)', result))
 
@@ -243,7 +243,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=juno ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product Juno debug build (ARM)', result))
 
@@ -251,7 +251,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=juno ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product Juno release build (GCC)', result))
 
@@ -259,7 +259,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=juno ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product Juno release build (ARM)', result))
 
@@ -269,7 +269,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=synquacer ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product synquacer release build (GCC)', result))
 
@@ -277,7 +277,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=synquacer ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product synquacer release build (ARM)', result))
 
@@ -285,7 +285,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=synquacer ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product synquacer debug build (GCC)', result))
 
@@ -293,7 +293,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=synquacer ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product synquacer debug build (ARM)', result))
 
@@ -303,7 +303,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=sgm776 ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgm776 release build (GCC)', result))
 
@@ -311,7 +311,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=sgm776 ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgm776 release build (ARM)', result))
 
@@ -319,7 +319,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=sgm776 ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgm776 debug build (GCC)', result))
 
@@ -327,7 +327,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=sgm776 ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product sgm776 debug build (ARM)', result))
 
@@ -337,7 +337,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=rddaniel ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product rddaniel release build (GCC)', result))
 
@@ -345,7 +345,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=rddaniel ' \
         'MODE=release ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product rddaniel release build (ARM)', result))
 
@@ -353,7 +353,7 @@ def main():
         'CC=arm-none-eabi-gcc ' \
         'PRODUCT=rddaniel ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product rddaniel debug build (GCC)', result))
 
@@ -361,7 +361,7 @@ def main():
         'CC=armclang ' \
         'PRODUCT=rddaniel ' \
         'MODE=debug ' \
-        'make clean all'
+        'make clean all -j'
     result = subprocess.call(cmd, shell=True)
     results.append(('Product rddaniel debug build (ARM)', result))
 


### PR DESCRIPTION
This patch is adding the -j flag when invoking
make to speed-up the compilation for all the
platforms.

Change-Id: Iad430b18380de895c645bf59104d4b2737c74d48
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>