### PR TITLE
Allow elements to be defined statically

### DIFF
--- a/framework/src/fwk_module.c
+++ b/framework/src/fwk_module.c
@@ -179,11 +179,23 @@ static int init_module(struct fwk_module_ctx *module_ctx,
     }
     #endif
 
-    if (module_config->get_element_table != NULL) {
-        element_table = module_config->get_element_table(module_ctx->id);
-        if (!fwk_expect(element_table != NULL))
-            return FWK_E_PARAM;
+    switch (module_config->elements.type) {
+    case FWK_MODULE_ELEMENTS_TYPE_STATIC:
+        element_table = module_config->elements.table;
 
+        break;
+
+    case FWK_MODULE_ELEMENTS_TYPE_DYNAMIC:
+        if (module_config->elements.generator != NULL) {
+            element_table = module_config->elements.generator(module_ctx->id);
+            if (!fwk_expect(element_table != NULL))
+                return FWK_E_PARAM;
+        }
+
+        break;
+    }
+
+    if (element_table != NULL) {
         for (count = 0; element_table[count].name != NULL; count++)
             continue;
 

--- a/framework/src/fwk_module.c
+++ b/framework/src/fwk_module.c
@@ -24,6 +24,7 @@
 #include <fwk_log.h>
 #include <fwk_mm.h>
 #include <fwk_module.h>
+#include <fwk_module_idx.h>
 #include <fwk_status.h>
 
 #include <stdbool.h>
@@ -46,11 +47,8 @@ struct context {
     /* Flag indicating whether all modules have been initialized */
     bool initialized;
 
-    /* Number of modules */
-    unsigned int module_count;
-
     /* Table of module contexts */
-    struct fwk_module_ctx *module_ctx_table;
+    struct fwk_module_ctx module_ctx_table[FWK_MODULE_IDX_COUNT];
 
     /* Pre-runtime phase stage */
     enum module_stage stage;
@@ -62,8 +60,9 @@ struct context {
     fwk_id_t bind_id;
 };
 
-extern const struct fwk_module *module_table[];
-extern const struct fwk_module_config *module_config_table[];
+extern const struct fwk_module *module_table[FWK_MODULE_IDX_COUNT];
+extern const struct fwk_module_config
+    *module_config_table[FWK_MODULE_IDX_COUNT];
 
 static struct context ctx;
 
@@ -225,13 +224,7 @@ static int init_modules(void)
     unsigned int module_idx;
     struct fwk_module_ctx *module_ctx;
 
-    while (module_table[ctx.module_count] != NULL)
-        ctx.module_count++;
-
-    ctx.module_ctx_table = fwk_mm_calloc(ctx.module_count,
-                                         sizeof(struct fwk_module_ctx));
-
-    for (module_idx = 0; module_idx < ctx.module_count; module_idx++) {
+    for (module_idx = 0; module_idx < FWK_MODULE_IDX_COUNT; module_idx++) {
         module_ctx = &ctx.module_ctx_table[module_idx];
         module_ctx->id = FWK_ID_MODULE(module_idx);
         status = init_module(module_ctx, module_table[module_idx],
@@ -304,7 +297,7 @@ static int bind_modules(unsigned int round)
     unsigned int module_idx;
     struct fwk_module_ctx *module_ctx;
 
-    for (module_idx = 0; module_idx < ctx.module_count; module_idx++) {
+    for (module_idx = 0; module_idx < FWK_MODULE_IDX_COUNT; module_idx++) {
         module_ctx = &ctx.module_ctx_table[module_idx];
         status = bind_module(module_ctx, round);
         if (status != FWK_SUCCESS)
@@ -366,7 +359,7 @@ static int start_modules(void)
     unsigned int module_idx;
     struct fwk_module_ctx *module_ctx;
 
-    for (module_idx = 0; module_idx < ctx.module_count; module_idx++) {
+    for (module_idx = 0; module_idx < FWK_MODULE_IDX_COUNT; module_idx++) {
         module_ctx = &ctx.module_ctx_table[module_idx];
         status = start_module(module_ctx);
         if (status != FWK_SUCCESS)
@@ -470,7 +463,7 @@ bool fwk_module_is_valid_module_id(fwk_id_t id)
     if (!fwk_id_is_type(id, FWK_ID_TYPE_MODULE))
         return false;
 
-    if (fwk_id_get_module_idx(id) >= ctx.module_count)
+    if (fwk_id_get_module_idx(id) >= FWK_MODULE_IDX_COUNT)
         return false;
 
     return true;
@@ -484,7 +477,7 @@ bool fwk_module_is_valid_element_id(fwk_id_t id)
         return false;
 
     module_idx = fwk_id_get_module_idx(id);
-    if (module_idx >= ctx.module_count)
+    if (module_idx >= FWK_MODULE_IDX_COUNT)
         return false;
 
     return (fwk_id_get_element_idx(id) <
@@ -501,7 +494,7 @@ bool fwk_module_is_valid_sub_element_id(fwk_id_t id)
         return false;
 
     module_idx = fwk_id_get_module_idx(id);
-    if (module_idx >= ctx.module_count)
+    if (module_idx >= FWK_MODULE_IDX_COUNT)
         return false;
     module_ctx = &ctx.module_ctx_table[module_idx];
 
@@ -540,7 +533,7 @@ bool fwk_module_is_valid_api_id(fwk_id_t id)
         return false;
 
     module_idx = fwk_id_get_module_idx(id);
-    if (module_idx >= ctx.module_count)
+    if (module_idx >= FWK_MODULE_IDX_COUNT)
         return false;
 
     return (fwk_id_get_api_idx(id) <
@@ -555,7 +548,7 @@ bool fwk_module_is_valid_event_id(fwk_id_t id)
         return false;
 
     module_idx = fwk_id_get_module_idx(id);
-    if (module_idx >= ctx.module_count)
+    if (module_idx >= FWK_MODULE_IDX_COUNT)
         return false;
 
     return (fwk_id_get_event_idx(id) <
@@ -571,7 +564,7 @@ bool fwk_module_is_valid_notification_id(fwk_id_t id)
         return false;
 
     module_idx = fwk_id_get_module_idx(id);
-    if (module_idx >= ctx.module_count)
+    if (module_idx >= FWK_MODULE_IDX_COUNT)
         return false;
 
     return (fwk_id_get_notification_idx(id) <

--- a/framework/test/Makefile
+++ b/framework/test/Makefile
@@ -220,8 +220,14 @@ test_fwk_multi_thread_util_WRAP += osThreadFlagsSet
 test_fwk_multi_thread_util_WRAP += osThreadFlagsWait
 test_fwk_multi_thread_util_WRAP += osThreadNew
 
+test_fwk_module_MODULE_IDX_H := test_fwk_module_module_idx.h
+
 $(foreach test, $(TESTS), \
     $(if $(filter fwk_multi_thread.c, $($(test)_SRC)), \
 		$(eval $(test)_CFLAGS += -DBUILD_HAS_MULTITHREADING)))
+
+$(foreach test, $(TESTS), \
+    $(if $($(test)_MODULE_IDX_H), \
+		$(eval $(test)_CFLAGS += -DFWK_TEST_MODULE_IDX_H=\"$($(test)_MODULE_IDX_H)\"),))
 
 include $(BS_DIR)/test.mk

--- a/framework/test/fwk_module_idx.h
+++ b/framework/test/fwk_module_idx.h
@@ -1,0 +1,33 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FWK_MODULE_IDX_H
+#define FWK_MODULE_IDX_H
+
+#include <fwk_id.h>
+
+#ifdef FWK_TEST_MODULE_IDX_H
+#    include FWK_TEST_MODULE_IDX_H
+#else
+
+enum fwk_module_idx {
+    FWK_MODULE_IDX_TEST0,
+    FWK_MODULE_IDX_TEST1,
+    FWK_MODULE_IDX_TEST2,
+    FWK_MODULE_IDX_COUNT,
+};
+
+static const fwk_id_t fwk_module_id_test0 =
+    FWK_ID_MODULE_INIT(FWK_MODULE_IDX_TEST0);
+static const fwk_id_t fwk_module_id_test1 =
+    FWK_ID_MODULE_INIT(FWK_MODULE_IDX_TEST1);
+static const fwk_id_t fwk_module_id_test2 =
+    FWK_ID_MODULE_INIT(FWK_MODULE_IDX_TEST2);
+
+#endif
+
+#endif /* FWK_MODULE_IDX_H */

--- a/framework/test/fwk_test.c
+++ b/framework/test/fwk_test.c
@@ -4,6 +4,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <fwk_module_idx.h>
 #include <fwk_noreturn.h>
 #include <fwk_status.h>
 #include <fwk_test.h>
@@ -18,8 +19,8 @@ extern struct fwk_test_suite_desc test_suite;
 
 static jmp_buf test_buf_context;
 
-__attribute((weak)) struct fwk_module *module_table[1];
-__attribute((weak)) struct fwk_module_config *module_config_table[1];
+struct fwk_module *module_table[FWK_MODULE_IDX_COUNT];
+struct fwk_module_config *module_config_table[FWK_MODULE_IDX_COUNT];
 
 noreturn void __assert_fail(const char *assertion,
     const char *file, unsigned int line, const char *function)

--- a/framework/test/test_fwk_module.c
+++ b/framework/test/test_fwk_module.c
@@ -8,14 +8,13 @@
 
 #include <fwk_assert.h>
 #include <fwk_macros.h>
+#include <fwk_module_idx.h>
 #include <fwk_status.h>
 #include <fwk_test.h>
 
 #include <stdlib.h>
 #include <string.h>
 
-#define MODULE0_IDX        0
-#define MODULE1_IDX        1
 #define ELEM0_IDX          0
 #define ELEM1_IDX          1
 #define ELEM2_IDX          0
@@ -29,22 +28,22 @@
 #define NOTIFICATION1_IDX  1
 #define NOTIFICATION2_IDX  2
 
-#define MODULE0_ID        FWK_ID_MODULE(MODULE0_IDX)
-#define MODULE1_ID        FWK_ID_MODULE(MODULE1_IDX)
-#define ELEM0_ID          FWK_ID_ELEMENT(MODULE0_IDX, ELEM0_IDX)
-#define ELEM1_ID          FWK_ID_ELEMENT(MODULE0_IDX, ELEM1_IDX)
-#define ELEM2_ID          FWK_ID_ELEMENT(MODULE1_IDX, ELEM2_IDX)
-#define SUB_ELEM0_ID      FWK_ID_SUB_ELEMENT(MODULE0_IDX, \
-                                             ELEM0_IDX, \
-                                             SUB_ELEM0_IDX)
-#define API0_ID           FWK_ID_API(MODULE0_IDX, API0_IDX)
-#define API1_ID           FWK_ID_API(MODULE0_IDX, API1_IDX)
-#define EVENT0_ID         FWK_ID_EVENT(MODULE1_IDX, EVENT0_IDX)
-#define EVENT1_ID         FWK_ID_EVENT(MODULE1_IDX, EVENT1_IDX)
-#define EVENT2_ID         FWK_ID_EVENT(MODULE1_IDX, EVENT2_IDX)
-#define NOTIFICATION0_ID  FWK_ID_NOTIFICATION(MODULE0_IDX, NOTIFICATION0_IDX)
-#define NOTIFICATION1_ID  FWK_ID_NOTIFICATION(MODULE0_IDX, NOTIFICATION1_IDX)
-#define NOTIFICATION2_ID  FWK_ID_NOTIFICATION(MODULE0_IDX, NOTIFICATION2_IDX)
+#define ELEM0_ID FWK_ID_ELEMENT(FWK_MODULE_IDX_FAKE0, ELEM0_IDX)
+#define ELEM1_ID FWK_ID_ELEMENT(FWK_MODULE_IDX_FAKE0, ELEM1_IDX)
+#define ELEM2_ID FWK_ID_ELEMENT(FWK_MODULE_IDX_FAKE1, ELEM2_IDX)
+#define SUB_ELEM0_ID \
+    FWK_ID_SUB_ELEMENT(FWK_MODULE_IDX_FAKE0, ELEM0_IDX, SUB_ELEM0_IDX)
+#define API0_ID FWK_ID_API(FWK_MODULE_IDX_FAKE0, API0_IDX)
+#define API1_ID FWK_ID_API(FWK_MODULE_IDX_FAKE0, API1_IDX)
+#define EVENT0_ID FWK_ID_EVENT(FWK_MODULE_IDX_FAKE1, EVENT0_IDX)
+#define EVENT1_ID FWK_ID_EVENT(FWK_MODULE_IDX_FAKE1, EVENT1_IDX)
+#define EVENT2_ID FWK_ID_EVENT(FWK_MODULE_IDX_FAKE1, EVENT2_IDX)
+#define NOTIFICATION0_ID \
+    FWK_ID_NOTIFICATION(FWK_MODULE_IDX_FAKE0, NOTIFICATION0_IDX)
+#define NOTIFICATION1_ID \
+    FWK_ID_NOTIFICATION(FWK_MODULE_IDX_FAKE0, NOTIFICATION1_IDX)
+#define NOTIFICATION2_ID \
+    FWK_ID_NOTIFICATION(FWK_MODULE_IDX_FAKE0, NOTIFICATION2_IDX)
 
 /* Fake API */
 struct fake_api {
@@ -75,8 +74,8 @@ struct config_module_data {
 static struct config_module_data config_module0;
 static struct config_module_data config_module1;
 
-struct fwk_module *module_table[3];
-struct fwk_module_config *module_config_table[3];
+extern struct fwk_module *module_table[FWK_MODULE_IDX_COUNT];
+extern struct fwk_module_config *module_config_table[FWK_MODULE_IDX_COUNT];
 
 static struct fwk_module fake_module_desc0;
 static struct fwk_module fake_module_desc1;
@@ -231,13 +230,13 @@ static void test_case_setup(void)
     start_count_call = 0;
 
     config_elem0.fake_val = 5;
-    config_elem0.ref = fwk_id_build_element_id(MODULE0_ID, ELEM0_IDX);
+    config_elem0.ref = fwk_id_build_element_id(fwk_module_id_fake0, ELEM0_IDX);
 
     config_elem1.fake_val = 6;
-    config_elem1.ref = fwk_id_build_element_id(MODULE0_ID, ELEM1_IDX);
+    config_elem1.ref = fwk_id_build_element_id(fwk_module_id_fake0, ELEM1_IDX);
 
     config_elem2.fake_val = 7;
-    config_elem2.ref = fwk_id_build_element_id(MODULE1_ID, ELEM2_IDX);
+    config_elem2.ref = fwk_id_build_element_id(fwk_module_id_fake1, ELEM2_IDX);
 
     config_module0.fake_val = 8;
     config_module1.fake_val = 9;
@@ -360,7 +359,7 @@ static void test___fwk_module_init_failure(void)
     assert(result == FWK_E_PARAM);
     init_return_val = FWK_SUCCESS;
 
-    result = __fwk_module_get_state(MODULE0_ID, &state);
+    result = __fwk_module_get_state(fwk_module_id_fake0, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_UNINITIALIZED);
 
@@ -370,11 +369,11 @@ static void test___fwk_module_init_failure(void)
     result = __fwk_module_init();
     assert(result == FWK_E_PARAM);
 
-    result = __fwk_module_get_state(MODULE0_ID, &state);
+    result = __fwk_module_get_state(fwk_module_id_fake0, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_UNINITIALIZED);
 
-    result = __fwk_module_get_state(MODULE1_ID, &state);
+    result = __fwk_module_get_state(fwk_module_id_fake1, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_UNINITIALIZED);
 
@@ -395,11 +394,11 @@ static void test___fwk_module_init_failure(void)
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_INITIALIZED);
 
-    result = __fwk_module_get_state(MODULE0_ID, &state);
+    result = __fwk_module_get_state(fwk_module_id_fake0, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_UNINITIALIZED);
 
-    result = __fwk_module_get_state(MODULE1_ID, &state);
+    result = __fwk_module_get_state(fwk_module_id_fake1, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_UNINITIALIZED);
 }
@@ -428,11 +427,11 @@ static void test___fwk_module_init_bind_failure(void)
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_INITIALIZED);
 
-    result = __fwk_module_get_state(MODULE0_ID, &state);
+    result = __fwk_module_get_state(fwk_module_id_fake0, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_INITIALIZED);
 
-    result = __fwk_module_get_state(MODULE1_ID, &state);
+    result = __fwk_module_get_state(fwk_module_id_fake1, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_INITIALIZED);
 
@@ -461,11 +460,11 @@ static void test___fwk_module_init_start_failure(void)
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_BOUND);
 
-    result = __fwk_module_get_state(MODULE0_ID, &state);
+    result = __fwk_module_get_state(fwk_module_id_fake0, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_BOUND);
 
-    result = __fwk_module_get_state(MODULE1_ID, &state);
+    result = __fwk_module_get_state(fwk_module_id_fake1, &state);
     assert(result == FWK_SUCCESS);
     assert(state == (FWK_MODULE_STATE_BOUND));
 }
@@ -488,19 +487,23 @@ static void check_correct_initialization(void)
     enum fwk_module_state state;
 
     /* Check module 0 is correctly initialized */
-    result = __fwk_module_get_state(MODULE0_ID, &state);
+    result = __fwk_module_get_state(fwk_module_id_fake0, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_STARTED);
-    assert(__fwk_module_get_ctx(MODULE0_ID)->desc == &fake_module_desc0);
-    assert(__fwk_module_get_ctx(MODULE0_ID)->config == &fake_module_config0);
-    assert(__fwk_module_get_ctx(MODULE0_ID)->element_count == 2);
+    assert(
+        __fwk_module_get_ctx(fwk_module_id_fake0)->desc == &fake_module_desc0);
+    assert(
+        __fwk_module_get_ctx(fwk_module_id_fake0)->config ==
+        &fake_module_config0);
+    assert(__fwk_module_get_ctx(fwk_module_id_fake0)->element_count == 2);
 
     /* Check element 0 is correctly initialized */
     result = __fwk_module_get_state(ELEM0_ID, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_STARTED);
-    assert(__fwk_module_get_element_ctx(ELEM0_ID) ==
-           &(__fwk_module_get_ctx(MODULE0_ID)->element_ctx_table[0]));
+    assert(
+        __fwk_module_get_element_ctx(ELEM0_ID) ==
+        &(__fwk_module_get_ctx(fwk_module_id_fake0)->element_ctx_table[0]));
     assert(__fwk_module_get_element_ctx(ELEM0_ID)->desc ==
         &fake_element_desc_table0[0]);
 
@@ -508,18 +511,22 @@ static void check_correct_initialization(void)
     result = __fwk_module_get_state(ELEM1_ID, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_STARTED);
-    assert(__fwk_module_get_element_ctx(ELEM1_ID) ==
-           &(__fwk_module_get_ctx(MODULE0_ID)->element_ctx_table[1]));
+    assert(
+        __fwk_module_get_element_ctx(ELEM1_ID) ==
+        &(__fwk_module_get_ctx(fwk_module_id_fake0)->element_ctx_table[1]));
     assert(__fwk_module_get_element_ctx(ELEM1_ID)->desc ==
         &fake_element_desc_table0[1]);
 
     /* Check module 1 is correctly initialized */
-    result = __fwk_module_get_state(MODULE1_ID, &state);
+    result = __fwk_module_get_state(fwk_module_id_fake1, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_STARTED);
-    assert(__fwk_module_get_ctx(MODULE1_ID)->desc == &fake_module_desc1);
-    assert(__fwk_module_get_ctx(MODULE1_ID)->config == &fake_module_config1);
-    assert(__fwk_module_get_ctx(MODULE1_ID)->element_count == 0);
+    assert(
+        __fwk_module_get_ctx(fwk_module_id_fake1)->desc == &fake_module_desc1);
+    assert(
+        __fwk_module_get_ctx(fwk_module_id_fake1)->config ==
+        &fake_module_config1);
+    assert(__fwk_module_get_ctx(fwk_module_id_fake1)->element_count == 0);
 }
 
 static void test___fwk_module_init_succeed(void)
@@ -569,13 +576,13 @@ static void test___fwk_module_get_state(void)
     assert(result == FWK_E_PARAM);
 
     /* Get module 0 state */
-    id = MODULE0_ID;
+    id = fwk_module_id_fake0;
     result = __fwk_module_get_state(id, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_STARTED);
 
     /* Get module 1 state */
-    id = MODULE1_ID;
+    id = fwk_module_id_fake1;
     result = __fwk_module_get_state(id, &state);
     assert(result == FWK_SUCCESS);
     assert(state == FWK_MODULE_STATE_STARTED);
@@ -593,12 +600,12 @@ static void test_fwk_module_is_valid_module_id(void)
     bool result;
 
     /* Valid module ID */
-    id = MODULE0_ID;
+    id = fwk_module_id_fake0;
     result = fwk_module_is_valid_module_id(id);
     assert(result);
 
     /* Valid module ID */
-    id = MODULE1_ID;
+    id = fwk_module_id_fake1;
     result = fwk_module_is_valid_module_id(id);
     assert(result);
 
@@ -634,17 +641,17 @@ static void test_fwk_module_is_valid_element_id(void)
     assert(!result);
 
     /* Element IDX non valid */
-    id = FWK_ID_ELEMENT(MODULE1_IDX, 0x01);
+    id = FWK_ID_ELEMENT(FWK_MODULE_IDX_FAKE1, 0x01);
     result = fwk_module_is_valid_element_id(id);
     assert(!result);
 
     /* Element IDX non valid */
-    id = FWK_ID_ELEMENT(MODULE0_IDX, 0x02);
+    id = FWK_ID_ELEMENT(FWK_MODULE_IDX_FAKE0, 0x02);
     result = fwk_module_is_valid_element_id(id);
     assert(!result);
 
     /* Invalid type */
-    id = MODULE0_ID;
+    id = fwk_module_id_fake0;
     result = fwk_module_is_valid_element_id(id);
     assert(!result);
 }
@@ -667,13 +674,13 @@ static void test_fwk_module_is_valid_sub_element_id(void)
     assert(!result);
 
     /* Invalid element IDX */
-    result = fwk_module_is_valid_sub_element_id(FWK_ID_SUB_ELEMENT(MODULE0_IDX,
-        5, SUB_ELEM0_IDX));
+    result = fwk_module_is_valid_sub_element_id(
+        FWK_ID_SUB_ELEMENT(FWK_MODULE_IDX_FAKE0, 5, SUB_ELEM0_IDX));
     assert(!result);
 
     /* Invalid sub-element ID */
-    result = fwk_module_is_valid_sub_element_id(FWK_ID_SUB_ELEMENT(MODULE0_IDX,
-        ELEM0_IDX, 5));
+    result = fwk_module_is_valid_sub_element_id(
+        FWK_ID_SUB_ELEMENT(FWK_MODULE_IDX_FAKE0, ELEM0_IDX, 5));
     assert(!result);
 }
 
@@ -682,7 +689,7 @@ static void test_fwk_module_is_valid_entity_id(void)
     bool result;
 
     /* Valid module ID */
-    result = fwk_module_is_valid_entity_id(MODULE0_ID);
+    result = fwk_module_is_valid_entity_id(fwk_module_id_fake0);
     assert(result);
 
     /* Invalid module ID */
@@ -731,17 +738,17 @@ static void test_fwk_module_is_valid_api_id(void)
     assert(!result);
 
     /* API IDX non valid */
-    id = FWK_ID_API(MODULE1_IDX, 0x01);
+    id = FWK_ID_API(FWK_MODULE_IDX_FAKE1, 0x01);
     result = fwk_module_is_valid_api_id(id);
     assert(!result);
 
     /* API IDX non valid */
-    id = FWK_ID_ELEMENT(MODULE0_IDX, 0x02);
+    id = FWK_ID_ELEMENT(FWK_MODULE_IDX_FAKE0, 0x02);
     result = fwk_module_is_valid_api_id(id);
     assert(!result);
 
     /* Invalid type */
-    id = MODULE0_ID;
+    id = fwk_module_id_fake0;
     result = fwk_module_is_valid_api_id(id);
     assert(!result);
 }
@@ -767,17 +774,17 @@ static void test_fwk_module_is_valid_event_id(void)
     assert(!result);
 
     /* Event IDX non valid */
-    id = FWK_ID_EVENT(MODULE1_IDX, 0x03);
+    id = FWK_ID_EVENT(FWK_MODULE_IDX_FAKE1, 0x03);
     result = fwk_module_is_valid_event_id(id);
     assert(!result);
 
     /* Module IDX non valid */
-    id = FWK_ID_EVENT(MODULE0_IDX, 0x00);
+    id = FWK_ID_EVENT(FWK_MODULE_IDX_FAKE0, 0x00);
     result = fwk_module_is_valid_event_id(id);
     assert(!result);
 
     /* Invalid type */
-    id = MODULE0_ID;
+    id = fwk_module_id_fake0;
     result = fwk_module_is_valid_event_id(id);
     assert(!result);
 }
@@ -803,17 +810,17 @@ static void test_fwk_module_is_valid_notification_id(void)
     assert(!result);
 
     /* Event IDX non valid */
-    id = FWK_ID_NOTIFICATION(MODULE0_IDX, 0x03);
+    id = FWK_ID_NOTIFICATION(FWK_MODULE_IDX_FAKE0, 0x03);
     result = fwk_module_is_valid_notification_id(id);
     assert(!result);
 
     /* Module IDX non valid */
-    id = FWK_ID_NOTIFICATION(MODULE1_IDX, 0x00);
+    id = FWK_ID_NOTIFICATION(FWK_MODULE_IDX_FAKE1, 0x00);
     result = fwk_module_is_valid_notification_id(id);
     assert(!result);
 
     /* Invalid type */
-    id = MODULE0_ID;
+    id = fwk_module_id_fake0;
     result = fwk_module_is_valid_notification_id(id);
     assert(!result);
 }
@@ -823,7 +830,7 @@ static void test_fwk_module_get_element_count(void)
     int element_count;
 
     /* Valid module ID with 2 elements */
-    element_count = fwk_module_get_element_count(MODULE0_ID);
+    element_count = fwk_module_get_element_count(fwk_module_id_fake0);
     assert(element_count == 2);
 
     /* Invalid module ID */
@@ -840,12 +847,12 @@ static void test_fwk_module_get_sub_element_count(void)
     int sub_element_count;
 
     /* Invalid element ID */
-    sub_element_count =
-        fwk_module_get_sub_element_count(FWK_ID_ELEMENT(MODULE0_IDX, 0x05));
+    sub_element_count = fwk_module_get_sub_element_count(
+        FWK_ID_ELEMENT(FWK_MODULE_IDX_FAKE0, 0x05));
     assert(sub_element_count == FWK_E_PARAM);
 
     /* Valid module ID, but not an element */
-    sub_element_count = fwk_module_get_sub_element_count(MODULE0_ID);
+    sub_element_count = fwk_module_get_sub_element_count(fwk_module_id_fake0);
     assert(sub_element_count == FWK_E_PARAM);
 
     /* Valid element ID with 0 sub-elements */
@@ -863,7 +870,7 @@ static void test_fwk_module_get_name(void)
     const char *result;
 
     /* Valid module ID */
-    id = MODULE0_ID;
+    id = fwk_module_id_fake0;
     result = fwk_module_get_name(id);
     assert(result != NULL);
     assert(strcmp(result, "FAKE MODULE 0") == 0);
@@ -886,7 +893,7 @@ static void test_fwk_module_get_data(void)
     const void *result;
 
     /* Valid module ID */
-    id = MODULE0_ID;
+    id = fwk_module_id_fake0;
     result = fwk_module_get_data(id);
     assert(result != NULL);
     assert(result == (void *)(&config_module0));
@@ -933,7 +940,7 @@ static void test_fwk_module_bind_stage_failure(void)
      * MODULE_STAGE_INITIALIZE and the module is in
      * FWK_MODULE_STATE_UNINITIALIZED state.
      */
-    result = fwk_module_bind(MODULE0_ID, API1_ID, &api);
+    result = fwk_module_bind(fwk_module_id_fake0, API1_ID, &api);
     assert(result == FWK_E_STATE);
 
     /*
@@ -950,7 +957,7 @@ static void test_fwk_module_bind_stage_failure(void)
      * framework is in MODULE_STAGE_START stage.
      */
     process_bind_request_return_val = FWK_SUCCESS;
-    result = fwk_module_bind(MODULE0_ID, API1_ID, &api);
+    result = fwk_module_bind(fwk_module_id_fake0, API1_ID, &api);
     assert(result == FWK_E_STATE);
 }
 
@@ -972,20 +979,20 @@ static void test_fwk_module_bind(void)
     assert(result == FWK_E_PARAM);
 
     /* The binding request should fail because the API ID is not valid */
-    result = fwk_module_bind(MODULE1_ID, FWK_ID_API(1, 0), &api);
+    result = fwk_module_bind(fwk_module_id_fake1, FWK_ID_API(1, 0), &api);
     assert(result == FWK_E_PARAM);
 
     /*
      * The binding request should fail because API0_ID does not belong to
-     * MODULE1_ID.
+     * fwk_module_id_fake1.
      */
-    result = fwk_module_bind(MODULE1_ID, API0_ID, &api);
+    result = fwk_module_bind(fwk_module_id_fake1, API0_ID, &api);
     assert(result == FWK_E_PARAM);
 
     /*
      * The binding request should fail because the API address pointer is NULL
      */
-    result = fwk_module_bind(MODULE0_ID, API1_ID, NULL);
+    result = fwk_module_bind(fwk_module_id_fake0, API1_ID, NULL);
     assert(result == FWK_E_PARAM);
 
     /*
@@ -993,7 +1000,7 @@ static void test_fwk_module_bind(void)
      * associated with the module fails.
      */
     process_bind_request_return_val = FWK_E_PARAM;
-    result = fwk_module_bind(MODULE0_ID, API1_ID, &api);
+    result = fwk_module_bind(fwk_module_id_fake0, API1_ID, &api);
     assert(result == FWK_E_PARAM);
     process_bind_request_return_val = FWK_SUCCESS;
 
@@ -1003,13 +1010,13 @@ static void test_fwk_module_bind(void)
      * function.
      */
     process_bind_request_return_api = false;
-    result = fwk_module_bind(MODULE0_ID, API1_ID, &null_api);
+    result = fwk_module_bind(fwk_module_id_fake0, API1_ID, &null_api);
     assert(result == FWK_E_HANDLER);
     assert(null_api == NULL);
     process_bind_request_return_api = true;
 
     /* The binding request should return successfully */
-    result = fwk_module_bind(MODULE0_ID, API1_ID, &api);
+    result = fwk_module_bind(fwk_module_id_fake0, API1_ID, &api);
     assert(result == FWK_SUCCESS);
 }
 

--- a/framework/test/test_fwk_module.c
+++ b/framework/test/test_fwk_module.c
@@ -277,10 +277,12 @@ static void test_case_setup(void)
     fake_element_desc_table1[1].name = NULL;
     fake_element_desc_table1[1].data = NULL;
 
-    fake_module_config0.get_element_table = get_element_table0;
+    fake_module_config0.elements.type = FWK_MODULE_ELEMENTS_TYPE_DYNAMIC;
+    fake_module_config0.elements.generator = get_element_table0;
     fake_module_config0.data = &config_module0;
 
-    fake_module_config1.get_element_table = get_element_table1;
+    fake_module_config1.elements.type = FWK_MODULE_ELEMENTS_TYPE_DYNAMIC;
+    fake_module_config1.elements.generator = get_element_table1;
     fake_module_config1.data = &config_module1;
 
     module_table[0] = &fake_module_desc0;
@@ -539,7 +541,7 @@ static void test___fwk_module_init_succeed(void)
     fake_module_desc1.start = NULL;
 
     /* Module 1 has no element */
-    fake_module_config1.get_element_table = NULL;
+    fake_module_config1.elements.generator = NULL;
 
     bind_count_call = 0;
     start_count_call = 0;

--- a/framework/test/test_fwk_module_module_idx.h
+++ b/framework/test/test_fwk_module_module_idx.h
@@ -1,0 +1,24 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TEST_FWK_MODULE_MODULE_IDX_H
+#define TEST_FWK_MODULE_MODULE_IDX_H
+
+#include <fwk_id.h>
+
+enum fwk_module_idx {
+    FWK_MODULE_IDX_FAKE0,
+    FWK_MODULE_IDX_FAKE1,
+    FWK_MODULE_IDX_COUNT,
+};
+
+static const fwk_id_t fwk_module_id_fake0 =
+    FWK_ID_MODULE_INIT(FWK_MODULE_IDX_FAKE0);
+static const fwk_id_t fwk_module_id_fake1 =
+    FWK_ID_MODULE_INIT(FWK_MODULE_IDX_FAKE1);
+
+#endif /* TEST_FWK_MODULE_MODULE_IDX_H */

--- a/product/juno/module/juno_system/src/mod_juno_system.c
+++ b/product/juno/module/juno_system/src/mod_juno_system.c
@@ -372,7 +372,4 @@ const struct fwk_module module_juno_system = {
 };
 
 /* No elements, no configuration data */
-struct fwk_module_config config_juno_system = {
-    .get_element_table = NULL,
-    .data = NULL,
-};
+struct fwk_module_config config_juno_system = { 0 };

--- a/product/juno/scp_ramfw/config_clock.c
+++ b/product/juno/scp_ramfw/config_clock.c
@@ -112,13 +112,15 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
-        .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
-        .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
-    }),
+    .data =
+        &(struct mod_clock_config){
+            .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
+            .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
 };

--- a/product/juno/scp_ramfw/config_debug.c
+++ b/product/juno/scp_ramfw/config_debug.c
@@ -32,6 +32,5 @@ static const struct fwk_element *get_debug_element_table(fwk_id_t module_id)
 
 /* Configuration of the Debug module */
 struct fwk_module_config config_debug = {
-    .get_element_table = get_debug_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_debug_element_table),
 };

--- a/product/juno/scp_ramfw/config_dvfs.c
+++ b/product/juno/scp_ramfw/config_dvfs.c
@@ -420,6 +420,5 @@ static const struct fwk_element *dvfs_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_dvfs = {
-    .get_element_table = dvfs_get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(dvfs_get_element_table),
 };

--- a/product/juno/scp_ramfw/config_i2c.c
+++ b/product/juno/scp_ramfw/config_i2c.c
@@ -38,7 +38,7 @@ static const struct fwk_element *dw_apb_i2c_get_element_table(
 }
 
 struct fwk_module_config config_dw_apb_i2c = {
-    .get_element_table = dw_apb_i2c_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(dw_apb_i2c_get_element_table),
 };
 
 static const struct fwk_element i2c_element_table[] = {
@@ -59,5 +59,5 @@ static const struct fwk_element *i2c_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_i2c = {
-    .get_element_table = i2c_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(i2c_get_element_table),
 };

--- a/product/juno/scp_ramfw/config_juno_adc.c
+++ b/product/juno/scp_ramfw/config_juno_adc.c
@@ -68,5 +68,5 @@ static const struct fwk_element *get_adc_juno_element_table(fwk_id_t id)
 }
 
 struct fwk_module_config config_juno_adc = {
-    .get_element_table = get_adc_juno_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_adc_juno_element_table),
 };

--- a/product/juno/scp_ramfw/config_juno_cdcel937.c
+++ b/product/juno/scp_ramfw/config_juno_cdcel937.c
@@ -203,8 +203,10 @@ static const struct fwk_element *juno_cdcel937_get_element_table(
 }
 
 struct fwk_module_config config_juno_cdcel937 = {
-    .get_element_table = juno_cdcel937_get_element_table,
-    .data = &(struct mod_juno_cdcel937_config) {
-        .i2c_hal_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_I2C, 0),
-    },
+    .data =
+        &(struct mod_juno_cdcel937_config){
+            .i2c_hal_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_I2C, 0),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(juno_cdcel937_get_element_table),
 };

