### PR TITLE
tools: Fix Python code style errors

### DIFF
--- a/tools/check_api.py
+++ b/tools/check_api.py
@@ -71,7 +71,7 @@ def main(argv=[], prog_name=''):
     illegal_use = 0
 
     with open(BANNED_LIST) as file:
-        for l, fname in enumerate(file):
+        for fname in file:
             if fname[0] == '#':
                 continue
             BANNED_API.append(fname.rstrip())

--- a/tools/check_tabs.py
+++ b/tools/check_tabs.py
@@ -80,7 +80,7 @@ def main(argv=[], prog_name=''):
     #  excluded by .git/info/exclude)
     git_clean_output = subprocess.check_output("git clean -ndX".split())
     git_clean_output = git_clean_output.decode()
-    git_ignores = [l.split()[-1] for l in git_clean_output.splitlines()]
+    git_ignores = [line.split()[-1] for line in git_clean_output.splitlines()]
 
     cwd = os.getcwd()
     print("Executing from %s" % cwd)


### PR DESCRIPTION
Release 2.3.1 of pycodestyle does not allow the use of 'l'
as a variable.

Change-Id: I938515fdc0b6fe3e348995f1b35f0c98b311950e
Signed-off-by: Jim Quigley <jim.quigley@arm.com>