### PR TITLE
ci: Add `requirements.txt` for Python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pycodestyle==2.6.0


### PR DESCRIPTION
The CI script requires certain Python packages to be available in order
to succeed. Adding a `requirements.txt` allows users to install all the
necessary requirements with:

    pip install -r requirements.txt

Change-Id: I231bae45baea6196d728b8b82a26b994412aad8b
Signed-off-by: Chris Kay <chris.kay@arm.com>