### PR TITLE
module: add support for CMN Booker interconnect

### DIFF
--- a/module/cmn_booker/include/internal/cmn_booker_ctx.h
+++ b/module/cmn_booker/include/internal/cmn_booker_ctx.h
@@ -1,0 +1,50 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *      CMN_BOOKER Context structure Interface
+ */
+
+#ifndef INTERNAL_CMN_BOOKER_CTX_H
+#define INTERNAL_CMN_BOOKER_CTX_H
+
+#include <cmn_booker.h>
+
+#include <mod_cmn_booker.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+static struct cmn_booker_ctx {
+    const struct mod_cmn_booker_config *config;
+
+    struct cmn_booker_cfgm_reg *root;
+
+    /* Number of HN-F (system cache) nodes in the system */
+    unsigned int hnf_count;
+    uint64_t *hnf_cache_group;
+    uint64_t *sn_nodeid_group;
+
+    /*
+     * External RN-SAMs. The driver keeps a list of tuples (node identifier and
+     * node pointers). The configuration of these nodes is via the SAM API.
+     */
+    unsigned int external_rnsam_count;
+    struct external_rnsam_tuple *external_rnsam_table;
+
+    /*
+     * Internal RN-SAMs. The driver keeps a list of RN-SAM pointers to
+     * configure them once the system has been fully discovered and all
+     * parameters are known
+     */
+    unsigned int internal_rnsam_count;
+    struct cmn_booker_rnsam_reg **internal_rnsam_table;
+
+    bool initialized;
+} *ctx;
+
+
+#endif /* INTERNAL_CMN600_CTX_H */

