### PR TITLE
product/rddanielxlr: disable internal log buffer

### DIFF
--- a/product/rddanielxlr/include/fmw_log.h
+++ b/product/rddanielxlr/include/fmw_log.h
@@ -1,0 +1,16 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FMW_LOG_H
+#define FMW_LOG_H
+
+/*
+ * Disable log buffering by setting buffer size to 0.
+ */
+#define FMW_LOG_BUFFER_SIZE 0
+
+#endif /* FMW_LOG_H */


### PR DESCRIPTION
Release mode builds enables log buffering functionality with a buffer
size of 4KiB. This will result in log messages not written to the
console immediately. To avoid this in release builds, disable buffering
by setting the buffer size to 0.

Change-Id: Ie2319ae0c313a136de2fdb98c67f6a87584f2309
Signed-off-by: Vijayenthiran Subramaniam <vijayenthiran.subramaniam@arm.com>