--- a/product/juno/scp_ramfw/config_juno_ddr_phy400.c
+++ b/product/juno/scp_ramfw/config_juno_ddr_phy400.c
@@ -47,8 +47,10 @@ static const struct fwk_element *juno_ddr_phy400_get_element_table
 }
 
 struct fwk_module_config config_juno_ddr_phy400 = {
-    .get_element_table = juno_ddr_phy400_get_element_table,
-    .data = &((struct mod_juno_ddr_phy400_config) {
-        .timer_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
-    })
+    .data =
+        &(struct mod_juno_ddr_phy400_config){
+            .timer_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(juno_ddr_phy400_get_element_table),
 };

--- a/product/juno/scp_ramfw/config_juno_debug.c
+++ b/product/juno/scp_ramfw/config_juno_debug.c
@@ -69,8 +69,10 @@ static const struct fwk_element *get_juno_debug_elem_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_juno_debug = {
-    .get_element_table = get_juno_debug_elem_table,
-    .data = &((struct mod_juno_debug_config) {
-        .timer_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
-    }),
+    .data =
+        &(struct mod_juno_debug_config){
+            .timer_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_juno_debug_elem_table),
 };

--- a/product/juno/scp_ramfw/config_juno_dmc400.c
+++ b/product/juno/scp_ramfw/config_juno_dmc400.c
@@ -111,12 +111,14 @@ static const struct fwk_element *juno_dmc400_get_element_table
 
 /* Configuration of the Juno DMC400 module */
 struct fwk_module_config config_juno_dmc400 = {
-    .get_element_table = juno_dmc400_get_element_table,
-    .data = &((struct mod_juno_dmc400_module_config) {
-        .timer_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
-        .ddr_phy_module_id =
-            FWK_ID_MODULE_INIT(FWK_MODULE_IDX_JUNO_DDR_PHY400),
-        .ddr_phy_api_id =
-            FWK_ID_API_INIT(FWK_MODULE_IDX_JUNO_DDR_PHY400, 0),
-    })
+    .data =
+        &(struct mod_juno_dmc400_module_config){
+            .timer_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
+            .ddr_phy_module_id =
+                FWK_ID_MODULE_INIT(FWK_MODULE_IDX_JUNO_DDR_PHY400),
+            .ddr_phy_api_id =
+                FWK_ID_API_INIT(FWK_MODULE_IDX_JUNO_DDR_PHY400, 0),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(juno_dmc400_get_element_table),
 };

--- a/product/juno/scp_ramfw/config_juno_hdlcd.c
+++ b/product/juno/scp_ramfw/config_juno_hdlcd.c
@@ -120,5 +120,5 @@ static const struct fwk_element *juno_hdlcd_get_element_table(
 }
 
 struct fwk_module_config config_juno_hdlcd = {
-    .get_element_table = juno_hdlcd_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(juno_hdlcd_get_element_table),
 };

--- a/product/juno/scp_ramfw/config_juno_ppu.c
+++ b/product/juno/scp_ramfw/config_juno_ppu.c
@@ -135,10 +135,13 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_juno_ppu = {
-    .get_element_table = get_element_table,
-    .data = &((struct mod_juno_ppu_config) {
-        .timer_alarm_id = FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_TIMER,
-                                                  0,
-                                                  JUNO_PPU_ALARM_IDX),
-    }),
+    .data =
+        &(struct mod_juno_ppu_config){
+            .timer_alarm_id = FWK_ID_SUB_ELEMENT_INIT(
+                FWK_MODULE_IDX_TIMER,
+                0,
+                JUNO_PPU_ALARM_IDX),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_ramfw/config_juno_pvt.c
+++ b/product/juno/scp_ramfw/config_juno_pvt.c
@@ -265,5 +265,5 @@ static const struct fwk_element *get_pvt_juno_element_table(fwk_id_t id)
 }
 
 struct fwk_module_config config_juno_pvt = {
-    .get_element_table = get_pvt_juno_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pvt_juno_element_table),
 };

--- a/product/juno/scp_ramfw/config_juno_soc_clock_ram.c
+++ b/product/juno/scp_ramfw/config_juno_soc_clock_ram.c
@@ -475,12 +475,17 @@ static const struct fwk_element *juno_soc_clock_ram_get_element_table
 }
 
 struct fwk_module_config config_juno_soc_clock_ram = {
-    .get_element_table = juno_soc_clock_ram_get_element_table,
-    .data = &((struct mod_juno_soc_clock_ram_config) {
+    .data =
+        &(struct mod_juno_soc_clock_ram_config){
             .timer_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
-            .debug_pd_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_POWER_DOMAIN,
+            .debug_pd_id = FWK_ID_ELEMENT_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
                 POWER_DOMAIN_IDX_DBGSYS),
-            .systop_pd_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_POWER_DOMAIN,
+            .systop_pd_id = FWK_ID_ELEMENT_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
                 POWER_DOMAIN_IDX_SYSTOP),
-        }),
+        },
+
+    .elements =
+        FWK_MODULE_DYNAMIC_ELEMENTS(juno_soc_clock_ram_get_element_table),
 };

