### PR TITLE
SCMIv2: fix memory initialization of fast channels

### DIFF
--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -1165,7 +1165,7 @@ static int scmi_perf_start(fwk_id_t id)
         if (domain->fast_channels_addr_scp != 0x0) {
             fc = (struct mod_scmi_perf_fast_channel *)
                 ((uintptr_t)domain->fast_channels_addr_scp);
-            memset((void *)fc, 0, sizeof(struct mod_scmi_perf_domain_config));
+            memset((void *)fc, 0, sizeof(struct mod_scmi_perf_fast_channel));
         }
     }
 


### PR DESCRIPTION
When a fast channel is set up it's memory is cleared. The wrong size
is used for the memset operation.

Change-Id: I278ef86606cacd050e3ca36186d3a0022b9fc284
Signed-off-by: Jim Quigley <jim.quigley@arm.com>