--- a/module/cmn_booker/include/mod_cmn_booker.h
+++ b/module/cmn_booker/include/mod_cmn_booker.h
@@ -1,0 +1,141 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOD_CMN_BOOKER_H
+#define MOD_CMN_BOOKER_H
+
+#include <fwk_id.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*!
+ * \addtogroup GroupModules Modules
+ * @{
+ */
+
+/*!
+ * \defgroup GroupModuleCMN_BOOKER CMN_BOOKER
+ *
+ * \brief Arm Coherent Mesh Network (CMN) BOOKER module
+ *
+ * \details This module adds support for the CMN_BOOKER interconnect
+ * @{
+ */
+
+/*!
+ * \brief Module API indices
+ */
+enum mod_cmn_booker_api_idx {
+    /*! Index of the PPU_V1 power state observer API */
+    MOD_CMN_BOOKER_API_IDX_PPU_OBSERVER,
+
+    /*! Number of APIs */
+    MOD_CMN_BOOKER_API_COUNT
+};
+
+/*!
+ * \brief Memory region configuration type
+ */
+enum mod_cmn_booker_mem_region_type {
+    /*! Input/Output region (serviced by dedicated HN-I and HN-D nodes) */
+    MOD_CMN_BOOKER_MEM_REGION_TYPE_IO,
+
+    /*!
+     * Region backed by the system cache (serviced by all HN-F nodes in the
+     * system)
+     */
+    MOD_CMN_BOOKER_MEM_REGION_TYPE_SYSCACHE,
+
+    /*!
+     * Sub region of the system cache for non-hashed access (serviced by
+     * dedicated SN-F nodes).
+     */
+    MOD_CMN_BOOKER_REGION_TYPE_SYSCACHE_SUB,
+};
+
+/*!
+ * \brief Memory region map descriptor
+ */
+struct mod_cmn_booker_mem_region_map {
+    /*! Base address */
+    uint64_t base;
+
+    /*! Region size in bytes */
+    uint64_t size;
+
+    /*! Region configuration type */
+    enum mod_cmn_booker_mem_region_type type;
+
+    /*!
+     * \brief Target node identifier
+     *
+     * \note Not used for \ref
+     *      mod_cmn_booker_mem_region_type.
+     *      MOD_CMN_BOOKER_MEM_REGION_TYPE_SYSCACHE
+     *      memory regions as it uses the pool of HN-F nodes available in the
+     *      system
+     */
+    unsigned int node_id;
+};
+
+/*!
+ * \brief CMN_BOOKER configuration data
+ */
+struct mod_cmn_booker_config {
+    /*! Peripheral base address. */
+    uintptr_t base;
+
+    /*! Size along x-axis of the interconnect mesh */
+    unsigned int mesh_size_x;
+
+    /*! Size along y-axis of the interconnect mesh */
+    unsigned int mesh_size_y;
+
+    /*! Default HN-D node identifier containing the global configuration */
+    unsigned int hnd_node_id;
+
+    /*!
+     * \brief Table of SN-Fs used as targets for the HN-F nodes
+     *
+     * \details Each entry of this table corresponds to a HN-F node in the
+     *      system. The HN-F's logical identifiers are used as indices in this
+     *      table
+     */
+    const unsigned int *snf_table;
+
+    /*! Number of entries in the \ref snf_table */
+    size_t snf_count;
+
+    /*! Table of region memory map entries */
+    const struct mod_cmn_booker_mem_region_map *mmap_table;
+
+    /*! Number of entries in the \ref mmap_table */
+    size_t mmap_count;
+
+    /*! Identifier of the clock that this device depends on */
+    fwk_id_t clock_id;
+
+    /*!
+     * \brief HN-F with CAL support flag
+     * \details When set to true, enables HN-F with CAL support. This flag will
+     * be used only if HN-F is found to be connected to CAL (When connected to
+     * a CAL port, node id of HN-F will be a odd number).
+     */
+    bool hnf_cal_mode;
+};
+
+/*!
+ * @}
+ */
+
+/*!
+ * @}
+ */
+
+#endif /* MOD_CMN_BOOKER_H */

--- a/module/cmn_booker/src/Makefile
+++ b/module/cmn_booker/src/Makefile
@@ -1,0 +1,13 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BS_LIB_NAME := CMN_BOOKER
+
+BS_LIB_SOURCES = mod_cmn_booker.c
+BS_LIB_SOURCES += cmn_booker.c
+
+include $(BS_DIR)/lib.mk

--- a/module/cmn_booker/src/cmn_booker.c
+++ b/module/cmn_booker/src/cmn_booker.c
@@ -1,0 +1,227 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <cmn_booker.h>
+
+#include <fwk_assert.h>
+#include <fwk_math.h>
+
+/*
+ * Encoding bits size of the X and Y position in the Node info value.
+ * If X and Y dimension are less than 4, encoding bits size will be 2.
+ * If X and Y dimension are between 5 and 8, encoding bits size will be 3.
+ */
+static unsigned int encoding_bits;
+static unsigned int mask_bits;
+
+unsigned int get_node_child_count(void *node_base)
+{
+    struct node_header *node = node_base;
+    return node->CHILD_INFO & CMN_BOOKER_CHILD_INFO_COUNT;
+}
+
+enum node_type get_node_type(void *node_base)
+{
+    struct node_header *node = node_base;
+    return (enum node_type)(node->NODE_INFO & CMN_BOOKER_NODE_INFO_TYPE);
+}
+
+unsigned int get_node_id(void *node_base)
+{
+    struct node_header *node = node_base;
+    return (node->NODE_INFO & CMN_BOOKER_NODE_INFO_ID) >>
+           CMN_BOOKER_NODE_INFO_ID_POS;
+}
+
+unsigned int get_node_logical_id(void *node_base)
+{
+    struct node_header *node = node_base;
+    return (node->NODE_INFO & CMN_BOOKER_NODE_INFO_LOGICAL_ID) >>
+           CMN_BOOKER_NODE_INFO_LOGICAL_ID_POS;
+}
+
+void *get_child_node(uintptr_t base, void *node_base, unsigned int child_index)
+{
+    struct node_header *node = node_base;
+    uint32_t child_pointer;
+    unsigned int offset;
+    void *child_node;
+
+    child_pointer = node->CHILD_POINTER[child_index];
+    offset = child_pointer & CMN_BOOKER_CHILD_POINTER_OFFSET;
+
+    child_node = (void *)(base + offset);
+    return child_node;
+}
+
+unsigned int get_child_node_id(void *node_base,
+    unsigned int child_index)
+{
+    struct node_header *node = node_base;
+    uint32_t node_pointer;
+    unsigned int node_id;
+
+    node_pointer = (node->CHILD_POINTER[child_index] &
+                    CMN_BOOKER_CHILD_POINTER_EXT_NODE_POINTER) >>
+                   CMN_BOOKER_CHILD_POINTER_EXT_NODE_POINTER_POS;
+
+    /*
+     * For mesh widths using 2 bits each for X,Y encoding:
+     * NodeID[1:0] = DeviceID[3:2]
+     * NodeID[2]   = DeviceID[0]
+     * NodeID[4:3] = NODE POINTER[7:6]
+     * NodeID[6:5] = NODE POINTER[9:8]
+     *
+     * For mesh widths using 3 bits each for X,Y encoding:
+     * NodeID[1:0] = DeviceID[3:2]
+     * NodeID[2]   = DeviceID[0]
+     * NodeID[5:3] = NODE POINTER[8:6]
+     * NodeID[8:6] = NODE POINTER[11:9]
+     */
+    node_id = (((node_pointer >> 6) & 0xff) << 3) |
+              ((node_pointer & 0x1) << 2) |
+              ((node_pointer >> 2) & 0x3);
+
+    return node_id;
+}
+
+bool is_child_external(void *node_base, unsigned int child_index)
+{
+    struct node_header *node = node_base;
+    return !!(node->CHILD_POINTER[child_index] & (1U << 31));
+}
+
+bool get_port_number(unsigned int child_node_id)
+{
+    return (child_node_id >> CMN_BOOKER_NODE_ID_PORT_POS) &
+           CMN_BOOKER_NODE_ID_PORT_MASK;
+}
+
+unsigned int get_device_type(void *mxp_base, bool port)
+{
+    struct cmn_booker_mxp_reg *mxp = mxp_base;
+    return mxp->PORT_CONNECT_INFO[port] &
+           CMN_BOOKER_MXP_PORT_CONNECT_INFO_DEVICE_TYPE_MASK;
+}
+
+uint64_t sam_encode_region_size(uint64_t size)
+{
+    uint64_t blocks;
+    uint64_t result;
+
+    /* Size must be a multiple of SAM_GRANULARITY */
+    fwk_assert((size % SAM_GRANULARITY) == 0);
+
+    /* Size also must be a power of two */
+    fwk_assert((size & (size - 1)) == 0);
+
+    blocks = size / SAM_GRANULARITY;
+    result = fwk_math_log2(blocks);
+
+    return result;
+}
+
+void configure_region(volatile uint64_t *reg, uint64_t base, uint64_t size,
+    enum sam_node_type node_type)
+{
+    uint64_t value;
+
+    fwk_assert(reg);
+    fwk_assert((base % size) == 0);
+
+    value = CMN_BOOKER_RNSAM_REGION_ENTRY_VALID;
+    value |= node_type << CMN_BOOKER_RNSAM_REGION_ENTRY_TYPE_POS;
+    value |= sam_encode_region_size(size) <<
+             CMN_BOOKER_RNSAM_REGION_ENTRY_SIZE_POS;
+    value |= (base / SAM_GRANULARITY) << CMN_BOOKER_RNSAM_REGION_ENTRY_BASE_POS;
+
+    *reg = value;
+}
+
+static const char * const type_to_name[] = {
+    [NODE_TYPE_INVALID] = "<Invalid>",
+    [NODE_TYPE_DVM]     = "DVM",
+    [NODE_TYPE_CFG]     = "CFG",
+    [NODE_TYPE_DTC]     = "DTC",
+    [NODE_TYPE_HN_I]    = "HN-I",
+    [NODE_TYPE_HN_F]    = "HN-F",
+    [NODE_TYPE_XP]      = "XP",
+    [NODE_TYPE_SBSX]    = "SBSX",
+    [NODE_TYPE_MPAM_S]  = "MPAM-S",
+    [NODE_TYPE_MPAM_NS] = "MPAM-NS",
+    [NODE_TYPE_RN_I]    = "RN-I",
+    [NODE_TYPE_RN_D]    = "RN-D",
+    [NODE_TYPE_RN_SAM]  = "RN-SAM",
+    [NODE_TYPE_MTU]     = "MTU",
+};
+
+static const char * const type_to_name_cml[] = {
+    [NODE_TYPE_CXRA - NODE_TYPE_CML_BASE] = "CXRA",
+    [NODE_TYPE_CXHA - NODE_TYPE_CML_BASE] = "CXHA",
+    [NODE_TYPE_CXLA - NODE_TYPE_CML_BASE] = "CXLA",
+
+};
+
+const char *get_node_type_name(enum node_type node_type)
+{
+    /* Base node IDs */
+    if (node_type <= NODE_TYPE_MTU)
+        return type_to_name[node_type];
+
+    /* CML node IDs */
+    if ((node_type >= NODE_TYPE_CML_BASE) &&
+        (node_type <= NODE_TYPE_CXLA))
+        return type_to_name_cml[node_type - NODE_TYPE_CML_BASE];
+
+    /* Invalid node IDs */
+    return type_to_name[NODE_TYPE_INVALID];
+}
+
+unsigned int get_node_pos_x(void *node_base)
+{
+    struct node_header *node = node_base;
+    return (get_node_id(node) >> (CMN_BOOKER_NODE_ID_Y_POS + encoding_bits)) &
+           mask_bits;
+}
+
+unsigned int get_node_pos_y(void *node_base)
+{
+    struct node_header *node = node_base;
+    return (get_node_id(node) >> CMN_BOOKER_NODE_ID_Y_POS) & mask_bits;
+}
+
+struct cmn_booker_cfgm_reg *get_root_node(uintptr_t base,
+    unsigned int hnd_node_id, unsigned int mesh_size_x,
+    unsigned int mesh_size_y)
+{
+    unsigned int node_pos_x;
+    unsigned int node_pos_y;
+    unsigned int node_port;
+    uintptr_t offset;
+
+    /*
+     * Determine the number of bits used to represent each node coordinate based
+     * on the mesh size as per CMN_BOOKER specification.
+     */
+    encoding_bits = ((mesh_size_x > 4) || (mesh_size_y > 4)) ? 3 : 2;
+
+    /* Extract node coordinates from the node identifier */
+    mask_bits = (1 << encoding_bits) - 1;
+    node_pos_y = (hnd_node_id >> CMN_BOOKER_NODE_ID_Y_POS) & mask_bits;
+    node_pos_x = (hnd_node_id >> (CMN_BOOKER_NODE_ID_Y_POS + encoding_bits)) &
+                 mask_bits;
+    node_port = (hnd_node_id >> CMN_BOOKER_NODE_ID_PORT_POS) &
+                CMN_BOOKER_NODE_ID_PORT_MASK;
+
+    /* Calculate node address offset */
+    offset = (node_pos_y << CMN_BOOKER_ROOT_NODE_OFFSET_Y_POS) |
+             (node_pos_x << (CMN_BOOKER_ROOT_NODE_OFFSET_Y_POS +
+                             encoding_bits)) |
+             (node_port << CMN_BOOKER_ROOT_NODE_OFFSET_PORT_POS);
+
+    return (struct cmn_booker_cfgm_reg *)(base + offset);
+}

--- a/module/cmn_booker/src/cmn_booker.h
+++ b/module/cmn_booker/src/cmn_booker.h
@@ -1,0 +1,428 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     Definitions and utility functions for the CMN BOOKER module.
+ */
+
+#ifndef CMN_BOOKER_H
+#define CMN_BOOKER_H
+
+#include <fwk_macros.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Max Node Counts */
+#define MAX_HNF_COUNT 64
+#define MAX_RND_COUNT 32
+#define MAX_RNI_COUNT 32
+#define MAX_RNF_COUNT 64
+
+/* Maximum System Cache Group regions supported by CMN-BOOKER */
+#define MAX_SCG_COUNT 4
+
+/* SAM Granularity of RN-SAM and HN-F SAM */
+#define SAM_GRANULARITY       (64 * FWK_MIB)
+
+/* Macros to split 64 bit value two 32 bit values */
+#define HIGH_WORD(x)    ((unsigned int)((((x) & 0xFFFFFFFF00000000ULL) >> 32)))
+#define LOW_WORD(x)     ((unsigned int)((x) & 0xFFFFFFFF))
+
+/* External nodes that require RN-SAM mapping during run-time */
+struct external_rnsam_tuple {
+    unsigned int node_id;
+    struct cmn_booker_rnsam_reg *node;
+};
+
+enum node_type {
+    NODE_TYPE_INVALID   = 0x0,
+    NODE_TYPE_DVM       = 0x1,
+    NODE_TYPE_CFG       = 0x2,
+    NODE_TYPE_DTC       = 0x3,
+    NODE_TYPE_HN_I      = 0x4,
+    NODE_TYPE_HN_F      = 0x5,
+    NODE_TYPE_XP        = 0x6,
+    NODE_TYPE_SBSX      = 0x7,
+    NODE_TYPE_MPAM_S    = 0x8,
+    NODE_TYPE_MPAM_NS   = 0x9,
+    NODE_TYPE_RN_I      = 0xA,
+    NODE_TYPE_RN_D      = 0xD,
+    NODE_TYPE_RN_SAM    = 0xF,
+    NODE_TYPE_MTU       = 0x10,
+    /* Coherent Multichip Link (CML) node types */
+    NODE_TYPE_CML_BASE  = 0x100,
+    NODE_TYPE_CXRA      = 0x100,
+    NODE_TYPE_CXHA      = 0x101,
+    NODE_TYPE_CXLA      = 0x102,
+};
+
+enum device_type {
+    DEVICE_TYPE_CXHA    = 0x11, // 0b10001
+    DEVICE_TYPE_CXRA    = 0x12, // 0b10010
+    DEVICE_TYPE_CXRH    = 0x13, // 0b10011
+};
+
+/* Common node header */
+struct node_header {
+    FWK_R uint64_t NODE_INFO;
+          uint8_t  RESERVED0[0x80 - 0x8];
+    FWK_R uint64_t CHILD_INFO;
+          uint8_t  RESERVED1[0x100 - 0x88];
+    FWK_R uint64_t CHILD_POINTER[256];
+};
+
+enum sam_node_type {
+    SAM_NODE_TYPE_HN_F = 0,
+    SAM_NODE_TYPE_HN_I = 1,
+    SAM_NODE_TYPE_CXRA = 2,
+    SAM_NODE_TYPE_COUNT
+};
+
+/*
+ * Request Node System Address Map (RN-SAM) registers
+ */
+struct cmn_booker_rnsam_reg {
+    FWK_R  uint64_t NODE_INFO;
+           uint8_t  RESERVED0[0x80 - 0x8];
+    FWK_R  uint64_t CHILD_INFO;
+           uint8_t  RESERVED1[0x900 - 0x88];
+    FWK_R  uint64_t UNIT_INFO;
+           uint8_t  RESERVED2[0xC00 - 0x908];
+    FWK_RW uint64_t NON_HASH_MEM_REGION[20];
+           uint8_t  RESERVED3[0xD80 - 0xCA0];
+    FWK_RW uint64_t NON_HASH_TGT_NODEID[5];
+           uint8_t  RESERVED4[0xE00 - 0xDA8];
+    FWK_RW uint64_t SYS_CACHE_GRP_REGION[4];
+           uint8_t  RESERVED5[0xEA0 - 0xE20];
+    FWK_RW uint64_t SYS_CACHE_GRP_HN_COUNT;
+           uint8_t  RESERVED6[0xF00 - 0xEA8];
+    FWK_RW uint64_t SYS_CACHE_GRP_HN_NODEID[16];
+           uint8_t  RESERVED7[0x1000 - 0xF80];
+    FWK_RW uint64_t SYS_CACHE_GRP_SN_NODEID[16];
+           uint8_t  RESERVED8[0x1100 - 0x1080];
+    FWK_RW uint64_t STATUS;
+           uint8_t  RESERVED9[0x1120 - 0x1108];
+    FWK_RW uint64_t SYS_CACHE_GRP_CAL_MODE;
+};
+
+/*
+ * Fully Coherent Home Node (HN-F) registers
+ */
+struct cmn_booker_hnf_reg {
+    FWK_R  uint64_t NODE_INFO;
+           uint8_t  RESERVED0[0x80 - 0x8];
+    FWK_R  uint64_t CHILD_INFO;
+           uint8_t  RESERVED1[0x900 - 0x88];
+    FWK_R  uint64_t UNIT_INFO;
+           uint8_t  RESERVED2[0xD00 - 0x908];
+    FWK_RW uint64_t SAM_CONTROL;
+    FWK_RW uint64_t SAM_MEMREGION[2];
+           uint8_t  RESERVED8[0x1C00 - 0xD18];
+    FWK_RW uint64_t PPU_PWPR;
+};
+
+/*
+ * Configuration slave registers
+ */
+struct cmn_booker_cfgm_reg {
+    FWK_R  uint64_t NODE_INFO;
+    FWK_RW uint64_t PERIPH_ID[4];
+    FWK_RW uint64_t COMPONENT_ID[2];
+           uint8_t  RESERVED0[0x80 - 0x38];
+    FWK_R  uint64_t CHILD_INFO;
+};
+
+/*
+ * Crosspoint (XP) registers
+ */
+struct cmn_booker_mxp_reg {
+    FWK_R  uint64_t NODE_INFO;
+    FWK_R  uint64_t PORT_CONNECT_INFO[2];
+           uint8_t  RESERVED0[0x80 - 0x18];
+    FWK_R  uint64_t CHILD_INFO;
+           uint8_t  RESERVED1[0x100 - 0x88];
+    FWK_R  uint64_t CHILD_POINTER[16];
+};
+
+/*
+ * Home Node I/O (HN-I) registers
+ */
+struct cmn_booker_hni_reg {
+    FWK_R  uint64_t NODE_INFO;
+           uint8_t  RESERVED0[0x80 - 0x8];
+    FWK_R  uint64_t CHILD_INFO;
+           uint8_t  RESERVED1[0x900 - 0x88];
+    FWK_R  uint64_t UNIT_INFO;
+           uint8_t  RESERVED2[0x980 - 0x908];
+    FWK_RW uint64_t SECURE_REGISTER_GROUPS_OVERRIDE;
+           uint8_t  RESERVED3[0xA00 - 0x988];
+    FWK_RW uint64_t CFG_CTL;
+    FWK_RW uint64_t AUX_CTL;
+           uint8_t  RESERVED4[0xC00 - 0xA10];
+    FWK_RW uint64_t SAM_ADDRREGION_CFG[4];
+           uint8_t  RESERVED5[0x2000 - 0xC20];
+    FWK_RW uint64_t PMU_EVENT_SEL;
+           uint8_t  RESERVED6[0x3000 - 0x2008];
+    FWK_R  uint64_t ERRFR;
+    FWK_RW uint64_t ERRCTL;
+    FWK_RW uint64_t ERRSTATUS;
+    FWK_RW uint64_t ERRADDR;
+    FWK_RW uint64_t ERRMISC;
+           uint8_t  RESERVED7[0x3100 - 0x3028];
+    FWK_R  uint64_t ERRFR_NS;
+    FWK_RW uint64_t ERRCTL_NS;
+    FWK_RW uint64_t ERRSTATUS_NS;
+    FWK_RW uint64_t ERRADDR_NS;
+    FWK_RW uint64_t ERRMISC_NS;
+};
+
+#define CMN_BOOKER_NODE_INFO_TYPE           UINT64_C(0x000000000000FFFF)
+#define CMN_BOOKER_NODE_INFO_ID             UINT64_C(0x00000000FFFF0000)
+#define CMN_BOOKER_NODE_INFO_ID_POS         16
+#define CMN_BOOKER_NODE_INFO_LOGICAL_ID     UINT64_C(0x0000FFFF00000000)
+#define CMN_BOOKER_NODE_INFO_LOGICAL_ID_POS 32
+
+#define CMN_BOOKER_CHILD_INFO_COUNT         UINT64_C(0x000000000000FFFF)
+
+#define CMN_BOOKER_CHILD_POINTER_OFFSET     UINT64_C(0x000000000FFFFFFF)
+#define CMN_BOOKER_CHILD_POINTER_EXT        UINT64_C(0x0000000080000000)
+
+/* External child node */
+#define CMN_BOOKER_CHILD_POINTER_EXT_REGISTER_OFFSET  UINT64_C(0x00003FFF)
+#define CMN_BOOKER_CHILD_POINTER_EXT_NODE_POINTER     UINT64_C(0x0FFFC000)
+#define CMN_BOOKER_CHILD_POINTER_EXT_NODE_POINTER_POS 14
+
+/* Used by NON_HASH_MEM_REGIONx and SYS_CACHE_GRP_REGIONx group registers */
+#define CMN_BOOKER_RNSAM_REGION_ENTRY_TYPE_POS 2
+#define CMN_BOOKER_RNSAM_REGION_ENTRY_SIZE_POS 56
+#define CMN_BOOKER_RNSAM_REGION_ENTRY_BASE_POS 26
+#define CMN_BOOKER_RNSAM_REGION_ENTRY_BITS_WIDTH 64
+#define CMN_BOOKER_RNSAM_REGION_ENTRY_VALID UINT64_C(0x0000000000000001)
+#define CMN_BOOKER_RNSAM_REGION_ENTRIES_PER_GROUP 1
+#define CMN_BOOKER_RNSAM_SYS_CACHE_GRP_SN_NODEID_ENTRIES_PER_GROUP 4
+#define CMN_BOOKER_RNSAM_SCG_HNF_CAL_MODE_EN UINT64_C(0x01)
+#define CMN_BOOKER_RNSAM_SCG_HNF_CAL_MODE_SHIFT 16
+
+#define CMN_BOOKER_RNSAM_STATUS_UNSTALL UINT64_C(0x0000000000000002)
+#define CMN_BOOKER_RNSAM_STATUS_DEFAULT_NODEID_POS 48
+
+#define CMN_BOOKER_RNSAM_NON_HASH_TGT_NODEID_ENTRY_BITS_WIDTH 12
+#define CMN_BOOKER_RNSAM_NON_HASH_TGT_NODEID_ENTRY_MASK UINT64_C(0xFFF)
+#define CMN_BOOKER_RNSAM_NON_HASH_TGT_NODEID_ENTRIES_PER_GROUP 4
+
+#define CMN_BOOKER_HNF_SAM_MEMREGION_SIZE_POS 12
+#define CMN_BOOKER_HNF_SAM_MEMREGION_BASE_POS 26
+#define CMN_BOOKER_HNF_SAM_MEMREGION_VALID UINT64_C(0x8000000000000000)
+
+#define CMN_BOOKER_HNF_CACHE_GROUP_ENTRIES_MAX 64
+#define CMN_BOOKER_HNF_CACHE_GROUP_ENTRIES_PER_GROUP 4
+#define CMN_BOOKER_HNF_CACHE_GROUP_ENTRY_BITS_WIDTH 12
+
+#define CMN_BOOKER_PPU_PWPR_POLICY_OFF UINT64_C(0x0000000000000000)
+#define CMN_BOOKER_PPU_PWPR_POLICY_MEM_RET UINT64_C(0x0000000000000002)
+#define CMN_BOOKER_PPU_PWPR_POLICY_FUNC_RET UINT64_C(0x000000000000007)
+#define CMN_BOOKER_PPU_PWPR_POLICY_ON UINT64_C(0x0000000000000008)
+#define CMN_BOOKER_PPU_PWPR_OPMODE_NOSFSLC UINT64_C(0x0000000000000000)
+#define CMN_BOOKER_PPU_PWPR_OPMODE_SFONLY UINT64_C(0x0000000000000010)
+#define CMN_BOOKER_PPU_PWPR_OPMODE_HAM UINT64_C(0x0000000000000020)
+#define CMN_BOOKER_PPU_PWPR_OPMODE_FAM UINT64_C(0x0000000000000030)
+#define CMN_BOOKER_PPU_PWPR_DYN_EN UINT64_C(0x0000000000000100)
+
+/* Mesh and Node ID mapping */
+#define CMN_BOOKER_MESH_X_MAX 8
+#define CMN_BOOKER_MESH_Y_MAX 8
+
+#define CMN_BOOKER_NODE_ID_PORT_POS 1
+#define CMN_BOOKER_NODE_ID_PORT_MASK 0x3
+#define CMN_BOOKER_NODE_ID_Y_POS 3
+
+#define CMN_BOOKER_MXP_PORT_CONNECT_INFO_DEVICE_TYPE_MASK UINT64_C(0x1F)
+
+#define CMN_BOOKER_ROOT_NODE_OFFSET_PORT_POS 16
+#define CMN_BOOKER_ROOT_NODE_OFFSET_Y_POS 22
+
+/*
+ * Retrieve the number of child nodes of a given node
+ *
+ * \param node_base Pointer to the node descriptor
+ *      \pre The node pointer must be valid
+ *
+ * \return Number of child nodes
+ */
+unsigned int get_node_child_count(void *node_base);
+
+/*
+ * Retrieve node type identifier
+ *
+ * \param node_base Pointer to the node descriptor
+ *      \pre The node pointer must be valid
+ *
+ * \return Node's type identifier
+ */
+enum node_type get_node_type(void *node_base);
+
+/*
+ * Retrieve the physical identifier of a node from its hardware node descriptor.
+ * This identifier encodes the node's position in the mesh.
+ *
+ * Note: Multiple node descriptors can share the same identifier if they are
+ * related to the same device node in the mesh.
+ *
+ * \param node_base Pointer to the node descriptor
+ *      \pre The node pointer must be valid
+ *
+ * \return Node's physical identifier
+ */
+unsigned int get_node_id(void *node_base);
+
+/*
+ * Retrieve the logical identifier of a node from its hardware node descriptor.
+ * This is an unique identifier (index) among nodes of the same type in the
+ * system.
+ *
+ * \param node_base Pointer to the node base address
+ *      \pre The node pointer must be valid
+ *
+ * \return An integer representing the node's logical identifier
+ */
+unsigned int get_node_logical_id(void *node_base);
+
+/*
+ * Retrieve a child node given a node and child index
+ *
+ * \param node_base Pointer to the node descriptor
+ *      \pre The node pointer must be valid
+ * \param child_index Child index
+ *      \pre The child index must be valid
+ *
+ * \return Pointer to the child's node descriptor
+ */
+void *get_child_node(uintptr_t base, void *node_base, unsigned int child_index);
+
+/*
+ * Retrieve the physical identifier of a node using its child pointer in the
+ * parent's node hardware descriptor
+ *
+ * This function is used to extract a node's identifier without accessing the
+ * node descriptor. This is specially useful for external nodes that are in an
+ * unavailable power or clock domain.
+ *
+ * \param node_base Pointer to the parent node descriptor
+ *      \pre The node pointer must be valid
+ * \param child_index Child index
+ *      \pre The child index must be valid
+ *
+ * \return Physical child node identifier
+ */
+unsigned int get_child_node_id(void *node_base, unsigned int child_index);
+
+/*
+ * Verify if a child node (given a parent node base and child index) is an
+ * external node from the CMN BOOKER instance point of view.
+ *
+ * \param node_base Pointer to the parent node descriptor
+ *      \pre The node pointer must be valid
+ * \param child_index Child index
+ *      \pre The child index must be valid
+ *
+ * \retval true if the node is external
+ * \retval false if the node is internal
+ */
+bool is_child_external(void *node_base, unsigned int child_index);
+
+/*
+ * Returns the port number from the child node id.
+ *
+ * \param child_node_id Child node id calculated from the child pointer.
+ *
+ * \retval port number (either 0 or 1).
+ */
+bool get_port_number(unsigned int child_node_id);
+
+/*
+ * Returns the device type from the MXP's port connect info register.
+ *
+ * \param mxp_base Pointer to the cross point node descriptor
+ *      \pre The cross point node pointer must be valid
+ * \param port Port number
+ *      \pre The port number should be either 0 or 1.
+ *
+ * \retval device type (por_mxp_por_mxp_device_port_connect_info_p[port] & 0x1F)
+ */
+unsigned int get_device_type(void *mxp_base, bool port);
+
+/*
+ * Convert a memory region size into a size format used by the CMN BOOKER
+ * registers. The format is the binary logarithm of the memory region size
+ * represented as blocks multiple of the CMN BOOKER's granularity:
+ * n =  log2(size / SAM_GRANULARITY)
+ *
+ * \param size Memory region size to be converted
+ *      \pre size must be a multiple of SAM_GRANULARITY
+ *
+ * \return log2(size / SAM_GRANULARITY)
+ */
+uint64_t sam_encode_region_size(uint64_t size);
+
+/*
+ * Configure a memory region
+ *
+ * \param reg Pointer to the region group descriptor to be configured
+ *      \pre Must be a valid pointer
+ * \param region Region entry in the region group descriptor
+ * \param base Region base address
+ * \param size Region size
+ * \param node_type Type of the target node
+ *
+ * \return None
+ */
+void configure_region(volatile uint64_t *reg, uint64_t base, uint64_t size,
+    enum sam_node_type node_type);
+
+/*
+ * Retrieve the node type name
+ *
+ * \param node_type Node type
+ *
+ * \return Pointer to the node type name string
+ */
+const char *get_node_type_name(enum node_type node_type);
+
+/*
+ * Retrieve the node's position in the mesh along the X-axis
+ *
+ * \param node_base Pointer to the node descriptor
+ *
+ * \return Zero-indexed position along the X-axis
+ */
+unsigned int get_node_pos_x(void *node_base);
+
+/*
+ * Retrieve the node's position in the mesh along the Y-axis
+ *
+ * \param node_base Pointer to the node descriptor
+ *
+ * \return Zero-indexed position along the Y-axis
+ */
+unsigned int get_node_pos_y(void *node_base);
+
+/*
+ * Get the root node descriptor based on the peripheral base, HN-D node
+ * identifier and mesh size.
+ *
+ * \param base CMN BOOKER peripheral base address
+ * \param hnd_node_id HN-D node identifier containing the global configuration
+ * \param mesh_size_x Size of the mesh along the x-axis
+ * \param mesh_size_y Size of the mesh along the x-axis
+ *
+ * \return Pointer to the root node descriptor
+ */
+struct cmn_booker_cfgm_reg *get_root_node(uintptr_t base,
+    unsigned int hnd_node_id, unsigned int mesh_size_x,
+    unsigned int mesh_size_y);
+
+#endif /* CMN_BOOKER_H */

--- a/module/cmn_booker/src/mod_cmn_booker.c
+++ b/module/cmn_booker/src/mod_cmn_booker.c
@@ -1,0 +1,589 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <cmn_booker.h>
+
+#include <internal/cmn_booker_ctx.h>
+
+#include <mod_clock.h>
+#include <mod_cmn_booker.h>
+#include <mod_ppu_v1.h>
+
+#include <fwk_assert.h>
+#include <fwk_event.h>
+#include <fwk_id.h>
+#include <fwk_log.h>
+#include <fwk_mm.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+#include <fwk_notification.h>
+#include <fwk_status.h>
+
+#include <inttypes.h>
+
+#define MOD_NAME "[CMN_BOOKER] "
+
+static struct cmn_booker_ctx *ctx;
+
+static void process_node_hnf(struct cmn_booker_hnf_reg *hnf)
+{
+    unsigned int bit_pos;
+    unsigned int group;
+    unsigned int logical_id;
+    unsigned int node_id;
+    unsigned int region_idx;
+    unsigned int region_sub_count = 0;
+    static unsigned int cal_mode_factor = 1;
+    const struct mod_cmn_booker_mem_region_map *region;
+    const struct mod_cmn_booker_config *config = ctx->config;
+
+    logical_id = get_node_logical_id(hnf);
+    node_id = get_node_id(hnf);
+
+    /*
+     * If CAL mode is set, only even numbered hnf node should be added to the
+     * sys_cache_grp_hn_nodeid registers.
+     */
+    if (config->hnf_cal_mode == true && (node_id % 2 == 1)) {
+        /* Factor to manipulate the group and bit_pos */
+        cal_mode_factor = 2;
+    }
+
+    assert(logical_id < config->snf_count);
+
+    group = logical_id /
+            (CMN_BOOKER_HNF_CACHE_GROUP_ENTRIES_PER_GROUP * cal_mode_factor);
+    bit_pos = (CMN_BOOKER_HNF_CACHE_GROUP_ENTRY_BITS_WIDTH / cal_mode_factor) *
+              ((logical_id %
+                (CMN_BOOKER_HNF_CACHE_GROUP_ENTRIES_PER_GROUP *
+                 cal_mode_factor)));
+
+    /*
+     * If CAL mode is set, add only even numbered hnd node to
+     * sys_cache_grp_hn_nodeid registers
+     */
+    if (config->hnf_cal_mode == true) {
+        if (node_id % 2 == 0) {
+            ctx->hnf_cache_group[group] += ((uint64_t)get_node_id(hnf)) <<
+                                           bit_pos;
+            ctx->sn_nodeid_group[group] +=
+                ((uint64_t)config->snf_table[logical_id]) << bit_pos;
+        }
+    } else {
+        ctx->hnf_cache_group[group] += ((uint64_t)get_node_id(hnf)) << bit_pos;
+        ctx->sn_nodeid_group[group] +=
+            ((uint64_t)config->snf_table[logical_id]) << bit_pos;
+    }
+
+    /* Set target node */
+    hnf->SAM_CONTROL = config->snf_table[logical_id];
+
+    /*
+     * Map sub-regions to this HN-F node
+     */
+    for (region_idx = 0; region_idx < config->mmap_count; region_idx++) {
+        region = &config->mmap_table[region_idx];
+
+        /* Skip non sub-regions */
+        if (region->type != MOD_CMN_BOOKER_REGION_TYPE_SYSCACHE_SUB)
+            continue;
+
+        /* Configure sub-region entry */
+        hnf->SAM_MEMREGION[region_sub_count] = region->node_id |
+            (sam_encode_region_size(region->size) <<
+             CMN_BOOKER_HNF_SAM_MEMREGION_SIZE_POS) |
+            ((region->base / SAM_GRANULARITY) <<
+             CMN_BOOKER_HNF_SAM_MEMREGION_BASE_POS) |
+            CMN_BOOKER_HNF_SAM_MEMREGION_VALID;
+
+        region_sub_count++;
+    }
+
+    /* Configure the system cache RAM PPU */
+    hnf->PPU_PWPR = CMN_BOOKER_PPU_PWPR_POLICY_ON |
+                    CMN_BOOKER_PPU_PWPR_OPMODE_FAM |
+                    CMN_BOOKER_PPU_PWPR_DYN_EN;
+}
+
+/*
+ * Discover the topology of the interconnect and identify the number of:
+ * - External RN-SAM nodes
+ * - Internal RN-SAM nodes
+ * - HN-F nodes (cache)
+ */
+static int cmn_booker_discovery(void)
+{
+    unsigned int xp_count;
+    unsigned int xp_idx;
+    unsigned int node_count;
+    unsigned int node_idx;
+    bool xp_port;
+    struct cmn_booker_mxp_reg *xp;
+    struct node_header *node;
+    const struct mod_cmn_booker_config *config = ctx->config;
+
+    FWK_LOG_INFO(MOD_NAME "Starting discovery...");
+
+    assert(get_node_type(ctx->root) == NODE_TYPE_CFG);
+
+    /* Traverse cross points (XP) */
+    xp_count = get_node_child_count(ctx->root);
+    for (xp_idx = 0; xp_idx < xp_count; xp_idx++) {
+        xp = get_child_node(config->base, ctx->root, xp_idx);
+        assert(get_node_type(xp) == NODE_TYPE_XP);
+
+        FWK_LOG_INFO(
+            MOD_NAME "XP (%d, %d) ID:%d, LID:%d",
+            get_node_pos_x(xp),
+            get_node_pos_y(xp),
+            get_node_id(xp),
+            get_node_logical_id(xp));
+
+        /* Traverse nodes */
+        node_count = get_node_child_count(xp);
+        for (node_idx = 0; node_idx < node_count; node_idx++) {
+            node = get_child_node(config->base, xp, node_idx);
+            if (is_child_external(xp, node_idx)) { /* External nodes */
+                xp_port = get_port_number(get_child_node_id(xp, node_idx));
+
+                /*
+                 * If the device type is CXRH, CXHA, or CXRA, then the external
+                 * child node is CXLA as every CXRH, CXHA, or CXRA node has a
+                 * corresponding external CXLA node.
+                 */
+                if ((get_device_type(xp, xp_port) == DEVICE_TYPE_CXRH) ||
+                    (get_device_type(xp, xp_port) == DEVICE_TYPE_CXHA) ||
+                    (get_device_type(xp, xp_port) == DEVICE_TYPE_CXRA)) {
+                    FWK_LOG_INFO(
+                        MOD_NAME "  Found CXLA at node ID: %d",
+                        get_child_node_id(xp, node_idx));
+                } else { /* External RN-SAM Node */
+                    ctx->external_rnsam_count++;
+                    FWK_LOG_INFO(
+                        MOD_NAME "  Found external node ID: %d",
+                        get_child_node_id(xp, node_idx));
+                }
+            } else { /* Internal nodes */
+                switch (get_node_type(node)) {
+                case NODE_TYPE_HN_F:
+                    if (ctx->hnf_count >= MAX_HNF_COUNT) {
+                        FWK_LOG_INFO(
+                            MOD_NAME "  hnf count %d >= max limit (%d)",
+                            ctx->hnf_count,
+                            MAX_HNF_COUNT);
+                        return FWK_E_DATA;
+                    }
+                    ctx->hnf_count++;
+                    break;
+
+                case NODE_TYPE_RN_SAM:
+                    ctx->internal_rnsam_count++;
+                    break;
+
+                default:
+                    /* Nothing to be done for other node types */
+                    break;
+                }
+
+                FWK_LOG_INFO(
+                    MOD_NAME "  %s ID:%d, LID:%d",
+                    get_node_type_name(get_node_type(node)),
+                    get_node_id(node),
+                    get_node_logical_id(node));
+            }
+        }
+    }
+
+    /* When CAL is present, the number of HN-Fs must be even. */
+    if ((ctx->hnf_count % 2 != 0) && (config->hnf_cal_mode == true)) {
+        FWK_LOG_ERR(
+            MOD_NAME "hnf count: %d should be even when CAL mode is set",
+            ctx->hnf_count);
+        return FWK_E_DATA;
+    }
+
+    FWK_LOG_INFO(MOD_NAME
+        "Total internal RN-SAM nodes: %d", ctx->internal_rnsam_count);
+    FWK_LOG_INFO(MOD_NAME
+        "Total external RN-SAM nodes: %d", ctx->external_rnsam_count);
+    FWK_LOG_INFO(MOD_NAME
+        "Total HN-F nodes: %d", ctx->hnf_count);
+
+    return FWK_SUCCESS;
+}
+
+static void cmn_booker_configure(void)
+{
+    unsigned int node_count;
+    unsigned int node_idx;
+    unsigned int xp_count;
+    unsigned int xp_idx;
+    unsigned int xrnsam_entry;
+    unsigned int irnsam_entry;
+    bool xp_port;
+    void *node;
+    struct cmn_booker_mxp_reg *xp;
+    const struct mod_cmn_booker_config *config = ctx->config;
+
+    assert(get_node_type(ctx->root) == NODE_TYPE_CFG);
+
+    xrnsam_entry = 0;
+    irnsam_entry = 0;
+
+    /* Traverse cross points (XP) */
+    xp_count = get_node_child_count(ctx->root);
+    for (xp_idx = 0; xp_idx < xp_count; xp_idx++) {
+        xp = get_child_node(config->base, ctx->root, xp_idx);
+        assert(get_node_type(xp) == NODE_TYPE_XP);
+
+        /* Traverse nodes */
+        node_count = get_node_child_count(xp);
+        for (node_idx = 0; node_idx < node_count; node_idx++) {
+            node = get_child_node(config->base, xp, node_idx);
+            if (is_child_external(xp, node_idx)) {
+                unsigned int node_id = get_child_node_id(xp, node_idx);
+                xp_port = get_port_number(get_child_node_id(xp, node_idx));
+
+                /* Skip if the device type is CXG */
+                if ((get_device_type(xp, xp_port) == DEVICE_TYPE_CXRH) ||
+                    (get_device_type(xp, xp_port) == DEVICE_TYPE_CXHA) ||
+                    (get_device_type(xp, xp_port) == DEVICE_TYPE_CXRA))
+                    continue;
+
+                fwk_assert(xrnsam_entry < ctx->external_rnsam_count);
+
+                ctx->external_rnsam_table[xrnsam_entry].node_id = node_id;
+                ctx->external_rnsam_table[xrnsam_entry].node = node;
+
+                xrnsam_entry++;
+            } else {
+                enum node_type node_type = get_node_type(node);
+
+                if (node_type == NODE_TYPE_RN_SAM) {
+                    fwk_assert(irnsam_entry < ctx->internal_rnsam_count);
+
+                    ctx->internal_rnsam_table[irnsam_entry] = node;
+
+                    irnsam_entry++;
+                } else if (node_type == NODE_TYPE_HN_F) {
+                    process_node_hnf(node);
+                } else if (node_type == NODE_TYPE_HN_I) {
+                    /*
+                    Disable sending of NDE response error to RN and logging of
+                    error information forthe following requests:
+                    1. Coherent Read
+                    2. CleanUnique/MakeUnique
+                    3. Coherent/CopyBack Write
+                    This enables coherent access through HNI.
+                    */
+                    struct cmn_booker_hni_reg* hni_node =
+                        (struct cmn_booker_hni_reg*) node;
+                    hni_node->CFG_CTL &= ~1;
+                }
+            }
+        }
+    }
+}
+
+static const char * const mmap_type_name[] = {
+    [MOD_CMN_BOOKER_MEM_REGION_TYPE_IO] = "I/O",
+    [MOD_CMN_BOOKER_MEM_REGION_TYPE_SYSCACHE] = "System Cache",
+    [MOD_CMN_BOOKER_REGION_TYPE_SYSCACHE_SUB] = "Sub-System Cache",
+};
+
+static int cmn_booker_setup_sam(struct cmn_booker_rnsam_reg *rnsam)
+{
+    unsigned int bit_pos;
+    unsigned int group;
+    unsigned int group_count;
+    unsigned int hnf_count;
+    unsigned int region_idx;
+    unsigned int region_io_count = 0;
+    unsigned int region_sys_count = 0;
+    unsigned int scg_regions_enabled[MAX_SCG_COUNT] = {0, 0, 0, 0};
+    const struct mod_cmn_booker_mem_region_map *region;
+    const struct mod_cmn_booker_config *config = ctx->config;
+
+    FWK_LOG_INFO(MOD_NAME "Configuring SAM for node %d", get_node_id(rnsam));
+
+    for (region_idx = 0; region_idx < config->mmap_count; region_idx++) {
+        region = &config->mmap_table[region_idx];
+
+        FWK_LOG_INFO(
+            MOD_NAME "  [0x%x%x - 0x%x%x] %s",
+            HIGH_WORD(region->base), LOW_WORD(region->base),
+            HIGH_WORD(region->base + region->size - 1),
+            LOW_WORD(region->base + region->size - 1),
+            mmap_type_name[region->type]);
+
+        switch (region->type) {
+        case MOD_CMN_BOOKER_MEM_REGION_TYPE_IO:
+            /*
+             * Configure memory region
+             */
+            configure_region(&rnsam->NON_HASH_MEM_REGION[region_io_count],
+                             region->base,
+                             region->size,
+                             SAM_NODE_TYPE_HN_I);
+
+            /*
+             * Configure target node
+             */
+            group = region_io_count /
+                    CMN_BOOKER_RNSAM_NON_HASH_TGT_NODEID_ENTRIES_PER_GROUP;
+            bit_pos = CMN_BOOKER_RNSAM_NON_HASH_TGT_NODEID_ENTRY_BITS_WIDTH *
+                      (region_io_count %
+                       CMN_BOOKER_RNSAM_NON_HASH_TGT_NODEID_ENTRIES_PER_GROUP);
+
+            rnsam->NON_HASH_TGT_NODEID[group] &=
+                ~(CMN_BOOKER_RNSAM_NON_HASH_TGT_NODEID_ENTRY_MASK << bit_pos);
+            rnsam->NON_HASH_TGT_NODEID[group] |=
+                (region->node_id &
+                 CMN_BOOKER_RNSAM_NON_HASH_TGT_NODEID_ENTRY_MASK) << bit_pos;
+
+            region_io_count++;
+            break;
+
+        case MOD_CMN_BOOKER_MEM_REGION_TYPE_SYSCACHE:
+            /*
+             * Configure memory region
+             */
+            configure_region(&rnsam->SYS_CACHE_GRP_REGION[region_sys_count],
+                             region->base,
+                             region->size,
+                             SAM_NODE_TYPE_HN_F);
+
+            /* Mark corresponding region as enabled */
+            fwk_assert(region_sys_count < MAX_SCG_COUNT);
+            scg_regions_enabled[region_sys_count] = 1;
+
+            region_sys_count++;
+            break;
+
+        case MOD_CMN_BOOKER_REGION_TYPE_SYSCACHE_SUB:
+            /* Do nothing. System cache sub-regions are handled by HN-Fs */
+            break;
+
+        default:
+            assert(false);
+            return FWK_E_DATA;
+        }
+    }
+
+    /*
+     * If CAL mode is enabled, then only the even numbered HN-F nodes are
+     * programmed to the SYS_CACHE registers. Hence reduce the HN-F count by
+     * half if CAL mode is enabled.
+     */
+    if (config->hnf_cal_mode)
+        hnf_count = ctx->hnf_count/2;
+    else
+        hnf_count = ctx->hnf_count;
+
+    group_count = hnf_count / CMN_BOOKER_HNF_CACHE_GROUP_ENTRIES_PER_GROUP;
+    for (group = 0; group <= group_count; group++)
+        rnsam->SYS_CACHE_GRP_HN_NODEID[group] = ctx->hnf_cache_group[group];
+
+    /* Program the number of HNFs */
+    rnsam->SYS_CACHE_GRP_HN_COUNT = hnf_count;
+
+    /*
+     * If CAL mode is enabled by the configuration program the SCG CAL Mode
+     * enable register.
+     */
+    if (config->hnf_cal_mode)
+        for (region_idx = 0; region_idx < MAX_SCG_COUNT; region_idx++)
+            rnsam->SYS_CACHE_GRP_CAL_MODE |= scg_regions_enabled[region_idx] *
+                (CMN_BOOKER_RNSAM_SCG_HNF_CAL_MODE_EN <<
+                 (region_idx * CMN_BOOKER_RNSAM_SCG_HNF_CAL_MODE_SHIFT));
+
+    /* Program the SYS_CACHE_GRP_SN_NODEID register for PrefetchTgt */
+     if (config->hnf_cal_mode)
+         group_count = config->snf_count/
+             (CMN_BOOKER_RNSAM_SYS_CACHE_GRP_SN_NODEID_ENTRIES_PER_GROUP * 2);
+     else
+         group_count = config->snf_count/
+             CMN_BOOKER_RNSAM_SYS_CACHE_GRP_SN_NODEID_ENTRIES_PER_GROUP;
+
+     for (group = 0; group <= group_count; group++)
+         rnsam->SYS_CACHE_GRP_SN_NODEID[group] = ctx->sn_nodeid_group[group];
+
+    /* Enable RNSAM */
+    rnsam->STATUS = ((uint64_t)config->hnd_node_id <<
+                     CMN_BOOKER_RNSAM_STATUS_DEFAULT_NODEID_POS) |
+                    CMN_BOOKER_RNSAM_STATUS_UNSTALL;
+    __sync_synchronize();
+
+    return FWK_SUCCESS;
+}
+
+static int cmn_booker_setup(void)
+{
+    unsigned int rnsam_idx;
+    int status = FWK_SUCCESS;
+
+    if (!ctx->initialized) {
+        status = cmn_booker_discovery();
+        if (status != FWK_SUCCESS)
+            return FWK_SUCCESS;
+
+        /*
+         * Allocate resources based on the discovery
+         */
+
+        /* Pointers for the internal RN-SAM nodes */
+        if (ctx->internal_rnsam_count != 0) {
+            ctx->internal_rnsam_table = fwk_mm_calloc(
+                ctx->internal_rnsam_count, sizeof(*ctx->internal_rnsam_table));
+        }
+
+        /* Tuples for the external RN-RAM nodes (including their node IDs) */
+        if (ctx->external_rnsam_count != 0) {
+            ctx->external_rnsam_table = fwk_mm_calloc(
+                ctx->external_rnsam_count, sizeof(*ctx->external_rnsam_table));
+        }
+
+        /* Cache groups */
+        if (ctx->hnf_count != 0) {
+            /*
+             * Allocate enough group descriptors to accommodate all expected
+             * HN-F nodes in the system.
+             */
+            ctx->hnf_cache_group = fwk_mm_calloc(
+                ctx->hnf_count / CMN_BOOKER_HNF_CACHE_GROUP_ENTRIES_PER_GROUP,
+                sizeof(*ctx->hnf_cache_group));
+            ctx->sn_nodeid_group = fwk_mm_calloc(
+                ctx->hnf_count /
+                CMN_BOOKER_RNSAM_SYS_CACHE_GRP_SN_NODEID_ENTRIES_PER_GROUP,
+                sizeof(*ctx->sn_nodeid_group));
+        }
+    }
+
+    cmn_booker_configure();
+
+    /* Setup internal RN-SAM nodes */
+    for (rnsam_idx = 0; rnsam_idx < ctx->internal_rnsam_count; rnsam_idx++)
+        cmn_booker_setup_sam(ctx->internal_rnsam_table[rnsam_idx]);
+
+    FWK_LOG_INFO(MOD_NAME "Done");
+
+    ctx->initialized = true;
+
+    return FWK_SUCCESS;
+}
+
+static int cmn_booker_setup_rnsam(unsigned int node_id)
+{
+    unsigned int node_idx;
+
+    for (node_idx = 0; node_idx < ctx->external_rnsam_count; node_idx++) {
+        if (ctx->external_rnsam_table[node_idx].node_id == node_id) {
+            cmn_booker_setup_sam(ctx->external_rnsam_table[node_idx].node);
+            return FWK_SUCCESS;
+        }
+    }
+
+    return FWK_E_PARAM;
+}
+
+/*
+ * PPUv1 State Observer API
+ */
+
+static void post_ppu_on(void *data)
+{
+    assert(data != NULL);
+    cmn_booker_setup_rnsam(*(unsigned int *)data);
+}
+
+static const struct mod_ppu_v1_power_state_observer_api
+cmn_booker_observer_api = {
+    .post_ppu_on = post_ppu_on,
+};
+
+/*
+ * Framework handlers
+ */
+
+static int cmn_booker_init(fwk_id_t module_id, unsigned int element_count,
+    const void *data)
+{
+    const struct mod_cmn_booker_config *config = data;
+
+    /* No elements support */
+    if (element_count > 0)
+        return FWK_E_DATA;
+
+    /* Allocate space for the context */
+    ctx = fwk_mm_calloc(1, sizeof(*ctx));
+
+    if (config->base == 0)
+        return FWK_E_DATA;
+
+    if ((config->mesh_size_x == 0) ||
+        (config->mesh_size_x > CMN_BOOKER_MESH_X_MAX))
+        return FWK_E_DATA;
+
+    if ((config->mesh_size_y == 0) ||
+        (config->mesh_size_y > CMN_BOOKER_MESH_Y_MAX))
+        return FWK_E_DATA;
+
+    if (config->snf_count > CMN_BOOKER_HNF_CACHE_GROUP_ENTRIES_MAX)
+        return FWK_E_DATA;
+
+    ctx->root = get_root_node(config->base, config->hnd_node_id,
+        config->mesh_size_x, config->mesh_size_y);
+
+    ctx->config = config;
+
+    return FWK_SUCCESS;
+}
+
+static int cmn_booker_process_bind_request(fwk_id_t requester_id,
+    fwk_id_t target_id, fwk_id_t api_id, const void **api)
+{
+    *api = &cmn_booker_observer_api;
+    return FWK_SUCCESS;
+}
+
+int cmn_booker_start(fwk_id_t id)
+{
+    if (fwk_id_is_equal(ctx->config->clock_id, FWK_ID_NONE)) {
+        cmn_booker_setup();
+        return FWK_SUCCESS;
+    }
+
+    /* Register the module for clock state notifications */
+    return fwk_notification_subscribe(mod_clock_notification_id_state_changed,
+                                      ctx->config->clock_id, id);
+}
+
+static int cmn_booker_process_notification(
+    const struct fwk_event *event,
+    struct fwk_event *resp_event)
+{
+    struct clock_notification_params *params;
+
+    assert(fwk_id_is_equal(event->id, mod_clock_notification_id_state_changed));
+    assert(fwk_id_is_type(event->target_id, FWK_ID_TYPE_MODULE));
+
+    params = (struct clock_notification_params *)event->params;
+    if (params->new_state == MOD_CLOCK_STATE_RUNNING)
+        cmn_booker_setup();
+
+    return FWK_SUCCESS;
+}
+
+const struct fwk_module module_cmn_booker = {
+    .name = "CMN_BOOKER",
+    .type = FWK_MODULE_TYPE_DRIVER,
+    .api_count = MOD_CMN_BOOKER_API_COUNT,
+    .init = cmn_booker_init,
+    .start = cmn_booker_start,
+    .process_bind_request = cmn_booker_process_bind_request,
+    .process_notification = cmn_booker_process_notification,
+};


### PR DESCRIPTION
Add initial support for CMN Booker interconnect. 

This include configuring SAM tables, programming the nodes and sufficient support for
single chip operation. When compared to other CMN such as CMN Rhodes and
CMN600, CMN Booker has support for MTSX node type and enables coherent
read/writes through HND node.