### PR TITLE
dbg: Fix the compile error when DEBUGGER flag set

### DIFF
--- a/debugger/include/cli.h
+++ b/debugger/include/cli.h
@@ -12,11 +12,11 @@
 /* Include Files                                                             */
 /*****************************************************************************/
 
-#include "cli_config.h"
-#include "cli_fifo.h"
-
 #include <stdbool.h>
 #include <stdint.h>
+
+#include "cli_config.h"
+#include "cli_fifo.h"
 
 /*****************************************************************************/
 /* Enumerated Types                                                          */

--- a/debugger/src/cli/cli_fifo.c
+++ b/debugger/src/cli/cli_fifo.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <cli_config.h>
-#include <cli_fifo.h>
-
 #include <stdbool.h>
 #include <stdint.h>
+
+#include <cli_config.h>
+#include <cli_fifo.h>
 
 uint32_t fifo_init(fifo_st *fifo, char *buf, uint32_t buf_size)
 {


### PR DESCRIPTION
This patch fixes the compile error seen when DEBUGGER flag is set

Change-Id: Ie9395eabf7b849cb43c2245cea3698bf916b915d
Signed-off-by: Jagadeeesh Ujja <jagadeesh.ujja@arm.com>