--- a/product/juno/scp_ramfw/config_juno_thermal.c
+++ b/product/juno/scp_ramfw/config_juno_thermal.c
@@ -45,5 +45,5 @@ static const struct fwk_element *juno_thermal_get_element_table(
 }
 
 const struct fwk_module_config config_juno_thermal = {
-    .get_element_table = juno_thermal_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(juno_thermal_get_element_table),
 };

--- a/product/juno/scp_ramfw/config_juno_xrp7724.c
+++ b/product/juno/scp_ramfw/config_juno_xrp7724.c
@@ -125,16 +125,20 @@ static const struct fwk_element *juno_xrp7724_get_element_table(
 }
 
 const struct fwk_module_config config_juno_xrp7724 = {
-    .get_element_table = juno_xrp7724_get_element_table,
-    .data = &((struct mod_juno_xrp7724_config) {
-        .slave_address = 0x28,
-        .i2c_hal_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_I2C, 0),
-        .timer_hal_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
-        .gpio_assert_id = FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_JUNO_XRP7724,
-            MOD_JUNO_XRP7724_ELEMENT_IDX_GPIO,
-            MOD_JUNO_XRP7724_GPIO_IDX_ASSERT),
-        .gpio_mode_id = FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_JUNO_XRP7724,
-            MOD_JUNO_XRP7724_ELEMENT_IDX_GPIO,
-            MOD_JUNO_XRP7724_GPIO_IDX_MODE),
-    }),
+    .data =
+        &(struct mod_juno_xrp7724_config){
+            .slave_address = 0x28,
+            .i2c_hal_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_I2C, 0),
+            .timer_hal_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
+            .gpio_assert_id = FWK_ID_SUB_ELEMENT_INIT(
+                FWK_MODULE_IDX_JUNO_XRP7724,
+                MOD_JUNO_XRP7724_ELEMENT_IDX_GPIO,
+                MOD_JUNO_XRP7724_GPIO_IDX_ASSERT),
+            .gpio_mode_id = FWK_ID_SUB_ELEMENT_INIT(
+                FWK_MODULE_IDX_JUNO_XRP7724,
+                MOD_JUNO_XRP7724_ELEMENT_IDX_GPIO,
+                MOD_JUNO_XRP7724_GPIO_IDX_MODE),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(juno_xrp7724_get_element_table),
 };

--- a/product/juno/scp_ramfw/config_log.c
+++ b/product/juno/scp_ramfw/config_log.c
@@ -41,7 +41,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*
@@ -55,6 +55,5 @@ static const struct mod_log_config log_data = {
 };
 
 struct fwk_module_config config_log = {
-    .get_element_table = NULL,
     .data = &log_data,
 };

--- a/product/juno/scp_ramfw/config_mhu.c
+++ b/product/juno/scp_ramfw/config_mhu.c
@@ -55,6 +55,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_mhu = {
-    .get_element_table = get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_ramfw/config_mock_psu.c
+++ b/product/juno/scp_ramfw/config_mock_psu.c
@@ -56,6 +56,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_mock_psu = {
-    .get_element_table = get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_ramfw/config_power_domain.c
+++ b/product/juno/scp_ramfw/config_power_domain.c
@@ -307,6 +307,7 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_power_domain = {
-    .get_element_table = get_element_table,
-    .data = &(struct mod_power_domain_config){ 0 }
+    .data = &(struct mod_power_domain_config){ 0 },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_ramfw/config_psu.c
+++ b/product/juno/scp_ramfw/config_psu.c
@@ -119,5 +119,5 @@ static const struct fwk_element *psu_get_dev_desc_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_psu = {
-    .get_element_table = psu_get_dev_desc_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(psu_get_dev_desc_table),
 };

--- a/product/juno/scp_ramfw/config_reg_sensor.c
+++ b/product/juno/scp_ramfw/config_reg_sensor.c
@@ -45,6 +45,5 @@ static const struct fwk_element *get_reg_sensor_element_table(fwk_id_t id)
 }
 
 struct fwk_module_config config_reg_sensor = {
-    .get_element_table = get_reg_sensor_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_reg_sensor_element_table),
 };

--- a/product/juno/scp_ramfw/config_scmi.c
+++ b/product/juno/scp_ramfw/config_scmi.c
@@ -105,12 +105,14 @@ static const struct mod_scmi_agent agent_table[] = {
 };
 
 struct fwk_module_config config_scmi = {
-    .get_element_table = get_element_table,
-    .data = &(struct mod_scmi_config) {
-        .protocol_count_max = 5,
-        .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
-        .agent_table = agent_table,
-        .vendor_identifier = "arm",
-        .sub_vendor_identifier = "arm",
-    },
+    .data =
+        &(struct mod_scmi_config){
+            .protocol_count_max = 5,
+            .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
+            .agent_table = agent_table,
+            .vendor_identifier = "arm",
+            .sub_vendor_identifier = "arm",
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_ramfw/config_scmi_perf.c
+++ b/product/juno/scp_ramfw/config_scmi_perf.c
@@ -66,7 +66,6 @@ static const struct mod_scmi_perf_domain_config domains[] = {
 
 
 struct fwk_module_config config_scmi_perf = {
-    .get_element_table = NULL,
     .data = &((struct mod_scmi_perf_config) {
         .domains = &domains,
 #ifdef BUILD_HAS_FAST_CHANNELS

--- a/product/juno/scp_ramfw/config_sds.c
+++ b/product/juno/scp_ramfw/config_sds.c
@@ -73,6 +73,7 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = get_element_table,
     .data = &sds_module_config,
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_ramfw/config_sensor.c
+++ b/product/juno/scp_ramfw/config_sensor.c
@@ -377,6 +377,5 @@ static const struct fwk_element *get_sensor_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sensor = {
-    .get_element_table = get_sensor_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_sensor_element_table),
 };

--- a/product/juno/scp_ramfw/config_smt.c
+++ b/product/juno/scp_ramfw/config_smt.c
@@ -100,6 +100,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_smt = {
-    .get_element_table = get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_ramfw/config_system_power.c
+++ b/product/juno/scp_ramfw/config_system_power.c
@@ -49,11 +49,13 @@ static const struct fwk_element *system_power_get_element_table(
 }
 
 const struct fwk_module_config config_system_power = {
-    .data = &((struct mod_system_power_config) {
-        .soc_wakeup_irq = EXT_WAKEUP_IRQ,
-        .driver_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_JUNO_SYSTEM),
-        .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_JUNO_SYSTEM, 0),
-        .initial_system_power_state = MOD_PD_STATE_ON,
-    }),
-    .get_element_table = system_power_get_element_table,
+    .data =
+        &(struct mod_system_power_config){
+            .soc_wakeup_irq = EXT_WAKEUP_IRQ,
+            .driver_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_JUNO_SYSTEM),
+            .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_JUNO_SYSTEM, 0),
+            .initial_system_power_state = MOD_PD_STATE_ON,
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_power_get_element_table),
 };

--- a/product/juno/scp_ramfw/config_timer.c
+++ b/product/juno/scp_ramfw/config_timer.c
@@ -39,7 +39,7 @@ static const struct fwk_element *gtimer_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_element_table),
 };
 
 static const struct fwk_element timer_element_table[] = {
@@ -60,5 +60,5 @@ static const struct fwk_element *timer_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_element_table),
 };

--- a/product/juno/scp_romfw/config_juno_ppu.c
+++ b/product/juno/scp_romfw/config_juno_ppu.c
@@ -114,6 +114,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_juno_ppu = {
-    .get_element_table = get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_romfw/config_log.c
+++ b/product/juno/scp_romfw/config_log.c
@@ -46,7 +46,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*
@@ -60,6 +60,5 @@ static const struct mod_log_config log_data = {
 };
 
 struct fwk_module_config config_log = {
-    .get_element_table = NULL,
     .data = &log_data,
 };

--- a/product/juno/scp_romfw/config_sds.c
+++ b/product/juno/scp_romfw/config_sds.c
@@ -189,6 +189,7 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = get_element_table,
     .data = &sds_module_config,
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_romfw/config_timer.c
+++ b/product/juno/scp_romfw/config_timer.c
@@ -34,5 +34,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_gtimer = {
-    .get_element_table = get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_romfw_bypass/config_juno_ppu.c
+++ b/product/juno/scp_romfw_bypass/config_juno_ppu.c
@@ -114,6 +114,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_juno_ppu = {
-    .get_element_table = get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_romfw_bypass/config_log.c
+++ b/product/juno/scp_romfw_bypass/config_log.c
@@ -46,7 +46,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*
@@ -60,6 +60,5 @@ static const struct mod_log_config log_data = {
 };
 
 struct fwk_module_config config_log = {
-    .get_element_table = NULL,
     .data = &log_data,
 };

--- a/product/juno/scp_romfw_bypass/config_sds.c
+++ b/product/juno/scp_romfw_bypass/config_sds.c
@@ -189,6 +189,7 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = get_element_table,
     .data = &sds_module_config,
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/juno/scp_romfw_bypass/config_timer.c
+++ b/product/juno/scp_romfw_bypass/config_timer.c
@@ -34,5 +34,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_gtimer = {
-    .get_element_table = get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/n1sdp/mcp_ramfw/config_log.c
+++ b/product/n1sdp/mcp_ramfw/config_log.c
@@ -40,7 +40,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/n1sdp/mcp_ramfw/config_mhu.c
+++ b/product/n1sdp/mcp_ramfw/config_mhu.c
@@ -35,5 +35,5 @@ static const struct fwk_element *mhu_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_n1sdp_mhu = {
-    .get_element_table = mhu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(mhu_get_element_table),
 };

--- a/product/n1sdp/mcp_ramfw/config_pik_clock.c
+++ b/product/n1sdp/mcp_ramfw/config_pik_clock.c
@@ -78,5 +78,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 const struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/n1sdp/mcp_ramfw/config_scmi_agent.c
+++ b/product/n1sdp/mcp_ramfw/config_scmi_agent.c
@@ -38,6 +38,5 @@ static const struct fwk_element *get_agent_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_scmi_agent = {
-    .get_element_table = get_agent_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_agent_table),
 };

--- a/product/n1sdp/mcp_ramfw/config_smt.c
+++ b/product/n1sdp/mcp_ramfw/config_smt.c
@@ -39,5 +39,5 @@ static const struct fwk_element *smt_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_n1sdp_smt = {
-    .get_element_table = smt_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(smt_get_element_table),
 };

--- a/product/n1sdp/mcp_romfw/config_log.c
+++ b/product/n1sdp/mcp_romfw/config_log.c
@@ -45,7 +45,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/n1sdp/scp_ramfw/config_clock.c
+++ b/product/n1sdp/scp_ramfw/config_clock.c
@@ -71,14 +71,15 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
-        .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
-        .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
-    }),
+    .data =
+        &(struct mod_clock_config){
+            .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
+            .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
+        },
 
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
 };

