### PR TITLE
SCMIv2: Add SYSTEM_POWER_STATE_NOTIFY to system_power protocol

### DIFF
--- a/module/scmi_system_power/include/internal/scmi_system_power.h
+++ b/module/scmi_system_power/include/internal/scmi_system_power.h
@@ -22,6 +22,10 @@ enum scmi_sys_power_command_id {
     SCMI_SYS_POWER_STATE_NOTIFY = 0x005,
 };
 
+enum scmi_sys_power_notification_id {
+    SCMI_SYS_POWER_STATE_SET_NOTIFY = 0x000,
+};
+
 /*
  * PROTOCOL_MESSAGE_ATTRIBUTES
  */
@@ -80,8 +84,9 @@ struct __attribute((packed)) scmi_sys_power_state_notify_p2a {
  * SYSTEM_POWER_STATE_NOTIFIER
  */
 
-struct __attribute((packed)) scmi_sys_power_state_notifier_p2a {
+struct __attribute((packed)) scmi_sys_power_state_notifier {
     uint32_t agent_id;
+    uint32_t flags;
     uint32_t system_state;
 };
 


### PR DESCRIPTION
This patch adds the SYSTEM_POWER_STATE_NOTIFY command requesting
notifications on power state changes to the system power protocol.

This patch also adds the notification sent when a power state
change is requested.

Change-Id: I403d11005146fa447e980077b1f315c6a0e3564f
Signed-off-by: Jim Quigley <jim.quigley@arm.com>