--- a/product/n1sdp/scp_ramfw/config_cmn600.c
+++ b/product/n1sdp/scp_ramfw/config_cmn600.c
@@ -168,7 +168,6 @@ static const struct mod_cmn600_memory_region_map mmap[] = {
 };
 
 const struct fwk_module_config config_cmn600 = {
-    .get_element_table = NULL,
     .data = &((struct mod_cmn600_config) {
         .base = SCP_CMN600_BASE,
         .mesh_size_x = 4,

--- a/product/n1sdp/scp_ramfw/config_css_clock.c
+++ b/product/n1sdp/scp_ramfw/config_css_clock.c
@@ -184,5 +184,5 @@ static const struct fwk_element *css_clock_get_element_table
 }
 
 const struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_debugger_cli.c
+++ b/product/n1sdp/scp_ramfw/config_debugger_cli.c
@@ -21,6 +21,5 @@ static const struct mod_debugger_cli_module_config debugger_cli_data = {
  * Configuration for the debugger CLI module
  */
 struct fwk_module_config config_debugger_cli = {
-    .get_element_table = NULL,
     .data = &debugger_cli_data
 };

--- a/product/n1sdp/scp_ramfw/config_log.c
+++ b/product/n1sdp/scp_ramfw/config_log.c
@@ -40,7 +40,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/n1sdp/scp_ramfw/config_mhu.c
+++ b/product/n1sdp/scp_ramfw/config_mhu.c
@@ -53,5 +53,5 @@ static const struct fwk_element *mhu_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_mhu = {
-    .get_element_table = mhu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(mhu_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_n1sdp_ddr_phy.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_ddr_phy.c
@@ -35,5 +35,5 @@ static const struct fwk_element *n1sdp_ddr_phy_get_element_table
 
 /* Configuration of the N1SDP DDR PHY module. */
 const struct fwk_module_config config_n1sdp_ddr_phy = {
-    .get_element_table = n1sdp_ddr_phy_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(n1sdp_ddr_phy_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_n1sdp_dmc620.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_dmc620.c
@@ -45,12 +45,12 @@ static const struct fwk_element *dmc620_get_element_table(fwk_id_t module_id)
 
 /* Configuration of the DMC620 module. */
 const struct fwk_module_config config_n1sdp_dmc620 = {
-    .get_element_table = dmc620_get_element_table,
-    .data = &((struct mod_dmc620_module_config) {
-            .ddr_module_id = FWK_ID_MODULE_INIT(
-                FWK_MODULE_IDX_N1SDP_DDR_PHY),
-            .ddr_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_N1SDP_DDR_PHY,
-                0),
+    .data =
+        &(struct mod_dmc620_module_config){
+            .ddr_module_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_N1SDP_DDR_PHY),
+            .ddr_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_N1SDP_DDR_PHY, 0),
             .ddr_speed = DDR_CLOCK_MHZ,
-        }),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(dmc620_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_n1sdp_i2c.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_i2c.c
@@ -60,5 +60,5 @@ static const struct fwk_element *get_i2c_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_n1sdp_i2c = {
-    .get_element_table = get_i2c_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_i2c_table),
 };

--- a/product/n1sdp/scp_ramfw/config_n1sdp_pcie.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_pcie.c
@@ -48,5 +48,5 @@ static const struct fwk_element *n1sdp_pcie_get_element_table
 }
 
 const struct fwk_module_config config_n1sdp_pcie = {
-    .get_element_table = n1sdp_pcie_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(n1sdp_pcie_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_n1sdp_pll.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_pll.c
@@ -90,9 +90,11 @@ static const struct fwk_element *n1sdp_pll_get_element_table
 }
 
 const struct fwk_module_config config_n1sdp_pll = {
-    .get_element_table = n1sdp_pll_get_element_table,
-    .data = &((struct n1sdp_pll_module_config) {
-        .custom_freq_table = freq_table,
-        .custom_freq_table_size = FWK_ARRAY_SIZE(freq_table),
-    }),
+    .data =
+        &(struct n1sdp_pll_module_config){
+            .custom_freq_table = freq_table,
+            .custom_freq_table_size = FWK_ARRAY_SIZE(freq_table),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(n1sdp_pll_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_n1sdp_remote_pd.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_remote_pd.c
@@ -76,5 +76,5 @@ static const struct fwk_element *remote_pd_get_element_table(fwk_id_t id)
 }
 
 const struct fwk_module_config config_n1sdp_remote_pd = {
-    .get_element_table = remote_pd_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(remote_pd_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_n1sdp_timer_sync.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_timer_sync.c
@@ -41,5 +41,5 @@ static const struct fwk_element *n1sdp_tsync_get_element_table(
 }
 
 struct fwk_module_config config_n1sdp_timer_sync = {
-    .get_element_table = n1sdp_tsync_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(n1sdp_tsync_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_pik_clock.c
+++ b/product/n1sdp/scp_ramfw/config_pik_clock.c
@@ -1023,5 +1023,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 const struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_power_domain.c
+++ b/product/n1sdp/scp_ramfw/config_power_domain.c
@@ -509,6 +509,8 @@ static const struct fwk_element *n1sdp_power_domain_get_element_table
  * Power module configuration data
  */
 const struct fwk_module_config config_power_domain = {
-    .get_element_table = n1sdp_power_domain_get_element_table,
     .data = &n1sdp_power_domain_config,
+
+    .elements =
+        FWK_MODULE_DYNAMIC_ELEMENTS(n1sdp_power_domain_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_ppu_v0.c
+++ b/product/n1sdp/scp_ramfw/config_ppu_v0.c
@@ -39,5 +39,5 @@ static const struct fwk_element *ppu_v0_get_element_table(fwk_id_t module_id)
  * Power module configuration data
  */
 const struct fwk_module_config config_ppu_v0 = {
-    .get_element_table = ppu_v0_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ppu_v0_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_ppu_v1.c
+++ b/product/n1sdp/scp_ramfw/config_ppu_v1.c
@@ -160,6 +160,7 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
  * Power module configuration data
  */
 const struct fwk_module_config config_ppu_v1 = {
-    .get_element_table = ppu_v1_get_element_table,
     .data = &ppu_v1_config_data,
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ppu_v1_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_scmi.c
+++ b/product/n1sdp/scp_ramfw/config_scmi.c
@@ -86,12 +86,14 @@ static struct mod_scmi_agent agent_table[] = {
 };
 
 const struct fwk_module_config config_scmi = {
-    .get_element_table = get_service_table,
-    .data = &((struct mod_scmi_config) {
-        .protocol_count_max = 8,
-        .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
-        .agent_table = agent_table,
-        .vendor_identifier = "arm",
-        .sub_vendor_identifier = "arm",
-    }),
+    .data =
+        &(struct mod_scmi_config){
+            .protocol_count_max = 8,
+            .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
+            .agent_table = agent_table,
+            .vendor_identifier = "arm",
+            .sub_vendor_identifier = "arm",
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_service_table),
 };

--- a/product/n1sdp/scp_ramfw/config_sds.c
+++ b/product/n1sdp/scp_ramfw/config_sds.c
@@ -155,6 +155,6 @@ static const struct fwk_element *sds_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = sds_get_element_table,
     .data = &sds_module_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sds_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_sensor.c
+++ b/product/n1sdp/scp_ramfw/config_sensor.c
@@ -98,14 +98,16 @@ static const struct fwk_element *get_n1sdp_sensor_element_table(fwk_id_t id)
 }
 
 struct fwk_module_config config_n1sdp_sensor = {
-    .get_element_table = get_n1sdp_sensor_element_table,
-    .data = &((struct mod_n1sdp_sensor_config) {
-        .alarm_id = FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0, 0),
-        .alarm_api = FWK_ID_API_INIT(FWK_MODULE_IDX_TIMER,
-                                     MOD_TIMER_API_IDX_ALARM),
-        .t_sensor_count = 3,
-        .v_sensor_count = 5,
-    }),
+    .data =
+        &(struct mod_n1sdp_sensor_config){
+            .alarm_id = FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0, 0),
+            .alarm_api =
+                FWK_ID_API_INIT(FWK_MODULE_IDX_TIMER, MOD_TIMER_API_IDX_ALARM),
+            .t_sensor_count = 3,
+            .v_sensor_count = 5,
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_n1sdp_sensor_element_table),
 };
 
 /*
@@ -185,6 +187,5 @@ static const struct fwk_element *get_sensor_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sensor = {
-    .get_element_table = get_sensor_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_sensor_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_smt.c
+++ b/product/n1sdp/scp_ramfw/config_smt.c
@@ -80,5 +80,5 @@ static const struct fwk_element *smt_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_smt = {
-    .get_element_table = smt_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(smt_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_ssc.c
+++ b/product/n1sdp/scp_ramfw/config_ssc.c
@@ -14,7 +14,6 @@
 #include <stddef.h>
 
 const struct fwk_module_config config_ssc = {
-    .get_element_table = NULL,
     .data = &(struct mod_ssc_config) {
         .ssc_base = SCP_SSC_BASE,
         .ssc_debug_cfg_set = 0xFF,

--- a/product/n1sdp/scp_ramfw/config_system_info.c
+++ b/product/n1sdp/scp_ramfw/config_system_info.c
@@ -15,7 +15,6 @@
 #include <stddef.h>
 
 const struct fwk_module_config config_system_info = {
-    .get_element_table = NULL,
     .data = &((struct mod_system_info_config) {
             .system_info_driver_module_id =
                 FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SSC),

--- a/product/n1sdp/scp_ramfw/config_system_power.c
+++ b/product/n1sdp/scp_ramfw/config_system_power.c
@@ -89,6 +89,6 @@ static const struct fwk_element *n1sdp_system_get_element_table(
 }
 
 const struct fwk_module_config config_system_power = {
-    .get_element_table = n1sdp_system_get_element_table,
     .data = &system_power_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(n1sdp_system_get_element_table),
 };

--- a/product/n1sdp/scp_ramfw/config_timer.c
+++ b/product/n1sdp/scp_ramfw/config_timer.c
@@ -43,7 +43,7 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };
 
 /*
@@ -67,5 +67,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/n1sdp/scp_romfw/config_log.c
+++ b/product/n1sdp/scp_romfw/config_log.c
@@ -45,7 +45,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/rddaniel/mcp_romfw/config_log.c
+++ b/product/rddaniel/mcp_romfw/config_log.c
@@ -39,7 +39,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/rddaniel/scp_ramfw/config_clock.c
+++ b/product/rddaniel/scp_ramfw/config_clock.c
@@ -193,14 +193,15 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
-        .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
-        .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
-    }),
+    .data =
+        &(struct mod_clock_config){
+            .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
+            .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
+        },
 
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
 };

--- a/product/rddaniel/scp_ramfw/config_cmn_rhodes.c
+++ b/product/rddaniel/scp_ramfw/config_cmn_rhodes.c
@@ -137,6 +137,5 @@ static const struct fwk_element *cmn_rhodes_get_device_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_cmn_rhodes = {
-    .get_element_table = cmn_rhodes_get_device_table,
-    .data = NULL
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(cmn_rhodes_get_device_table),
 };

--- a/product/rddaniel/scp_ramfw/config_css_clock.c
+++ b/product/rddaniel/scp_ramfw/config_css_clock.c
@@ -451,5 +451,5 @@ static const struct fwk_element *css_clock_get_element_table
 }
 
 const struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/rddaniel/scp_ramfw/config_gtimer.c
+++ b/product/rddaniel/scp_ramfw/config_gtimer.c
@@ -39,5 +39,5 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };

--- a/product/rddaniel/scp_ramfw/config_mhu2.c
+++ b/product/rddaniel/scp_ramfw/config_mhu2.c
@@ -36,5 +36,5 @@ static const struct fwk_element *mhu_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_mhu2 = {
-    .get_element_table = mhu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(mhu_get_element_table),
 };

--- a/product/rddaniel/scp_ramfw/config_pik_clock.c
+++ b/product/rddaniel/scp_ramfw/config_pik_clock.c
@@ -382,5 +382,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 const struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/rddaniel/scp_ramfw/config_power_domain.c
+++ b/product/rddaniel/scp_ramfw/config_power_domain.c
@@ -369,6 +369,7 @@ static const struct fwk_element *rddaniel_power_domain_get_element_table
  * Power module configuration data
  */
 const struct fwk_module_config config_power_domain = {
-    .get_element_table = rddaniel_power_domain_get_element_table,
     .data = &rddaniel_power_domain_config,
+    .elements =
+        FWK_MODULE_DYNAMIC_ELEMENTS(rddaniel_power_domain_get_element_table),
 };

--- a/product/rddaniel/scp_ramfw/config_ppu_v1.c
+++ b/product/rddaniel/scp_ramfw/config_ppu_v1.c
@@ -142,6 +142,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
  * Power module configuration data
  */
 const struct fwk_module_config config_ppu_v1 = {
-    .get_element_table = ppu_v1_get_element_table,
     .data = &ppu_v1_config_data,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ppu_v1_get_element_table),
 };

--- a/product/rddaniel/scp_ramfw/config_scmi.c
+++ b/product/rddaniel/scp_ramfw/config_scmi.c
@@ -50,12 +50,14 @@ static struct mod_scmi_agent agent_table[] = {
 };
 
 const struct fwk_module_config config_scmi = {
-    .get_element_table = get_service_table,
-    .data = &((struct mod_scmi_config) {
-        .protocol_count_max = 9,
-        .agent_count = FWK_ARRAY_SIZE(agent_table),
-        .agent_table = agent_table,
-        .vendor_identifier = "arm",
-        .sub_vendor_identifier = "arm",
-    }),
+    .data =
+        &(struct mod_scmi_config){
+            .protocol_count_max = 9,
+            .agent_count = FWK_ARRAY_SIZE(agent_table),
+            .agent_table = agent_table,
+            .vendor_identifier = "arm",
+            .sub_vendor_identifier = "arm",
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_service_table),
 };

--- a/product/rddaniel/scp_ramfw/config_sds.c
+++ b/product/rddaniel/scp_ramfw/config_sds.c
@@ -136,6 +136,6 @@ static const struct fwk_element *sds_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = sds_get_element_table,
     .data = &sds_module_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sds_get_element_table),
 };

--- a/product/rddaniel/scp_ramfw/config_smt.c
+++ b/product/rddaniel/scp_ramfw/config_smt.c
@@ -51,5 +51,5 @@ static const struct fwk_element *smt_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_smt = {
-    .get_element_table = smt_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(smt_get_element_table),
 };

--- a/product/rddaniel/scp_ramfw/config_system_pll.c
+++ b/product/rddaniel/scp_ramfw/config_system_pll.c
@@ -255,5 +255,5 @@ static const struct fwk_element *system_pll_get_element_table
 }
 
 const struct fwk_module_config config_system_pll = {
-    .get_element_table = system_pll_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_pll_get_element_table),
 };

--- a/product/rddaniel/scp_ramfw/config_system_power.c
+++ b/product/rddaniel/scp_ramfw/config_system_power.c
@@ -89,6 +89,6 @@ static const struct fwk_element *rddaniel_system_get_element_table(
 }
 
 const struct fwk_module_config config_system_power = {
-    .get_element_table = rddaniel_system_get_element_table,
     .data = &system_power_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(rddaniel_system_get_element_table),
 };

--- a/product/rddaniel/scp_ramfw/config_timer.c
+++ b/product/rddaniel/scp_ramfw/config_timer.c
@@ -35,5 +35,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/rddaniel/src/config_pl011.c
+++ b/product/rddaniel/src/config_pl011.c
@@ -34,5 +34,5 @@ static const struct fwk_element *get_pl011_table(fwk_id_t id)
 }
 
 const struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };

--- a/product/rddaniel/src/config_sid.c
+++ b/product/rddaniel/src/config_sid.c
@@ -29,7 +29,6 @@ static const struct fwk_element *get_subsystem_table(fwk_id_t id)
 }
 
 const struct fwk_module_config config_sid = {
-    .get_element_table = get_subsystem_table,
     .data = &(struct mod_sid_config) {
         .sid_base = SCP_SID_BASE,
         .pcid_expected = {
@@ -44,4 +43,6 @@ const struct fwk_module_config config_sid = {
             .CID3 = 0xB1,
         },
     },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_subsystem_table),
 };

--- a/product/rddaniel/src/config_system_info.c
+++ b/product/rddaniel/src/config_system_info.c
@@ -15,7 +15,6 @@
 #include <stddef.h>
 
 const struct fwk_module_config config_system_info = {
-    .get_element_table = NULL,
     .data = &((struct mod_system_info_config) {
             .system_info_driver_module_id =
                 FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SID),

--- a/product/rddanielxlr/mcp_romfw/config_log.c
+++ b/product/rddanielxlr/mcp_romfw/config_log.c
@@ -39,7 +39,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/rddanielxlr/scp_ramfw/config_clock.c
+++ b/product/rddanielxlr/scp_ramfw/config_clock.c
@@ -85,13 +85,15 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
-        .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
-        .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
-    }),
+    .data =
+        &(struct mod_clock_config){
+            .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
+            .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_cmn_rhodes.c
+++ b/product/rddanielxlr/scp_ramfw/config_cmn_rhodes.c
@@ -582,6 +582,5 @@ static const struct fwk_element *cmn_rhodes_get_device_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_cmn_rhodes = {
-    .get_element_table = cmn_rhodes_get_device_table,
-    .data = NULL
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(cmn_rhodes_get_device_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_css_clock.c
+++ b/product/rddanielxlr/scp_ramfw/config_css_clock.c
@@ -175,5 +175,5 @@ static const struct fwk_element *css_clock_get_element_table
 }
 
 const struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_gtimer.c
+++ b/product/rddanielxlr/scp_ramfw/config_gtimer.c
@@ -39,5 +39,5 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_mhu2.c
+++ b/product/rddanielxlr/scp_ramfw/config_mhu2.c
@@ -36,5 +36,5 @@ static const struct fwk_element *mhu_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_mhu2 = {
-    .get_element_table = mhu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(mhu_get_element_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_pik_clock.c
+++ b/product/rddanielxlr/scp_ramfw/config_pik_clock.c
@@ -238,5 +238,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 const struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_power_domain.c
+++ b/product/rddanielxlr/scp_ramfw/config_power_domain.c
@@ -207,6 +207,7 @@ static const struct fwk_element *rddanielxlr_power_domain_get_element_table
  * Power module configuration data
  */
 const struct fwk_module_config config_power_domain = {
-    .get_element_table = rddanielxlr_power_domain_get_element_table,
     .data = &rddanielxlr_power_domain_config,
+    .elements =
+        FWK_MODULE_DYNAMIC_ELEMENTS(rddanielxlr_power_domain_get_element_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_ppu_v1.c
+++ b/product/rddanielxlr/scp_ramfw/config_ppu_v1.c
@@ -150,6 +150,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
  * Power module configuration data
  */
 const struct fwk_module_config config_ppu_v1 = {
-    .get_element_table = ppu_v1_get_element_table,
     .data = &ppu_v1_config_data,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ppu_v1_get_element_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_scmi.c
+++ b/product/rddanielxlr/scp_ramfw/config_scmi.c
@@ -50,12 +50,13 @@ static struct mod_scmi_agent agent_table[] = {
 };
 
 const struct fwk_module_config config_scmi = {
-    .get_element_table = get_service_table,
-    .data = &((struct mod_scmi_config) {
+    .data = &((struct mod_scmi_config){
         .protocol_count_max = 9,
         .agent_count = FWK_ARRAY_SIZE(agent_table),
         .agent_table = agent_table,
         .vendor_identifier = "arm",
         .sub_vendor_identifier = "arm",
     }),
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_service_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_sds.c
+++ b/product/rddanielxlr/scp_ramfw/config_sds.c
@@ -135,6 +135,6 @@ static const struct fwk_element *sds_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = sds_get_element_table,
     .data = &sds_module_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sds_get_element_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_smt.c
+++ b/product/rddanielxlr/scp_ramfw/config_smt.c
@@ -51,5 +51,5 @@ static const struct fwk_element *smt_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_smt = {
-    .get_element_table = smt_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(smt_get_element_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_system_pll.c
+++ b/product/rddanielxlr/scp_ramfw/config_system_pll.c
@@ -111,5 +111,5 @@ static const struct fwk_element *system_pll_get_element_table
 }
 
 const struct fwk_module_config config_system_pll = {
-    .get_element_table = system_pll_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_pll_get_element_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_system_power.c
+++ b/product/rddanielxlr/scp_ramfw/config_system_power.c
@@ -89,6 +89,7 @@ static const struct fwk_element *rddanielxlr_system_get_element_table(
 }
 
 const struct fwk_module_config config_system_power = {
-    .get_element_table = rddanielxlr_system_get_element_table,
     .data = &system_power_config,
+    .elements =
+        FWK_MODULE_DYNAMIC_ELEMENTS(rddanielxlr_system_get_element_table),
 };

--- a/product/rddanielxlr/scp_ramfw/config_timer.c
+++ b/product/rddanielxlr/scp_ramfw/config_timer.c
@@ -35,5 +35,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/rddanielxlr/src/config_pl011.c
+++ b/product/rddanielxlr/src/config_pl011.c
@@ -34,5 +34,5 @@ static const struct fwk_element *get_pl011_table(fwk_id_t id)
 }
 
 const struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };

--- a/product/rddanielxlr/src/config_sid.c
+++ b/product/rddanielxlr/src/config_sid.c
@@ -29,7 +29,6 @@ static const struct fwk_element *get_subsystem_table(fwk_id_t id)
 }
 
 const struct fwk_module_config config_sid = {
-    .get_element_table = get_subsystem_table,
     .data = &(struct mod_sid_config) {
         .sid_base = SCP_SID_BASE,
         .pcid_expected = {
@@ -44,4 +43,6 @@ const struct fwk_module_config config_sid = {
             .CID3 = 0xB1,
         },
     },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_subsystem_table),
 };

--- a/product/rddanielxlr/src/config_system_info.c
+++ b/product/rddanielxlr/src/config_system_info.c
@@ -13,7 +13,6 @@
 #include <fwk_module_idx.h>
 
 const struct fwk_module_config config_system_info = {
-    .get_element_table = NULL,
     .data = &((struct mod_system_info_config) {
             .system_info_driver_module_id =
                 FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SID),

--- a/product/rdn1e1/mcp_romfw/config_log.c
+++ b/product/rdn1e1/mcp_romfw/config_log.c
@@ -40,7 +40,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/rdn1e1/scp_ramfw/config_clock.c
+++ b/product/rdn1e1/scp_ramfw/config_clock.c
@@ -67,14 +67,15 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
-        .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
-        .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
-    }),
+    .data =
+        &(struct mod_clock_config){
+            .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
+            .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
+        },
 
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_cmn600.c
+++ b/product/rdn1e1/scp_ramfw/config_cmn600.c
@@ -110,7 +110,6 @@ static const struct mod_cmn600_memory_region_map mmap[] = {
 };
 
 const struct fwk_module_config config_cmn600 = {
-    .get_element_table = NULL,
     .data = &((struct mod_cmn600_config) {
         .base = SCP_CMN600_BASE,
         .mesh_size_x = 4,

--- a/product/rdn1e1/scp_ramfw/config_css_clock.c
+++ b/product/rdn1e1/scp_ramfw/config_css_clock.c
@@ -188,5 +188,5 @@ static const struct fwk_element *css_clock_get_element_table
 }
 
 const struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_ddr_phy500.c
+++ b/product/rdn1e1/scp_ramfw/config_ddr_phy500.c
@@ -53,10 +53,12 @@ static const struct fwk_element *ddr_phy500_get_element_table
 
 /* Configuration of the DDR PHY500 module. */
 const struct fwk_module_config config_ddr_phy500 = {
-    .get_element_table = ddr_phy500_get_element_table,
-    .data = &((struct mod_ddr_phy500_module_config) {
+    .data =
+        &(struct mod_ddr_phy500_module_config){
             .ddr_reg_val = &ddr_reg_val,
             .initialize_init_complete = true,
             .initialize_ref_en = true,
-        }),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ddr_phy500_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_dmc620.c
+++ b/product/rdn1e1/scp_ramfw/config_dmc620.c
@@ -209,11 +209,13 @@ static void direct_ddr_cmd(struct mod_dmc620_reg *dmc)
 
 /* Configuration of the DMC500 module. */
 const struct fwk_module_config config_dmc620 = {
-    .get_element_table = dmc620_get_element_table,
-    .data = &((struct mod_dmc620_module_config) {
+    .data =
+        &(struct mod_dmc620_module_config){
             .dmc_val = &dmc_val,
             .ddr_module_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_DDR_PHY500),
             .ddr_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_DDR_PHY500, 0),
             .direct_ddr_cmd = direct_ddr_cmd,
-        }),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(dmc620_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_dvfs.c
+++ b/product/rdn1e1/scp_ramfw/config_dvfs.c
@@ -119,5 +119,5 @@ static const struct fwk_element *dvfs_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_dvfs = {
-    .get_element_table = dvfs_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(dvfs_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_log.c
+++ b/product/rdn1e1/scp_ramfw/config_log.c
@@ -40,7 +40,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/rdn1e1/scp_ramfw/config_mhu2.c
+++ b/product/rdn1e1/scp_ramfw/config_mhu2.c
@@ -46,5 +46,5 @@ static const struct fwk_element *mhu_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_mhu2 = {
-    .get_element_table = mhu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(mhu_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_mock_psu.c
+++ b/product/rdn1e1/scp_ramfw/config_mock_psu.c
@@ -51,5 +51,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_mock_psu = {
-    .get_element_table = get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_pik_clock.c
+++ b/product/rdn1e1/scp_ramfw/config_pik_clock.c
@@ -300,5 +300,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 const struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_power_domain.c
+++ b/product/rdn1e1/scp_ramfw/config_power_domain.c
@@ -211,6 +211,7 @@ static const struct fwk_element *rdn1e1_power_domain_get_element_table
  * Power module configuration data
  */
 const struct fwk_module_config config_power_domain = {
-    .get_element_table = rdn1e1_power_domain_get_element_table,
     .data = &rdn1e1_power_domain_config,
+    .elements =
+        FWK_MODULE_DYNAMIC_ELEMENTS(rdn1e1_power_domain_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_ppu_v0.c
+++ b/product/rdn1e1/scp_ramfw/config_ppu_v0.c
@@ -36,5 +36,5 @@ static const struct fwk_element *ppu_v0_get_element_table(fwk_id_t module_id)
  * Power module configuration data
  */
 const struct fwk_module_config config_ppu_v0 = {
-    .get_element_table = ppu_v0_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ppu_v0_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_ppu_v1.c
+++ b/product/rdn1e1/scp_ramfw/config_ppu_v1.c
@@ -152,6 +152,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
  * Power module configuration data
  */
 const struct fwk_module_config config_ppu_v1 = {
-    .get_element_table = ppu_v1_get_element_table,
     .data = &ppu_v1_config_data,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ppu_v1_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_psu.c
+++ b/product/rdn1e1/scp_ramfw/config_psu.c
@@ -39,5 +39,5 @@ static const struct fwk_element *psu_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_psu = {
-    .get_element_table = psu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(psu_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_scmi.c
+++ b/product/rdn1e1/scp_ramfw/config_scmi.c
@@ -69,12 +69,14 @@ static struct mod_scmi_agent agent_table[] = {
 };
 
 const struct fwk_module_config config_scmi = {
-    .get_element_table = get_service_table,
-    .data = &((struct mod_scmi_config) {
-        .protocol_count_max = 9,
-        .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
-        .agent_table = agent_table,
-        .vendor_identifier = "arm",
-        .sub_vendor_identifier = "arm",
-    }),
+    .data =
+        &(struct mod_scmi_config){
+            .protocol_count_max = 9,
+            .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
+            .agent_table = agent_table,
+            .vendor_identifier = "arm",
+            .sub_vendor_identifier = "arm",
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_service_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_scmi_perf.c
+++ b/product/rdn1e1/scp_ramfw/config_scmi_perf.c
@@ -32,7 +32,6 @@ static const struct mod_scmi_perf_domain_config domains[] = {
 };
 
 const struct fwk_module_config config_scmi_perf = {
-    .get_element_table = NULL,
     .data = &((struct mod_scmi_perf_config) {
         .domains = &domains,
         .fast_channels_alarm_id = FWK_ID_NONE_INIT,

--- a/product/rdn1e1/scp_ramfw/config_sds.c
+++ b/product/rdn1e1/scp_ramfw/config_sds.c
@@ -137,6 +137,6 @@ static const struct fwk_element *sds_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = sds_get_element_table,
     .data = &sds_module_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sds_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_sensor.c
+++ b/product/rdn1e1/scp_ramfw/config_sensor.c
@@ -49,7 +49,7 @@ static const struct fwk_element *get_reg_sensor_element_table(fwk_id_t id)
 }
 
 struct fwk_module_config config_reg_sensor = {
-    .get_element_table = get_reg_sensor_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_reg_sensor_element_table),
 };
 
 /*
@@ -73,5 +73,5 @@ static const struct fwk_element *get_sensor_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_sensor = {
-    .get_element_table = get_sensor_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_sensor_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_smt.c
+++ b/product/rdn1e1/scp_ramfw/config_smt.c
@@ -63,5 +63,5 @@ static const struct fwk_element *smt_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_smt = {
-    .get_element_table = smt_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(smt_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_system_pll.c
+++ b/product/rdn1e1/scp_ramfw/config_system_pll.c
@@ -88,5 +88,5 @@ static const struct fwk_element *system_pll_get_element_table
 }
 
 const struct fwk_module_config config_system_pll = {
-    .get_element_table = system_pll_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_pll_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_system_power.c
+++ b/product/rdn1e1/scp_ramfw/config_system_power.c
@@ -89,6 +89,6 @@ static const struct fwk_element *rdn1e1_system_get_element_table(
 }
 
 const struct fwk_module_config config_system_power = {
-    .get_element_table = rdn1e1_system_get_element_table,
     .data = &system_power_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(rdn1e1_system_get_element_table),
 };

--- a/product/rdn1e1/scp_ramfw/config_timer.c
+++ b/product/rdn1e1/scp_ramfw/config_timer.c
@@ -43,7 +43,7 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };
 
 /*
@@ -67,5 +67,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/rdn1e1/scp_romfw/config_gtimer.c
+++ b/product/rdn1e1/scp_romfw/config_gtimer.c
@@ -37,5 +37,5 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };

--- a/product/rdn1e1/scp_romfw/config_log.c
+++ b/product/rdn1e1/scp_romfw/config_log.c
@@ -40,7 +40,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/rdn1e1/src/config_sid.c
+++ b/product/rdn1e1/src/config_sid.c
@@ -35,7 +35,6 @@ static const struct fwk_element *get_subsystem_table(fwk_id_t id)
 }
 
 const struct fwk_module_config config_sid = {
-    .get_element_table = get_subsystem_table,
     .data = &(struct mod_sid_config) {
         .sid_base = SCP_SID_BASE,
         .pcid_expected = {
@@ -50,4 +49,6 @@ const struct fwk_module_config config_sid = {
             .CID3 = 0xB1,
         },
     },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_subsystem_table),
 };

--- a/product/rdn1e1/src/config_system_info.c
+++ b/product/rdn1e1/src/config_system_info.c
@@ -15,12 +15,10 @@
 #include <stddef.h>
 
 const struct fwk_module_config config_system_info = {
-    .get_element_table = NULL,
-    .data = &((struct mod_system_info_config) {
-            .system_info_driver_module_id =
-                FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SID),
-            .system_info_driver_data_api_id =
-                FWK_ID_API_INIT(FWK_MODULE_IDX_SID,
-                                MOD_SID_SYSTEM_INFO_DRIVER_DATA_API_IDX),
+    .data = &((struct mod_system_info_config){
+        .system_info_driver_module_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SID),
+        .system_info_driver_data_api_id = FWK_ID_API_INIT(
+            FWK_MODULE_IDX_SID,
+            MOD_SID_SYSTEM_INFO_DRIVER_DATA_API_IDX),
     }),
 };

--- a/product/sgi575/mcp_romfw/config_log.c
+++ b/product/sgi575/mcp_romfw/config_log.c
@@ -40,7 +40,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/sgi575/scp_ramfw/config_clock.c
+++ b/product/sgi575/scp_ramfw/config_clock.c
@@ -67,14 +67,15 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
-        .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
-        .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
-    }),
+    .data =
+        &(struct mod_clock_config){
+            .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
+            .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
+        },
 
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
 };

--- a/product/sgi575/scp_ramfw/config_cmn600.c
+++ b/product/sgi575/scp_ramfw/config_cmn600.c
@@ -97,8 +97,7 @@ static const struct mod_cmn600_memory_region_map mmap[] = {
 };
 
 const struct fwk_module_config config_cmn600 = {
-    .get_element_table = NULL,
-    .data = &((struct mod_cmn600_config) {
+    .data = &((struct mod_cmn600_config){
         .base = SCP_CMN600_BASE,
         .mesh_size_x = 4,
         .mesh_size_y = 2,
@@ -108,8 +107,8 @@ const struct fwk_module_config config_cmn600 = {
         .mmap_table = mmap,
         .mmap_count = FWK_ARRAY_SIZE(mmap),
         .chip_addr_space = UINT64_C(4) * FWK_TIB,
-        .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK,
-            CLOCK_IDX_INTERCONNECT),
+        .clock_id =
+            FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_INTERCONNECT),
         .hnf_cal_mode = false,
     }),
 };

--- a/product/sgi575/scp_ramfw/config_css_clock.c
+++ b/product/sgi575/scp_ramfw/config_css_clock.c
@@ -188,5 +188,5 @@ static const struct fwk_element *css_clock_get_element_table
 }
 
 const struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_ddr_phy500.c
+++ b/product/sgi575/scp_ramfw/config_ddr_phy500.c
@@ -54,10 +54,12 @@ static const struct fwk_element *ddr_phy500_get_element_table
 
 /* Configuration of the DDR PHY500 module. */
 struct fwk_module_config config_ddr_phy500 = {
-    .get_element_table = ddr_phy500_get_element_table,
-    .data = &((struct mod_ddr_phy500_module_config) {
+    .data =
+        &(struct mod_ddr_phy500_module_config){
             .ddr_reg_val = &ddr_reg_val,
             .initialize_init_complete = true,
             .initialize_ref_en = true,
-        }),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ddr_phy500_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_dmc620.c
+++ b/product/sgi575/scp_ramfw/config_dmc620.c
@@ -209,13 +209,13 @@ static void direct_ddr_cmd(struct mod_dmc620_reg *dmc)
 
 /* Configuration of the DMC620 module. */
 const struct fwk_module_config config_dmc620 = {
-    .get_element_table = dmc620_get_element_table,
-    .data = &((struct mod_dmc620_module_config) {
+    .data =
+        &(struct mod_dmc620_module_config){
             .dmc_val = &dmc_val,
-            .ddr_module_id = FWK_ID_MODULE_INIT(
-                FWK_MODULE_IDX_DDR_PHY500),
-            .ddr_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_DDR_PHY500,
-                0),
+            .ddr_module_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_DDR_PHY500),
+            .ddr_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_DDR_PHY500, 0),
             .direct_ddr_cmd = direct_ddr_cmd,
-        }),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(dmc620_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_dvfs.c
+++ b/product/sgi575/scp_ramfw/config_dvfs.c
@@ -79,5 +79,5 @@ static const struct fwk_element *dvfs_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_dvfs = {
-    .get_element_table = dvfs_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(dvfs_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_log.c
+++ b/product/sgi575/scp_ramfw/config_log.c
@@ -40,7 +40,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/sgi575/scp_ramfw/config_mhu.c
+++ b/product/sgi575/scp_ramfw/config_mhu.c
@@ -45,5 +45,5 @@ static const struct fwk_element *mhu_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_mhu = {
-    .get_element_table = mhu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(mhu_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_mock_psu.c
+++ b/product/sgi575/scp_ramfw/config_mock_psu.c
@@ -51,5 +51,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_mock_psu = {
-    .get_element_table = get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_pik_clock.c
+++ b/product/sgi575/scp_ramfw/config_pik_clock.c
@@ -300,5 +300,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 const struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_power_domain.c
+++ b/product/sgi575/scp_ramfw/config_power_domain.c
@@ -212,6 +212,7 @@ static const struct fwk_element *sgi575_power_domain_get_element_table
  * Power module configuration data
  */
 const struct fwk_module_config config_power_domain = {
-    .get_element_table = sgi575_power_domain_get_element_table,
     .data = &sgi575_power_domain_config,
+    .elements =
+        FWK_MODULE_DYNAMIC_ELEMENTS(sgi575_power_domain_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_ppu_v0.c
+++ b/product/sgi575/scp_ramfw/config_ppu_v0.c
@@ -36,5 +36,5 @@ static const struct fwk_element *ppu_v0_get_element_table(fwk_id_t module_id)
  * Power module configuration data
  */
 const struct fwk_module_config config_ppu_v0 = {
-    .get_element_table = ppu_v0_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ppu_v0_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_ppu_v1.c
+++ b/product/sgi575/scp_ramfw/config_ppu_v1.c
@@ -152,6 +152,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
  * Power module configuration data
  */
 const struct fwk_module_config config_ppu_v1 = {
-    .get_element_table = ppu_v1_get_element_table,
     .data = &ppu_v1_config_data,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ppu_v1_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_psu.c
+++ b/product/sgi575/scp_ramfw/config_psu.c
@@ -39,5 +39,5 @@ static const struct fwk_element *psu_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_psu = {
-    .get_element_table = psu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(psu_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_scmi.c
+++ b/product/sgi575/scp_ramfw/config_scmi.c
@@ -69,12 +69,13 @@ static struct mod_scmi_agent agent_table[] = {
 };
 
 const struct fwk_module_config config_scmi = {
-    .get_element_table = get_service_table,
-    .data = &((struct mod_scmi_config) {
+    .data = &((struct mod_scmi_config){
         .protocol_count_max = 9,
         .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
         .agent_table = agent_table,
         .vendor_identifier = "arm",
         .sub_vendor_identifier = "arm",
     }),
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_service_table),
 };

--- a/product/sgi575/scp_ramfw/config_scmi_perf.c
+++ b/product/sgi575/scp_ramfw/config_scmi_perf.c
@@ -32,8 +32,7 @@ static const struct mod_scmi_perf_domain_config domains[] = {
 };
 
 const struct fwk_module_config config_scmi_perf = {
-    .get_element_table = NULL,
-    .data = &((struct mod_scmi_perf_config) {
+    .data = &((struct mod_scmi_perf_config){
         .domains = &domains,
         .fast_channels_alarm_id = FWK_ID_NONE_INIT,
     }),

--- a/product/sgi575/scp_ramfw/config_sds.c
+++ b/product/sgi575/scp_ramfw/config_sds.c
@@ -158,6 +158,6 @@ static const struct fwk_element *sds_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = sds_get_element_table,
     .data = &sds_module_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sds_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_sensor.c
+++ b/product/sgi575/scp_ramfw/config_sensor.c
@@ -49,7 +49,7 @@ static const struct fwk_element *get_reg_sensor_element_table(fwk_id_t id)
 }
 
 struct fwk_module_config config_reg_sensor = {
-    .get_element_table = get_reg_sensor_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_reg_sensor_element_table),
 };
 
 /*
@@ -73,5 +73,5 @@ static const struct fwk_element *get_sensor_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_sensor = {
-    .get_element_table = get_sensor_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_sensor_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_smt.c
+++ b/product/sgi575/scp_ramfw/config_smt.c
@@ -63,5 +63,5 @@ static const struct fwk_element *smt_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_smt = {
-    .get_element_table = smt_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(smt_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_ssc.c
+++ b/product/sgi575/scp_ramfw/config_ssc.c
@@ -14,9 +14,8 @@
 #include <stddef.h>
 
 const struct fwk_module_config config_ssc = {
-    .get_element_table = NULL,
-    .data = &(struct mod_ssc_config) {
-        .ssc_base = SSC_BASE,
-        .product_name = "System Guidance for Infrastructure - 575"
-    },
+    .data =
+        &(struct mod_ssc_config){
+            .ssc_base = SSC_BASE,
+            .product_name = "System Guidance for Infrastructure - 575" },
 };

--- a/product/sgi575/scp_ramfw/config_system_info.c
+++ b/product/sgi575/scp_ramfw/config_system_info.c
@@ -15,12 +15,10 @@
 #include <stddef.h>
 
 const struct fwk_module_config config_system_info = {
-    .get_element_table = NULL,
-    .data = &((struct mod_system_info_config) {
-            .system_info_driver_module_id =
-                FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SSC),
-            .system_info_driver_data_api_id =
-                FWK_ID_API_INIT(FWK_MODULE_IDX_SSC,
-                                MOD_SSC_SYSTEM_INFO_DRIVER_DATA_API_IDX),
+    .data = &((struct mod_system_info_config){
+        .system_info_driver_module_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SSC),
+        .system_info_driver_data_api_id = FWK_ID_API_INIT(
+            FWK_MODULE_IDX_SSC,
+            MOD_SSC_SYSTEM_INFO_DRIVER_DATA_API_IDX),
     }),
 };

--- a/product/sgi575/scp_ramfw/config_system_pll.c
+++ b/product/sgi575/scp_ramfw/config_system_pll.c
@@ -88,5 +88,5 @@ static const struct fwk_element *system_pll_get_element_table
 }
 
 const struct fwk_module_config config_system_pll = {
-    .get_element_table = system_pll_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_pll_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_system_power.c
+++ b/product/sgi575/scp_ramfw/config_system_power.c
@@ -90,5 +90,5 @@ static const struct fwk_element *sgi575_system_get_element_table(
 
 const struct fwk_module_config config_system_power = {
     .data = &system_power_config,
-    .get_element_table = sgi575_system_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sgi575_system_get_element_table),
 };

--- a/product/sgi575/scp_ramfw/config_timer.c
+++ b/product/sgi575/scp_ramfw/config_timer.c
@@ -43,7 +43,7 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };
 
 /*
@@ -67,5 +67,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/sgi575/scp_romfw/config_gtimer.c
+++ b/product/sgi575/scp_romfw/config_gtimer.c
@@ -37,5 +37,5 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };

--- a/product/sgi575/scp_romfw/config_log.c
+++ b/product/sgi575/scp_romfw/config_log.c
@@ -40,7 +40,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/sgm775/scp_ramfw/config_clock.c
+++ b/product/sgm775/scp_ramfw/config_clock.c
@@ -109,8 +109,7 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
+    .data = &((struct mod_clock_config){
         .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
             FWK_MODULE_IDX_POWER_DOMAIN,
             MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
@@ -118,4 +117,6 @@ struct fwk_module_config config_clock = {
             FWK_MODULE_IDX_POWER_DOMAIN,
             MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
     }),
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
 };

--- a/product/sgm775/scp_ramfw/config_css_clock.c
+++ b/product/sgm775/scp_ramfw/config_css_clock.c
@@ -300,6 +300,5 @@ static const struct fwk_element *css_clock_get_element_table
 }
 
 struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_debugger_cli.c
+++ b/product/sgm775/scp_ramfw/config_debugger_cli.c
@@ -24,6 +24,5 @@ static const struct mod_debugger_cli_module_config debugger_cli_data = {
  * Configuration for the debugger CLI module
  */
 struct fwk_module_config config_debugger_cli = {
-    .get_element_table = NULL,
     .data = &debugger_cli_data
 };

--- a/product/sgm775/scp_ramfw/config_dvfs.c
+++ b/product/sgm775/scp_ramfw/config_dvfs.c
@@ -236,6 +236,5 @@ static const struct fwk_element *dvfs_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_dvfs = {
-    .get_element_table = dvfs_get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(dvfs_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_log.c
+++ b/product/sgm775/scp_ramfw/config_log.c
@@ -45,7 +45,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*
@@ -59,6 +59,5 @@ static const struct mod_log_config log_data = {
 };
 
 struct fwk_module_config config_log = {
-    .get_element_table = NULL,
     .data = &log_data,
 };

--- a/product/sgm775/scp_ramfw/config_mhu.c
+++ b/product/sgm775/scp_ramfw/config_mhu.c
@@ -53,5 +53,5 @@ static const struct fwk_element *mhu_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_mhu = {
-    .get_element_table = mhu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(mhu_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_mock_psu.c
+++ b/product/sgm775/scp_ramfw/config_mock_psu.c
@@ -78,6 +78,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_mock_psu = {
-    .get_element_table = get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_pik_clock.c
+++ b/product/sgm775/scp_ramfw/config_pik_clock.c
@@ -300,6 +300,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_power_domain.c
+++ b/product/sgm775/scp_ramfw/config_power_domain.c
@@ -256,6 +256,7 @@ static const struct fwk_element *sgm775_power_domain_get_element_table
  * Power module configuration data
  */
 struct fwk_module_config config_power_domain = {
-    .get_element_table = sgm775_power_domain_get_element_table,
     .data = &sgm775_power_domain_config,
+    .elements =
+        FWK_MODULE_DYNAMIC_ELEMENTS(sgm775_power_domain_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_ppu_v0.c
+++ b/product/sgm775/scp_ramfw/config_ppu_v0.c
@@ -95,6 +95,5 @@ static const struct fwk_element *sgm775_ppu_v0_get_element_table
  * Power module configuration data
  */
 struct fwk_module_config config_ppu_v0 = {
-    .get_element_table = sgm775_ppu_v0_get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sgm775_ppu_v0_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_ppu_v1.c
+++ b/product/sgm775/scp_ramfw/config_ppu_v1.c
@@ -102,6 +102,6 @@ static const struct fwk_element *sgm775_ppu_v1_get_element_table
  * Power module configuration data
  */
 struct fwk_module_config config_ppu_v1 = {
-    .get_element_table = sgm775_ppu_v1_get_element_table,
     .data = &sgm775_ppu_v1_notification_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sgm775_ppu_v1_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_psu.c
+++ b/product/sgm775/scp_ramfw/config_psu.c
@@ -72,6 +72,5 @@ static const struct fwk_element *psu_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_psu = {
-    .get_element_table = psu_get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(psu_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_scmi.c
+++ b/product/sgm775/scp_ramfw/config_scmi.c
@@ -78,12 +78,13 @@ static const struct mod_scmi_agent agent_table[] = {
 };
 
 struct fwk_module_config config_scmi = {
-    .get_element_table = get_service_table,
-    .data = &((struct mod_scmi_config) {
+    .data = &((struct mod_scmi_config){
         .protocol_count_max = 9,
         .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
         .agent_table = agent_table,
         .vendor_identifier = "arm",
         .sub_vendor_identifier = "arm",
     }),
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_service_table),
 };

--- a/product/sgm775/scp_ramfw/config_scmi_perf.c
+++ b/product/sgm775/scp_ramfw/config_scmi_perf.c
@@ -40,8 +40,7 @@ static const struct mod_scmi_perf_domain_config domains[] = {
 };
 
 struct fwk_module_config config_scmi_perf = {
-    .get_element_table = NULL,
-    .data = &((struct mod_scmi_perf_config) {
+    .data = &((struct mod_scmi_perf_config){
         .domains = &domains,
         .fast_channels_alarm_id = FWK_ID_NONE_INIT,
     }),

--- a/product/sgm775/scp_ramfw/config_scmi_system_power.c
+++ b/product/sgm775/scp_ramfw/config_scmi_system_power.c
@@ -13,9 +13,7 @@
 #include <stddef.h>
 
 struct fwk_module_config config_scmi_system_power = {
-    .get_element_table = NULL,
-    .data = &((struct mod_scmi_system_power_config) {
+    .data = &((struct mod_scmi_system_power_config){
         .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
-        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0
-    }),
+        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0 }),
 };

--- a/product/sgm775/scp_ramfw/config_sds.c
+++ b/product/sgm775/scp_ramfw/config_sds.c
@@ -88,6 +88,6 @@ static const struct fwk_element *sds_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = sds_get_element_table,
     .data = &sds_module_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sds_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_sensor.c
+++ b/product/sgm775/scp_ramfw/config_sensor.c
@@ -50,7 +50,7 @@ static const struct fwk_element *get_reg_sensor_element_table(fwk_id_t id)
 }
 
 struct fwk_module_config config_reg_sensor = {
-    .get_element_table = get_reg_sensor_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_reg_sensor_element_table),
 };
 
 /*
@@ -74,6 +74,5 @@ static const struct fwk_element *get_sensor_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sensor = {
-    .get_element_table = get_sensor_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_sensor_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_sgm775_ddr_phy500.c
+++ b/product/sgm775/scp_ramfw/config_sgm775_ddr_phy500.c
@@ -48,6 +48,6 @@ static const struct fwk_element *sgm775_ddr_phy500_get_element_table
 
 /* Configuration of the DDR PHY500 module. */
 struct fwk_module_config config_sgm775_ddr_phy500 = {
-    .get_element_table = sgm775_ddr_phy500_get_element_table,
-    .data = NULL,
+    .elements =
+        FWK_MODULE_DYNAMIC_ELEMENTS(sgm775_ddr_phy500_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_sgm775_dmc500.c
+++ b/product/sgm775/scp_ramfw/config_sgm775_dmc500.c
@@ -54,8 +54,10 @@ static const struct fwk_element *sgm775_dmc500_get_element_table(
 
 /* Configuration of the DMC500 module. */
 struct fwk_module_config config_sgm775_dmc500 = {
-    .get_element_table = sgm775_dmc500_get_element_table,
-    .data = &((struct mod_sgm775_dmc500_module_config) {
+    .data =
+        &(struct mod_sgm775_dmc500_module_config){
             .timer_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
-        }),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sgm775_dmc500_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_smt.c
+++ b/product/sgm775/scp_ramfw/config_smt.c
@@ -75,5 +75,5 @@ static const struct fwk_element *smt_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_smt = {
-    .get_element_table = smt_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(smt_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_system_pll.c
+++ b/product/sgm775/scp_ramfw/config_system_pll.c
@@ -119,6 +119,5 @@ static const struct fwk_element *system_pll_get_element_table
 }
 
 struct fwk_module_config config_system_pll = {
-    .get_element_table = system_pll_get_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_pll_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_system_power.c
+++ b/product/sgm775/scp_ramfw/config_system_power.c
@@ -95,14 +95,17 @@ static const struct fwk_element *system_power_get_element_table(
 }
 
 const struct fwk_module_config config_system_power = {
-    .data = &((struct mod_system_power_config) {
-        .soc_wakeup_irq = SOC_WAKEUP0_IRQ,
-        .ext_ppus = ext_ppus,
-        .ext_ppus_count = FWK_ARRAY_SIZE(ext_ppus),
-        .driver_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SGM775_SYSTEM),
-        .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_SGM775_SYSTEM,
-             MOD_SGM775_SYSTEM_API_IDX_SYSTEM_POWER_DRIVER),
-        .initial_system_power_state = MOD_PD_STATE_ON,
-    }),
-    .get_element_table = system_power_get_element_table,
+    .data =
+        &(struct mod_system_power_config){
+            .soc_wakeup_irq = SOC_WAKEUP0_IRQ,
+            .ext_ppus = ext_ppus,
+            .ext_ppus_count = FWK_ARRAY_SIZE(ext_ppus),
+            .driver_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SGM775_SYSTEM),
+            .driver_api_id = FWK_ID_API_INIT(
+                FWK_MODULE_IDX_SGM775_SYSTEM,
+                MOD_SGM775_SYSTEM_API_IDX_SYSTEM_POWER_DRIVER),
+            .initial_system_power_state = MOD_PD_STATE_ON,
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_power_get_element_table),
 };

--- a/product/sgm775/scp_ramfw/config_timer.c
+++ b/product/sgm775/scp_ramfw/config_timer.c
@@ -45,7 +45,7 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };
 
 /*
@@ -71,5 +71,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/sgm775/scp_romfw/config_clock.c
+++ b/product/sgm775/scp_romfw/config_clock.c
@@ -118,11 +118,13 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
-        .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_MSYS_ROM,
-            MOD_MSYS_ROM_NOTIFICATION_IDX_POWER_SYSTOP),
-        .pd_pre_transition_notification_id = FWK_ID_NONE_INIT,
-    }),
+    .data =
+        &(struct mod_clock_config){
+            .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_MSYS_ROM,
+                MOD_MSYS_ROM_NOTIFICATION_IDX_POWER_SYSTOP),
+            .pd_pre_transition_notification_id = FWK_ID_NONE_INIT,
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
 };

--- a/product/sgm775/scp_romfw/config_css_clock.c
+++ b/product/sgm775/scp_romfw/config_css_clock.c
@@ -134,5 +134,5 @@ static const struct fwk_element *css_clock_get_element_table
 }
 
 struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/sgm775/scp_romfw/config_log.c
+++ b/product/sgm775/scp_romfw/config_log.c
@@ -45,7 +45,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*
@@ -59,6 +59,5 @@ static const struct mod_log_config log_data = {
 };
 
 struct fwk_module_config config_log = {
-    .get_element_table = NULL,
     .data = &log_data,
 };

--- a/product/sgm775/scp_romfw/config_pik_clock.c
+++ b/product/sgm775/scp_romfw/config_pik_clock.c
@@ -310,5 +310,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/sgm775/scp_romfw/config_ppu_v0.c
+++ b/product/sgm775/scp_romfw/config_ppu_v0.c
@@ -51,5 +51,5 @@ static const struct fwk_element *sgm775_ppu_v0_get_element_table(
  * Power module configuration data
  */
 struct fwk_module_config config_ppu_v0 = {
-    .get_element_table = sgm775_ppu_v0_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sgm775_ppu_v0_get_element_table),
 };

--- a/product/sgm775/scp_romfw/config_ppu_v1.c
+++ b/product/sgm775/scp_romfw/config_ppu_v1.c
@@ -50,11 +50,13 @@ static const struct fwk_element *sgm775_ppu_v1_get_element_table(
  * Power module configuration data
  */
 struct fwk_module_config config_ppu_v1 = {
-    .get_element_table = sgm775_ppu_v1_get_element_table,
-    .data = &(struct mod_ppu_v1_config) {
-        .pd_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_MSYS_ROM,
-            MOD_MSYS_ROM_NOTIFICATION_IDX_POWER_SYSTOP),
-        .pd_source_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_MSYS_ROM),
-    },
+    .data =
+        &(struct mod_ppu_v1_config){
+            .pd_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_MSYS_ROM,
+                MOD_MSYS_ROM_NOTIFICATION_IDX_POWER_SYSTOP),
+            .pd_source_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_MSYS_ROM),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sgm775_ppu_v1_get_element_table),
 };

--- a/product/sgm775/scp_romfw/config_sds.c
+++ b/product/sgm775/scp_romfw/config_sds.c
@@ -165,6 +165,6 @@ static const struct fwk_element *sds_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = sds_get_element_table,
     .data = &sds_module_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sds_get_element_table),
 };

--- a/product/sgm775/scp_romfw/config_system_pll.c
+++ b/product/sgm775/scp_romfw/config_system_pll.c
@@ -94,5 +94,5 @@ static const struct fwk_element *system_pll_get_element_table
 }
 
 struct fwk_module_config config_system_pll = {
-    .get_element_table = system_pll_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_pll_get_element_table),
 };

--- a/product/sgm775/scp_romfw/config_timer.c
+++ b/product/sgm775/scp_romfw/config_timer.c
@@ -42,7 +42,7 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };
 
 /*
@@ -66,5 +66,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/sgm775/src/config_sid.c
+++ b/product/sgm775/src/config_sid.c
@@ -30,7 +30,6 @@ static const struct fwk_element *get_subsystem_table(fwk_id_t id)
 }
 
 struct fwk_module_config config_sid = {
-    .get_element_table = get_subsystem_table,
     .data = &(struct mod_sid_config) {
         .sid_base = SSC_BASE,
         .pcid_expected = {
@@ -44,4 +43,6 @@ struct fwk_module_config config_sid = {
             .CID3 = 0xB1,
         },
     },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_subsystem_table),
 };

--- a/product/sgm775/src/config_system_info.c
+++ b/product/sgm775/src/config_system_info.c
@@ -15,12 +15,10 @@
 #include <stddef.h>
 
 const struct fwk_module_config config_system_info = {
-    .get_element_table = NULL,
-    .data = &((struct mod_system_info_config) {
-            .system_info_driver_module_id =
-                FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SID),
-            .system_info_driver_data_api_id =
-                FWK_ID_API_INIT(FWK_MODULE_IDX_SID,
-                                MOD_SID_SYSTEM_INFO_DRIVER_DATA_API_IDX),
+    .data = &((struct mod_system_info_config){
+        .system_info_driver_module_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SID),
+        .system_info_driver_data_api_id = FWK_ID_API_INIT(
+            FWK_MODULE_IDX_SID,
+            MOD_SID_SYSTEM_INFO_DRIVER_DATA_API_IDX),
     }),
 };

--- a/product/sgm776/scp_ramfw/config_clock.c
+++ b/product/sgm776/scp_ramfw/config_clock.c
@@ -109,13 +109,15 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
-        .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
-        .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_POWER_DOMAIN,
-            MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
-    }),
+    .data =
+        &(struct mod_clock_config){
+            .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),
+            .pd_pre_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_POWER_DOMAIN,
+                MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
 };

--- a/product/sgm776/scp_ramfw/config_css_clock.c
+++ b/product/sgm776/scp_ramfw/config_css_clock.c
@@ -354,5 +354,5 @@ static const struct fwk_element *css_clock_get_element_table
 }
 
 const struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_ddr_phy500.c
+++ b/product/sgm776/scp_ramfw/config_ddr_phy500.c
@@ -59,8 +59,10 @@ static const struct fwk_element *ddr_phy500_get_element_table(
 
 /* Configuration of the DDR PHY500 module. */
 const struct fwk_module_config config_ddr_phy500 = {
-    .get_element_table = ddr_phy500_get_element_table,
-    .data = &((struct mod_ddr_phy500_module_config) {
-        .ddr_reg_val = &ddr_reg_val,
-    }),
+    .data =
+        &(struct mod_ddr_phy500_module_config){
+            .ddr_reg_val = &ddr_reg_val,
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ddr_phy500_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_dmc500.c
+++ b/product/sgm776/scp_ramfw/config_dmc500.c
@@ -213,12 +213,14 @@ static void direct_ddr_cmd(struct mod_dmc500_reg *dmc)
 
 /* Configuration of the DMC500 module. */
 const struct fwk_module_config config_dmc500 = {
-    .get_element_table = dmc500_get_element_table,
-    .data = &((struct mod_dmc500_module_config) {
-        .timer_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
-        .ddr_phy_module_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_DDR_PHY500),
-        .ddr_phy_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_DDR_PHY500, 0),
-        .reg_val = &reg_val,
-        .direct_ddr_cmd = direct_ddr_cmd,
-    }),
+    .data =
+        &(struct mod_dmc500_module_config){
+            .timer_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0),
+            .ddr_phy_module_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_DDR_PHY500),
+            .ddr_phy_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_DDR_PHY500, 0),
+            .reg_val = &reg_val,
+            .direct_ddr_cmd = direct_ddr_cmd,
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(dmc500_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_dvfs.c
+++ b/product/sgm776/scp_ramfw/config_dvfs.c
@@ -212,5 +212,5 @@ static const struct fwk_element *dvfs_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_dvfs = {
-    .get_element_table = dvfs_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(dvfs_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_log.c
+++ b/product/sgm776/scp_ramfw/config_log.c
@@ -45,7 +45,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*
@@ -59,6 +59,5 @@ static const struct mod_log_config log_data = {
 };
 
 const struct fwk_module_config config_log = {
-    .get_element_table = NULL,
     .data = &log_data,
 };

--- a/product/sgm776/scp_ramfw/config_mhu.c
+++ b/product/sgm776/scp_ramfw/config_mhu.c
@@ -56,5 +56,5 @@ static const struct fwk_element *mhu_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_mhu2 = {
-    .get_element_table = mhu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(mhu_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_mock_psu.c
+++ b/product/sgm776/scp_ramfw/config_mock_psu.c
@@ -75,5 +75,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_mock_psu = {
-    .get_element_table = get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_pik_clock.c
+++ b/product/sgm776/scp_ramfw/config_pik_clock.c
@@ -312,5 +312,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 const struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_power_domain.c
+++ b/product/sgm776/scp_ramfw/config_power_domain.c
@@ -245,6 +245,7 @@ static const struct fwk_element *sgm776_power_domain_get_element_table
  * Power module configuration data
  */
 struct fwk_module_config config_power_domain = {
-    .get_element_table = sgm776_power_domain_get_element_table,
     .data = &sgm776_power_domain_config,
+    .elements =
+        FWK_MODULE_DYNAMIC_ELEMENTS(sgm776_power_domain_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_ppu_v1.c
+++ b/product/sgm776/scp_ramfw/config_ppu_v1.c
@@ -172,6 +172,6 @@ static const struct fwk_element *sgm776_ppu_v1_get_element_table(
  * Power module configuration data
  */
 struct fwk_module_config config_ppu_v1 = {
-    .get_element_table = sgm776_ppu_v1_get_element_table,
     .data = &sgm776_ppu_v1_notification_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sgm776_ppu_v1_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_psu.c
+++ b/product/sgm776/scp_ramfw/config_psu.c
@@ -55,5 +55,5 @@ static const struct fwk_element *psu_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_psu = {
-    .get_element_table = psu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(psu_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_scmi.c
+++ b/product/sgm776/scp_ramfw/config_scmi.c
@@ -78,12 +78,14 @@ static const struct mod_scmi_agent agent_table[] = {
 };
 
 struct fwk_module_config config_scmi = {
-    .get_element_table = get_service_table,
-    .data = &((struct mod_scmi_config) {
-        .protocol_count_max = 9,
-        .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
-        .agent_table = agent_table,
-        .vendor_identifier = "arm",
-        .sub_vendor_identifier = "arm",
-    }),
+    .data =
+        &(struct mod_scmi_config){
+            .protocol_count_max = 9,
+            .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
+            .agent_table = agent_table,
+            .vendor_identifier = "arm",
+            .sub_vendor_identifier = "arm",
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_service_table),
 };

--- a/product/sgm776/scp_ramfw/config_scmi_system_power.c
+++ b/product/sgm776/scp_ramfw/config_scmi_system_power.c
@@ -13,9 +13,7 @@
 #include <stddef.h>
 
 struct fwk_module_config config_scmi_system_power = {
-    .get_element_table = NULL,
-    .data = &((struct mod_scmi_system_power_config) {
+    .data = &((struct mod_scmi_system_power_config){
         .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
-        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0
-    }),
+        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0 }),
 };

--- a/product/sgm776/scp_ramfw/config_sds.c
+++ b/product/sgm776/scp_ramfw/config_sds.c
@@ -85,6 +85,6 @@ static const struct fwk_element *sds_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_sds = {
-    .get_element_table = sds_get_element_table,
     .data = &sds_module_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sds_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_sensor.c
+++ b/product/sgm776/scp_ramfw/config_sensor.c
@@ -51,7 +51,7 @@ static const struct fwk_element *get_reg_sensor_element_table(fwk_id_t id)
 }
 
 struct fwk_module_config config_reg_sensor = {
-    .get_element_table = get_reg_sensor_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_reg_sensor_element_table),
 };
 
 /*
@@ -75,6 +75,5 @@ static const struct fwk_element *get_sensor_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_sensor = {
-    .get_element_table = get_sensor_element_table,
-    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_sensor_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_smt.c
+++ b/product/sgm776/scp_ramfw/config_smt.c
@@ -79,5 +79,5 @@ static const struct fwk_element *smt_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_smt = {
-    .get_element_table = smt_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(smt_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_system_pll.c
+++ b/product/sgm776/scp_ramfw/config_system_pll.c
@@ -119,5 +119,5 @@ static const struct fwk_element *system_pll_get_element_table
 }
 
 const struct fwk_module_config config_system_pll = {
-    .get_element_table = system_pll_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_pll_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_system_power.c
+++ b/product/sgm776/scp_ramfw/config_system_power.c
@@ -93,14 +93,17 @@ static const struct fwk_element *system_power_get_element_table(
 }
 
 const struct fwk_module_config config_system_power = {
-    .data = &((struct mod_system_power_config) {
-        .soc_wakeup_irq = SOC_WAKEUP0_IRQ,
-        .ext_ppus = ext_ppus,
-        .ext_ppus_count = FWK_ARRAY_SIZE(ext_ppus),
-        .driver_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SGM776_SYSTEM),
-        .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_SGM776_SYSTEM,
-             MOD_SGM776_SYSTEM_API_IDX_SYSTEM_POWER_DRIVER),
-        .initial_system_power_state = MOD_PD_STATE_ON,
-    }),
-    .get_element_table = system_power_get_element_table,
+    .data =
+        &(struct mod_system_power_config){
+            .soc_wakeup_irq = SOC_WAKEUP0_IRQ,
+            .ext_ppus = ext_ppus,
+            .ext_ppus_count = FWK_ARRAY_SIZE(ext_ppus),
+            .driver_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SGM776_SYSTEM),
+            .driver_api_id = FWK_ID_API_INIT(
+                FWK_MODULE_IDX_SGM776_SYSTEM,
+                MOD_SGM776_SYSTEM_API_IDX_SYSTEM_POWER_DRIVER),
+            .initial_system_power_state = MOD_PD_STATE_ON,
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_power_get_element_table),
 };

--- a/product/sgm776/scp_ramfw/config_timer.c
+++ b/product/sgm776/scp_ramfw/config_timer.c
@@ -44,7 +44,7 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };
 
 /*
@@ -70,5 +70,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/sgm776/scp_romfw/config_clock.c
+++ b/product/sgm776/scp_romfw/config_clock.c
@@ -109,11 +109,13 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
-        .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
-            FWK_MODULE_IDX_MSYS_ROM,
-            MOD_MSYS_ROM_NOTIFICATION_IDX_POWER_SYSTOP),
-        .pd_pre_transition_notification_id = FWK_ID_NONE_INIT,
-    }),
+    .data =
+        &(struct mod_clock_config){
+            .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_MSYS_ROM,
+                MOD_MSYS_ROM_NOTIFICATION_IDX_POWER_SYSTOP),
+            .pd_pre_transition_notification_id = FWK_ID_NONE_INIT,
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
 };

--- a/product/sgm776/scp_romfw/config_css_clock.c
+++ b/product/sgm776/scp_romfw/config_css_clock.c
@@ -188,5 +188,5 @@ static const struct fwk_element *css_clock_get_element_table
 }
 
 const struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/sgm776/scp_romfw/config_log.c
+++ b/product/sgm776/scp_romfw/config_log.c
@@ -44,7 +44,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*
@@ -58,6 +58,5 @@ static const struct mod_log_config log_data = {
 };
 
 struct fwk_module_config config_log = {
-    .get_element_table = NULL,
     .data = &log_data,
 };

--- a/product/sgm776/scp_romfw/config_pik_clock.c
+++ b/product/sgm776/scp_romfw/config_pik_clock.c
@@ -346,5 +346,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 const struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/sgm776/scp_romfw/config_ppu_v1.c
+++ b/product/sgm776/scp_romfw/config_ppu_v1.c
@@ -73,10 +73,13 @@ static const struct fwk_element *sgm776_ppu_v1_get_element_table(
  * Power module configuration data
  */
 struct fwk_module_config config_ppu_v1 = {
-    .get_element_table = sgm776_ppu_v1_get_element_table,
-    .data = &(struct mod_ppu_v1_config) {
-        .pd_notification_id = FWK_ID_NOTIFICATION_INIT(FWK_MODULE_IDX_MSYS_ROM,
-                                  MOD_MSYS_ROM_NOTIFICATION_IDX_POWER_SYSTOP),
-        .pd_source_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_MSYS_ROM),
-    },
+    .data =
+        &(struct mod_ppu_v1_config){
+            .pd_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_MSYS_ROM,
+                MOD_MSYS_ROM_NOTIFICATION_IDX_POWER_SYSTOP),
+            .pd_source_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_MSYS_ROM),
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sgm776_ppu_v1_get_element_table),
 };

--- a/product/sgm776/scp_romfw/config_sds.c
+++ b/product/sgm776/scp_romfw/config_sds.c
@@ -172,6 +172,6 @@ static const struct fwk_element *sds_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = sds_get_element_table,
     .data = &sds_module_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sds_get_element_table),
 };

--- a/product/sgm776/scp_romfw/config_system_pll.c
+++ b/product/sgm776/scp_romfw/config_system_pll.c
@@ -81,5 +81,5 @@ static const struct fwk_element *system_pll_get_element_table
 }
 
 const struct fwk_module_config config_system_pll = {
-    .get_element_table = system_pll_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_pll_get_element_table),
 };

--- a/product/sgm776/scp_romfw/config_timer.c
+++ b/product/sgm776/scp_romfw/config_timer.c
@@ -42,7 +42,7 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };
 
 /*
@@ -66,5 +66,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/sgm776/src/config_sid.c
+++ b/product/sgm776/src/config_sid.c
@@ -36,7 +36,6 @@ static const struct fwk_element *get_subsystem_table(fwk_id_t id)
 }
 
 struct fwk_module_config config_sid = {
-    .get_element_table = get_subsystem_table,
     .data = &(struct mod_sid_config) {
         .sid_base = SID_BASE,
         .pcid_expected = {
@@ -50,4 +49,6 @@ struct fwk_module_config config_sid = {
             .CID3 = 0xB1,
         },
     },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_subsystem_table),
 };

--- a/product/sgm776/src/config_system_info.c
+++ b/product/sgm776/src/config_system_info.c
@@ -15,12 +15,10 @@
 #include <stddef.h>
 
 const struct fwk_module_config config_system_info = {
-    .get_element_table = NULL,
-    .data = &((struct mod_system_info_config) {
-            .system_info_driver_module_id =
-                FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SID),
-            .system_info_driver_data_api_id =
-                FWK_ID_API_INIT(FWK_MODULE_IDX_SID,
-                                MOD_SID_SYSTEM_INFO_DRIVER_DATA_API_IDX),
+    .data = &((struct mod_system_info_config){
+        .system_info_driver_module_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SID),
+        .system_info_driver_data_api_id = FWK_ID_API_INIT(
+            FWK_MODULE_IDX_SID,
+            MOD_SID_SYSTEM_INFO_DRIVER_DATA_API_IDX),
     }),
 };

--- a/product/synquacer/scp_ramfw/config_ccn512.c
+++ b/product/synquacer/scp_ramfw/config_ccn512.c
@@ -17,7 +17,6 @@
  * CCN512 module
  */
 struct fwk_module_config config_ccn512 = {
-    .get_element_table = NULL,
     .data = &((struct mod_ccn512_module_config){
         .reg_base = (ccn512_reg_t *)CCN512_BASE,
     }),

--- a/product/synquacer/scp_ramfw/config_css_clock.c
+++ b/product/synquacer/scp_ramfw/config_css_clock.c
@@ -19,5 +19,5 @@ static const struct fwk_element *css_clock_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/synquacer/scp_ramfw/config_f_i2c.c
+++ b/product/synquacer/scp_ramfw/config_f_i2c.c
@@ -10,6 +10,4 @@
 #include <stddef.h>
 
 /* Configuration of the F_I2C module. */
-const struct fwk_module_config config_f_i2c = {
-    .get_element_table = NULL,
-};
+const struct fwk_module_config config_f_i2c = { 0 };

--- a/product/synquacer/scp_ramfw/config_hsspi.c
+++ b/product/synquacer/scp_ramfw/config_hsspi.c
@@ -10,6 +10,4 @@
 #include <stddef.h>
 
 /* Configuration of the HSSPI module. */
-const struct fwk_module_config config_hsspi = {
-    .get_element_table = NULL,
-};
+const struct fwk_module_config config_hsspi = { 0 };

--- a/product/synquacer/scp_ramfw/config_log_f_uart3.c
+++ b/product/synquacer/scp_ramfw/config_log_f_uart3.c
@@ -40,7 +40,7 @@ static const struct fwk_element *get_f_uart3_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_f_uart3 = {
-    .get_element_table = get_f_uart3_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_f_uart3_table),
 };
 
 /*

--- a/product/synquacer/scp_ramfw/config_log_pl011.c
+++ b/product/synquacer/scp_ramfw/config_log_pl011.c
@@ -39,7 +39,7 @@ static const struct fwk_element *get_pl011_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };
 
 /*

--- a/product/synquacer/scp_ramfw/config_mhu.c
+++ b/product/synquacer/scp_ramfw/config_mhu.c
@@ -42,5 +42,5 @@ static const struct fwk_element *mhu_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_mhu = {
-    .get_element_table = mhu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(mhu_get_element_table),
 };

--- a/product/synquacer/scp_ramfw/config_pik_clock.c
+++ b/product/synquacer/scp_ramfw/config_pik_clock.c
@@ -1149,5 +1149,5 @@ static const struct fwk_element *pik_clock_get_element_table(
 }
 
 const struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/synquacer/scp_ramfw/config_power_domain.c
+++ b/product/synquacer/scp_ramfw/config_power_domain.c
@@ -227,6 +227,7 @@ static const struct fwk_element *synquacer_power_domain_get_element_table(
  * Power module configuration data
  */
 const struct fwk_module_config config_power_domain = {
-    .get_element_table = synquacer_power_domain_get_element_table,
     .data = &synquacer_power_domain_config,
+    .elements =
+        FWK_MODULE_DYNAMIC_ELEMENTS(synquacer_power_domain_get_element_table),
 };

--- a/product/synquacer/scp_ramfw/config_ppu_v0_synquacer.c
+++ b/product/synquacer/scp_ramfw/config_ppu_v0_synquacer.c
@@ -153,5 +153,5 @@ static const struct fwk_element *ppu_v0_get_element_table(fwk_id_t module_id)
  * Power module configuration data
  */
 const struct fwk_module_config config_ppu_v0_synquacer = {
-    .get_element_table = ppu_v0_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ppu_v0_get_element_table),
 };

--- a/product/synquacer/scp_ramfw/config_scmi.c
+++ b/product/synquacer/scp_ramfw/config_scmi.c
@@ -50,12 +50,14 @@ static struct mod_scmi_agent agent_table[] = {
 };
 
 const struct fwk_module_config config_scmi = {
-    .get_element_table = get_service_table,
-    .data = &((struct mod_scmi_config) {
-        .protocol_count_max = 9,
-        .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
-        .agent_table = agent_table,
-        .vendor_identifier = "socionext",
-        .sub_vendor_identifier = "socionext",
-    }),
+    .data =
+        &(struct mod_scmi_config){
+            .protocol_count_max = 9,
+            .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
+            .agent_table = agent_table,
+            .vendor_identifier = "socionext",
+            .sub_vendor_identifier = "socionext",
+        },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_service_table),
 };

--- a/product/synquacer/scp_ramfw/config_smt.c
+++ b/product/synquacer/scp_ramfw/config_smt.c
@@ -54,5 +54,5 @@ static const struct fwk_element *smt_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_smt = {
-    .get_element_table = smt_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(smt_get_element_table),
 };

--- a/product/synquacer/scp_ramfw/config_synquacer_memc.c
+++ b/product/synquacer/scp_ramfw/config_synquacer_memc.c
@@ -10,6 +10,4 @@
 #include <stddef.h>
 
 /* Configuration of the SynQuacerMEMC module. */
-const struct fwk_module_config config_synquacer_memc = {
-    .get_element_table = NULL,
-};
+const struct fwk_module_config config_synquacer_memc = { 0 };

--- a/product/synquacer/scp_ramfw/config_system_power.c
+++ b/product/synquacer/scp_ramfw/config_system_power.c
@@ -84,15 +84,16 @@ static const struct fwk_element *system_power_get_element_table(
 }
 
 const struct fwk_module_config config_system_power = {
-    .data = &((struct mod_system_power_config) {
-        .soc_wakeup_irq = FWK_INTERRUPT_NONE,
-        .ext_ppus = ext_ppus,
-        .ext_ppus_count = FWK_ARRAY_SIZE(ext_ppus),
-        .initial_system_power_state = MOD_PD_STATE_ON,
-        .driver_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SYNQUACER_SYSTEM),
-        .driver_api_id = FWK_ID_API_INIT(
-            FWK_MODULE_IDX_SYNQUACER_SYSTEM,
-            MOD_SYNQUACER_SYSTEM_API_IDX_SYSTEM_POWER_DRIVER)
-    }),
-    .get_element_table = system_power_get_element_table,
+    .data =
+        &(struct mod_system_power_config){
+            .soc_wakeup_irq = FWK_INTERRUPT_NONE,
+            .ext_ppus = ext_ppus,
+            .ext_ppus_count = FWK_ARRAY_SIZE(ext_ppus),
+            .initial_system_power_state = MOD_PD_STATE_ON,
+            .driver_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SYNQUACER_SYSTEM),
+            .driver_api_id = FWK_ID_API_INIT(
+                FWK_MODULE_IDX_SYNQUACER_SYSTEM,
+                MOD_SYNQUACER_SYSTEM_API_IDX_SYSTEM_POWER_DRIVER) },
+
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_power_get_element_table),
 };

--- a/product/synquacer/scp_ramfw/config_timer.c
+++ b/product/synquacer/scp_ramfw/config_timer.c
@@ -39,7 +39,7 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };
 
 /*
@@ -65,5 +65,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/synquacer/scp_romfw/config_log_f_uart3.c
+++ b/product/synquacer/scp_romfw/config_log_f_uart3.c
@@ -40,7 +40,7 @@ static const struct fwk_element *get_f_uart3_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_f_uart3 = {
-    .get_element_table = get_f_uart3_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_f_uart3_table),
 };
 
 /*

--- a/product/synquacer/scp_romfw/config_synquacer_pik_clock.c
+++ b/product/synquacer/scp_romfw/config_synquacer_pik_clock.c
@@ -244,5 +244,5 @@ static const struct fwk_element *pik_clock_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_synquacer_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/synquacer/scp_romfw/config_timer.c
+++ b/product/synquacer/scp_romfw/config_timer.c
@@ -39,7 +39,7 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };
 
 /*
@@ -65,5 +65,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/tc0/scp_ramfw/config_clock.c
+++ b/product/tc0/scp_ramfw/config_clock.c
@@ -86,8 +86,8 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
+    .data = &((struct mod_clock_config){
         .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
             FWK_MODULE_IDX_POWER_DOMAIN,
             MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION),

--- a/product/tc0/scp_ramfw/config_css_clock.c
+++ b/product/tc0/scp_ramfw/config_css_clock.c
@@ -126,5 +126,5 @@ static const struct fwk_element *css_clock_get_element_table
 }
 
 const struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/tc0/scp_ramfw/config_dvfs.c
+++ b/product/tc0/scp_ramfw/config_dvfs.c
@@ -65,5 +65,5 @@ static const struct fwk_element *dvfs_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_dvfs = {
-    .get_element_table = dvfs_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(dvfs_get_element_table),
 };

--- a/product/tc0/scp_ramfw/config_gtimer.c
+++ b/product/tc0/scp_ramfw/config_gtimer.c
@@ -39,5 +39,5 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };

--- a/product/tc0/scp_ramfw/config_mhu2.c
+++ b/product/tc0/scp_ramfw/config_mhu2.c
@@ -46,5 +46,5 @@ static const struct fwk_element *mhu_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_mhu2 = {
-    .get_element_table = mhu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(mhu_get_element_table),
 };

--- a/product/tc0/scp_ramfw/config_mock_psu.c
+++ b/product/tc0/scp_ramfw/config_mock_psu.c
@@ -34,5 +34,5 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_mock_psu = {
-    .get_element_table = get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
 };

--- a/product/tc0/scp_ramfw/config_pik_clock.c
+++ b/product/tc0/scp_ramfw/config_pik_clock.c
@@ -203,5 +203,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 const struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/tc0/scp_ramfw/config_power_domain.c
+++ b/product/tc0/scp_ramfw/config_power_domain.c
@@ -166,6 +166,6 @@ static const struct fwk_element *tc0_power_domain_get_element_table
  * Power module configuration data
  */
 const struct fwk_module_config config_power_domain = {
-    .get_element_table = tc0_power_domain_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(tc0_power_domain_get_element_table),
     .data = &tc0_power_domain_config,
 };

--- a/product/tc0/scp_ramfw/config_ppu_v1.c
+++ b/product/tc0/scp_ramfw/config_ppu_v1.c
@@ -150,6 +150,6 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
  * Power module configuration data
  */
 const struct fwk_module_config config_ppu_v1 = {
-    .get_element_table = ppu_v1_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(ppu_v1_get_element_table),
     .data = &ppu_v1_config_data,
 };

--- a/product/tc0/scp_ramfw/config_psu.c
+++ b/product/tc0/scp_ramfw/config_psu.c
@@ -30,5 +30,5 @@ static const struct fwk_element *psu_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_psu = {
-    .get_element_table = psu_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(psu_get_element_table),
 };

--- a/product/tc0/scp_ramfw/config_scmi.c
+++ b/product/tc0/scp_ramfw/config_scmi.c
@@ -69,8 +69,8 @@ static struct mod_scmi_agent agent_table[] = {
 };
 
 const struct fwk_module_config config_scmi = {
-    .get_element_table = get_service_table,
-    .data = &((struct mod_scmi_config) {
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_service_table),
+    .data = &((struct mod_scmi_config){
         .protocol_count_max = 9,
         .agent_count = FWK_ARRAY_SIZE(agent_table),
         .agent_table = agent_table,

--- a/product/tc0/scp_ramfw/config_scmi_perf.c
+++ b/product/tc0/scp_ramfw/config_scmi_perf.c
@@ -24,8 +24,8 @@ static const struct mod_scmi_perf_domain_config domains[] = {
 };
 
 const struct fwk_module_config config_scmi_perf = {
-    .get_element_table = NULL,
-    .data = &((struct mod_scmi_perf_config) {
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(NULL),
+    .data = &((struct mod_scmi_perf_config){
         .domains = &domains,
         .fast_channels_alarm_id = FWK_ID_NONE_INIT,
     }),

--- a/product/tc0/scp_ramfw/config_sds.c
+++ b/product/tc0/scp_ramfw/config_sds.c
@@ -80,6 +80,6 @@ static const struct fwk_element *sds_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = sds_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sds_get_element_table),
     .data = &sds_module_config,
 };

--- a/product/tc0/scp_ramfw/config_smt.c
+++ b/product/tc0/scp_ramfw/config_smt.c
@@ -63,5 +63,5 @@ static const struct fwk_element *smt_get_element_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_smt = {
-    .get_element_table = smt_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(smt_get_element_table),
 };

--- a/product/tc0/scp_ramfw/config_system_pll.c
+++ b/product/tc0/scp_ramfw/config_system_pll.c
@@ -100,5 +100,5 @@ static const struct fwk_element *system_pll_get_element_table
 }
 
 const struct fwk_module_config config_system_pll = {
-    .get_element_table = system_pll_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_pll_get_element_table),
 };

--- a/product/tc0/scp_ramfw/config_system_power.c
+++ b/product/tc0/scp_ramfw/config_system_power.c
@@ -89,6 +89,6 @@ static const struct fwk_element *tc0_system_get_element_table(
 }
 
 const struct fwk_module_config config_system_power = {
-    .get_element_table = tc0_system_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(tc0_system_get_element_table),
     .data = &system_power_config,
 };

--- a/product/tc0/scp_ramfw/config_timer.c
+++ b/product/tc0/scp_ramfw/config_timer.c
@@ -38,5 +38,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/tc0/scp_romfw/config_clock.c
+++ b/product/tc0/scp_romfw/config_clock.c
@@ -51,8 +51,8 @@ static const struct fwk_element *clock_get_dev_desc_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_clock = {
-    .get_element_table = clock_get_dev_desc_table,
-    .data = &((struct mod_clock_config) {
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(clock_get_dev_desc_table),
+    .data = &((struct mod_clock_config){
         .pd_transition_notification_id = FWK_ID_NOTIFICATION_INIT(
             FWK_MODULE_IDX_MSYS_ROM,
             MOD_MSYS_ROM_NOTIFICATION_IDX_POWER_SYSTOP),

--- a/product/tc0/scp_romfw/config_cmn_booker.c
+++ b/product/tc0/scp_romfw/config_cmn_booker.c
@@ -94,8 +94,8 @@ static const struct mod_cmn_booker_mem_region_map mmap[] = {
 };
 
 const struct fwk_module_config config_cmn_booker = {
-    .get_element_table = NULL,
-    .data = &((struct mod_cmn_booker_config) {
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(NULL),
+    .data = &((struct mod_cmn_booker_config){
         .base = SCP_CMN_BOOKER_BASE,
         .mesh_size_x = 2,
         .mesh_size_y = 2,
@@ -104,8 +104,8 @@ const struct fwk_module_config config_cmn_booker = {
         .snf_count = FWK_ARRAY_SIZE(snf_table),
         .mmap_table = mmap,
         .mmap_count = FWK_ARRAY_SIZE(mmap),
-        .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK,
-            CLOCK_IDX_INTERCONNECT),
+        .clock_id =
+            FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_INTERCONNECT),
         .hnf_cal_mode = false,
     }),
 };

--- a/product/tc0/scp_romfw/config_css_clock.c
+++ b/product/tc0/scp_romfw/config_css_clock.c
@@ -104,5 +104,5 @@ static const struct fwk_element *css_clock_get_element_table
 }
 
 const struct fwk_module_config config_css_clock = {
-    .get_element_table = css_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(css_clock_get_element_table),
 };

--- a/product/tc0/scp_romfw/config_gtimer.c
+++ b/product/tc0/scp_romfw/config_gtimer.c
@@ -39,5 +39,5 @@ static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_gtimer = {
-    .get_element_table = gtimer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
 };

--- a/product/tc0/scp_romfw/config_pik_clock.c
+++ b/product/tc0/scp_romfw/config_pik_clock.c
@@ -178,5 +178,5 @@ static const struct fwk_element *pik_clock_get_element_table
 }
 
 const struct fwk_module_config config_pik_clock = {
-    .get_element_table = pik_clock_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(pik_clock_get_element_table),
 };

--- a/product/tc0/scp_romfw/config_ppu_v1.c
+++ b/product/tc0/scp_romfw/config_ppu_v1.c
@@ -132,10 +132,12 @@ static const struct fwk_element *tc0_ppu_v1_get_element_table(
  * Power module configuration data
  */
 struct fwk_module_config config_ppu_v1 = {
-    .get_element_table = tc0_ppu_v1_get_element_table,
-    .data = &(struct mod_ppu_v1_config) {
-        .pd_notification_id = FWK_ID_NOTIFICATION_INIT(FWK_MODULE_IDX_MSYS_ROM,
-                                  MOD_MSYS_ROM_NOTIFICATION_IDX_POWER_SYSTOP),
-        .pd_source_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_MSYS_ROM),
-    },
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(tc0_ppu_v1_get_element_table),
+    .data =
+        &(struct mod_ppu_v1_config){
+            .pd_notification_id = FWK_ID_NOTIFICATION_INIT(
+                FWK_MODULE_IDX_MSYS_ROM,
+                MOD_MSYS_ROM_NOTIFICATION_IDX_POWER_SYSTOP),
+            .pd_source_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_MSYS_ROM),
+        },
 };

--- a/product/tc0/scp_romfw/config_sds.c
+++ b/product/tc0/scp_romfw/config_sds.c
@@ -90,6 +90,6 @@ static const struct fwk_element *sds_get_element_table(fwk_id_t module_id)
 }
 
 struct fwk_module_config config_sds = {
-    .get_element_table = sds_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(sds_get_element_table),
     .data = &sds_module_config,
 };

--- a/product/tc0/scp_romfw/config_system_pll.c
+++ b/product/tc0/scp_romfw/config_system_pll.c
@@ -63,5 +63,5 @@ static const struct fwk_element *system_pll_get_element_table
 }
 
 const struct fwk_module_config config_system_pll = {
-    .get_element_table = system_pll_get_element_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(system_pll_get_element_table),
 };

--- a/product/tc0/scp_romfw/config_timer.c
+++ b/product/tc0/scp_romfw/config_timer.c
@@ -35,5 +35,5 @@ static const struct fwk_element *timer_get_dev_table(fwk_id_t module_id)
 }
 
 const struct fwk_module_config config_timer = {
-    .get_element_table = timer_get_dev_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(timer_get_dev_table),
 };

--- a/product/tc0/src/config_pl011.c
+++ b/product/tc0/src/config_pl011.c
@@ -34,5 +34,5 @@ static const struct fwk_element *get_pl011_table(fwk_id_t id)
 }
 
 const struct fwk_module_config config_pl011 = {
-    .get_element_table = get_pl011_table,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_pl011_table),
 };

--- a/tools/ci.py
+++ b/tools/ci.py
@@ -45,29 +45,6 @@ def main():
     result = subprocess.call('CC=gcc make clean test', shell=True)
     results.append(('Framework tests', result))
 
-    banner('Test building the framework library')
-
-    cmd = \
-        'CC=gcc ' \
-        'BS_FIRMWARE_CPU=host ' \
-        'make clean lib-framework -j'
-    result = subprocess.call(cmd, shell=True)
-    results.append(('Framework build (Host, GCC)', result))
-
-    cmd = \
-        'CC=arm-none-eabi-gcc ' \
-        'BS_FIRMWARE_CPU=cortex-m3 ' \
-        'make clean lib-framework -j'
-    result = subprocess.call(cmd, shell=True)
-    results.append(('Framework build (Cortex-M3, GCC)', result))
-
-    cmd = \
-        'CC=armclang ' \
-        'BS_FIRMWARE_CPU=cortex-m3 ' \
-        'make clean lib-framework -j'
-    result = subprocess.call(cmd, shell=True)
-    results.append(('Framework build (Cortex-M3, ARM)', result))
-
     banner('Test building host product')
 
     cmd = \

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -32,3 +32,6 @@ nullPointerRedundantCheck:product/juno/*
 
 // Cppcheck seems to get confused when encountering parentheses in strings
 syntaxError:product/synquacer/module/synquacer_system/src/mmu500.c:34
+
+// Cppcheck doesn't like include directives that use macros
+preprocessorErrorDirective:framework/test/fwk_module_idx.h:14

--- a/tools/gen_module_code.py
+++ b/tools/gen_module_code.py
@@ -44,12 +44,10 @@ TEMPLATE_C = "/* This file was auto generated using {} */\n" \
              "\n" \
              "const struct fwk_module *module_table[] = {{\n" \
              "{}" \
-             "    NULL\n" \
              "}};\n" \
              "\n" \
              "const struct fwk_module_config *module_config_table[] = {{\n" \
              "{}" \
-             "    NULL\n" \
              "}};\n"
 
 
@@ -73,6 +71,8 @@ def generate_header(path, modules):
                  "FWK_ID_MODULE_INIT(FWK_MODULE_IDX_{});\n".format(module,
                                                                    module
                                                                    .upper())
+
+    enum += "    FWK_MODULE_IDX_COUNT,\n"
 
     content = TEMPLATE_H.format(sys.argv[0], enum, const)
     generate_file(path, FILENAME_H, content)

--- a/tools/gen_module_code.py
+++ b/tools/gen_module_code.py
@@ -65,14 +65,14 @@ def generate_file(path, filename, content):
 def generate_header(path, modules):
     enum = ""
     const = ""
-    for module in modules:
-        enum += "    FWK_MODULE_IDX_{},\n".format(module.upper())
+    for idx, module in enumerate(modules):
+        enum += "    FWK_MODULE_IDX_{} = {},\n".format(module.upper(), idx)
         const += "static const fwk_id_t fwk_module_id_{} = " \
                  "FWK_ID_MODULE_INIT(FWK_MODULE_IDX_{});\n".format(module,
                                                                    module
                                                                    .upper())
 
-    enum += "    FWK_MODULE_IDX_COUNT,\n"
+    enum += "    FWK_MODULE_IDX_COUNT = {},\n".format(idx + 1)
 
     content = TEMPLATE_H.format(sys.argv[0], enum, const)
     generate_file(path, FILENAME_H, content)


### PR DESCRIPTION
This PR allows element tables to be created withut a prior generator function (`get_element_table()`). All existing platforms have been updated to reflect the change in module structure, but their behaviour has not been changed and all modules continue to use the dynamic element generator.