### PR TITLE
Add timestamping support

### DIFF
--- a/framework/include/fwk_time.h
+++ b/framework/include/fwk_time.h
@@ -1,0 +1,258 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FWK_TIME_H
+#define FWK_TIME_H
+
+#include <fwk_assert.h>
+#include <fwk_id.h>
+
+#include <inttypes.h>
+#include <stdint.h>
+
+struct fwk_arch_counter_driver;
+
+/*!
+ * \addtogroup GroupLibFramework
+ * \defgroup GroupTime Time operations.
+ *
+ * \details This component adds support for various time operations, including
+ *      timestamping and duration calculations. It also provides facilities for
+ *      converting between units of time as well as printing them using the
+ *      standard framework printing and logging facilities.
+ *
+ * \{
+ */
+
+/*!
+ * \brief Create a nanosecond duration.
+ *
+ * \param[in] N Number of nanoseconds.
+ *
+ * \return A value of type ::fwk_duration_ns_t representing the duration \p N.
+ */
+#define FWK_NS(N) ((fwk_duration_ns_t)(N))
+
+/*!
+ * \brief Create a nanosecond duration from a microsecond value.
+ *
+ * \param[in] N Number of microseconds.
+ *
+ * \return A value of type ::fwk_duration_ns_t representing the duration \p N.
+ */
+#define FWK_US(N) FWK_NS((N) * UINT64_C(1000))
+
+/*!
+ * \brief Create a nanosecond duration from a millisecond value.
+ *
+ * \param[in] N Number of milliseconds.
+ *
+ * \return A value of type ::fwk_duration_ns_t representing the duration \p N.
+ */
+#define FWK_MS(N) FWK_US((N) * UINT64_C(1000))
+
+/*!
+ * \brief Create a nanosecond duration from a second value.
+ *
+ * \param[in] N Number of seconds.
+ *
+ * \return A value of type ::fwk_duration_ns_t representing the duration \p N.
+ */
+#define FWK_S(N) FWK_MS((N) * UINT64_C(1000))
+
+/*!
+ * \brief Create a nanosecond duration from a minute value.
+ *
+ * \param[in] N Number of minutes.
+ *
+ * \return A value of type ::fwk_duration_ns_t representing the duration \p N.
+ */
+#define FWK_M(N) FWK_S((N) * UINT64_C(60))
+
+/*!
+ * \brief Create a nanosecond duration from an hour value.
+ *
+ * \param[in] N Number of hours.
+ *
+ * \return A value of type ::fwk_duration_ns_t representing the duration \p N.
+ */
+#define FWK_H(N) (FWK_M(N * UINT64_C(60)))
+
+/*!
+ * \brief Format specifier for ::fwk_duration_ns_t.
+ */
+#define FWK_PRDNS PRIu64
+
+/*!
+ * \brief Format specifier for ::fwk_duration_us_t.
+ */
+#define FWK_PRDUS PRIu64
+
+/*!
+ * \brief Format specifier for ::fwk_duration_ms_t.
+ */
+#define FWK_PRDMS PRIu64
+
+/*!
+ * \brief Format specifier for ::fwk_duration_s_t.
+ */
+#define FWK_PRDS PRIu64
+
+/*!
+ * \brief Format specifier for ::fwk_duration_m_t.
+ */
+#define FWK_PRDM PRIu32
+
+/*!
+ * \brief Format specifier for ::fwk_duration_h_t.
+ */
+#define FWK_PRDH PRIu32
+
+/*!
+ * \brief A timestamp, representing nanoseconds since boot.
+ */
+typedef uint64_t fwk_timestamp_t;
+
+/*!
+ * \brief A duration of time measured in nanoseconds.
+ */
+typedef uint64_t fwk_duration_ns_t;
+
+/*!
+ * \brief A duration of time measured in microseconds.
+ */
+typedef uint64_t fwk_duration_us_t;
+
+/*!
+ * \brief A duration of time measured in milliseconds.
+ */
+typedef uint64_t fwk_duration_ms_t;
+
+/*!
+ * \brief A duration of time measured in seconds.
+ */
+typedef uint64_t fwk_duration_s_t;
+
+/*!
+ * \brief A duration of time measured in minutes.
+ */
+typedef uint32_t fwk_duration_m_t;
+
+/*!
+ * \brief A duration of time measured in hours.
+ */
+typedef uint32_t fwk_duration_h_t;
+
+/*!
+ * \brief Get a timestamp representing the current time.
+ *
+ * \return Current timestamp.
+ */
+fwk_timestamp_t fwk_time_current(void);
+
+/*!
+ * \brief Convert a timestamp to duration since boot, in nanoseconds.
+ *
+ * \param[in] timestamp Timestamp.
+ *
+ * \return Duration of time since boot, in nanoseconds.
+ */
+fwk_duration_ns_t fwk_time_stamp_duration(fwk_timestamp_t timestamp);
+
+/*!
+ * \brief Get the duration of time between two points.
+ *
+ * \param[in] start Timestamp representing the beginning of the measurement.
+ * \param[in] end Timestamp representing the end of the measurement.
+ *
+ * \return Duration of time between two points, in nanoseconds.
+ */
+fwk_duration_ns_t fwk_time_duration(fwk_timestamp_t start, fwk_timestamp_t end);
+
+/*!
+ * \brief Convert a nanosecond duration to a microsecond duration.
+ *
+ * \param[in] duration Duration in nanoseconds.
+ *
+ * \return Duration in microseconds.
+ */
+fwk_duration_us_t fwk_time_duration_us(fwk_duration_ns_t duration);
+
+/*!
+ * \brief Convert a nanosecond duration to a millisecond duration.
+ *
+ * \param[in] duration Duration in nanoseconds.
+ *
+ * \return Duration in milliseconds.
+ */
+fwk_duration_ms_t fwk_time_duration_ms(fwk_duration_ns_t duration);
+
+/*!
+ * \brief Convert a nanosecond duration to a second duration.
+ *
+ * \param[in] duration Duration in nanoseconds.
+ *
+ * \return Duration in seconds.
+ */
+fwk_duration_s_t fwk_time_duration_s(fwk_duration_ns_t duration);
+
+/*!
+ * \brief Convert a nanosecond duration to a minute duration.
+ *
+ * \param[in] duration Duration in nanoseconds.
+ *
+ * \return Duration in minutes.
+ */
+fwk_duration_m_t fwk_time_duration_m(fwk_duration_ns_t duration);
+
+/*!
+ * \brief Convert a nanosecond duration to an hour duration.
+ *
+ * \param[in] duration Duration in nanoseconds.
+ *
+ * \return Duration in hours.
+ */
+fwk_duration_h_t fwk_time_duration_h(fwk_duration_ns_t duration);
+
+/*!
+ * \brief Time driver.
+ */
+struct fwk_time_driver {
+    /*!
+     * \brief Read the current timestamp value.
+     *
+     * \param[in] Driver-specific context given by the firmware.
+     *
+     * \return Current timestamp.
+     */
+    fwk_timestamp_t (*timestamp)(const void *ctx);
+};
+
+/*!
+ * \brief Register a framework time driver.
+ *
+ * \details In order to update timestamp details on demand, the framework needs
+ *      to reach out to a particular device. This is done through the time
+ *      driver, which should be configured to read from a particular counter in
+ *      the system.
+ *
+ *      This is a weak function provided by the framework that, by default, does
+ *      not register a driver, and should be overridden by the firmware if you
+ *      wish to provide one.
+ *
+ * \param[out] ctx Context specific to the driver, provided to calls to the
+ *      driver API.
+ *
+ * \return Framework time driver.
+ */
+struct fwk_time_driver fmw_time_driver(const void **ctx);
+
+/*!
+ * \}
+ */
+
+#endif /* FWK_TIME_H */

--- a/framework/src/Makefile
+++ b/framework/src/Makefile
@@ -17,16 +17,19 @@ BS_LIB_SOURCES += fwk_mm.c
 BS_LIB_SOURCES += fwk_module.c
 BS_LIB_SOURCES += fwk_ring.c
 BS_LIB_SOURCES += fwk_slist.c
+BS_LIB_SOURCES += fwk_status.c
 BS_LIB_SOURCES += fwk_thread_delayed_resp.c
+BS_LIB_SOURCES += fwk_time.c
+
 ifeq ($(BUILD_HAS_MULTITHREADING),yes)
     BS_LIB_SOURCES += fwk_multi_thread.c
 else
     BS_LIB_SOURCES += fwk_thread.c
 endif
+
 ifeq ($(BUILD_HAS_NOTIFICATION),yes)
     BS_LIB_SOURCES += fwk_notification.c
 endif
-BS_LIB_SOURCES += fwk_status.c
 
 BS_LIB_INCLUDES += $(FWK_DIR)/include
 

--- a/framework/src/fwk_time.c
+++ b/framework/src/fwk_time.c
@@ -1,0 +1,76 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <fwk_arch.h>
+#include <fwk_status.h>
+#include <fwk_time.h>
+
+#include <string.h>
+
+struct {
+    struct fwk_time_driver driver; /* Time driver */
+    const void *driver_ctx; /* Time driver context */
+} fwk_time_ctx;
+
+__attribute__((constructor)) void fwk_time_init(void)
+{
+    struct fwk_time_driver driver = fmw_time_driver(&fwk_time_ctx.driver_ctx);
+
+    memcpy(&fwk_time_ctx.driver, &driver, sizeof(driver));
+}
+
+fwk_timestamp_t fwk_time_current(void)
+{
+    if (fwk_time_ctx.driver.timestamp == NULL)
+        return FWK_NS(0);
+
+    return fwk_time_ctx.driver.timestamp(fwk_time_ctx.driver_ctx);
+}
+
+fwk_duration_ns_t fwk_time_stamp_duration(fwk_timestamp_t timestamp)
+{
+    return FWK_NS(timestamp);
+}
+
+fwk_duration_ns_t fwk_time_duration(fwk_timestamp_t start, fwk_timestamp_t end)
+{
+    fwk_assert(end > start);
+
+    return end - start;
+}
+
+fwk_duration_us_t fwk_time_duration_us(fwk_duration_ns_t duration)
+{
+    return duration / FWK_US(1);
+}
+
+fwk_duration_ms_t fwk_time_duration_ms(fwk_duration_ns_t duration)
+{
+    return duration / FWK_MS(1);
+}
+
+fwk_duration_s_t fwk_time_duration_s(fwk_duration_ns_t duration)
+{
+    return duration / FWK_S(1);
+}
+
+fwk_duration_m_t fwk_time_duration_m(fwk_duration_ns_t duration)
+{
+    return duration / FWK_M(1);
+}
+
+fwk_duration_h_t fwk_time_duration_h(fwk_duration_ns_t duration)
+{
+    return duration / FWK_H(1);
+}
+
+__attribute__((weak)) struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return (struct fwk_time_driver){
+        .timestamp = NULL,
+    };
+}

--- a/framework/test/Makefile
+++ b/framework/test/Makefile
@@ -50,6 +50,7 @@ COMMON_SRC += fwk_ring.c
 COMMON_SRC += fwk_slist.c
 COMMON_SRC += fwk_test.c
 COMMON_SRC += fwk_thread_delayed_resp.c
+COMMON_SRC += fwk_time.c
 
 test_fwk_arch_SRC += fwk_thread.c
 test_fwk_id_build_SRC += fwk_thread.c

--- a/module/gtimer/include/mod_gtimer.h
+++ b/module/gtimer/include/mod_gtimer.h
@@ -49,6 +49,21 @@ struct mod_gtimer_dev_config {
 };
 
 /*!
+ * \brief Get the framework time driver for a generic timer device.
+ *
+ * \details This function is intended to be used by a firmware to register a
+ *      generic timer as the driver for the framework time component.
+ *
+ * \param[out] ctx Pointer to storage for the context passed to the driver.
+ * \param[in] cfg Generic timer configuration.
+ *
+ * \return Framework time driver for the given device.
+ */
+struct fwk_time_driver mod_gtimer_driver(
+    const void **ctx,
+    const struct mod_gtimer_dev_config *cfg);
+
+/*!
  * @}
  */
 

--- a/module/gtimer/src/mod_gtimer.c
+++ b/module/gtimer/src/mod_gtimer.c
@@ -19,6 +19,7 @@
 #include <fwk_module.h>
 #include <fwk_notification.h>
 #include <fwk_status.h>
+#include <fwk_time.h>
 
 #include <stddef.h>
 #include <stdint.h>
@@ -35,8 +36,31 @@ struct dev_ctx {
     const struct mod_gtimer_dev_config *config;
 };
 
-/* Table of device context structures */
-static struct dev_ctx *ctx_table;
+static struct mod_gtimer_ctx {
+    bool initialized; /* Whether the device context has been initialized */
+
+    struct dev_ctx *table; /* Device context table */
+} mod_gtimer_ctx;
+
+static uint64_t mod_gtimer_get_counter(const struct cntbase_reg *hw_timer)
+{
+    uint32_t counter_low;
+    uint32_t counter_high;
+
+    /*
+     * To avoid race conditions where the high half of the counter increments
+     * after it has been sampled but before the low half is sampled, the values
+     * are resampled until the high half has stabilized. This assumes that the
+     * loop is faster than the high half incrementation.
+     */
+
+    do {
+        counter_high = hw_timer->PCTH;
+        counter_low = hw_timer->PCTL;
+    } while (counter_high != hw_timer->PCTH);
+
+    return ((uint64_t)counter_high << 32) | counter_low;
+}
 
 /*
  * Functions fulfilling the Timer module's driver interface
@@ -46,7 +70,7 @@ static int enable(fwk_id_t dev_id)
 {
     struct dev_ctx *ctx;
 
-    ctx = ctx_table + fwk_id_get_element_idx(dev_id);
+    ctx = mod_gtimer_ctx.table + fwk_id_get_element_idx(dev_id);
 
     ctx->hw_timer->P_CTL &= ~CNTBASE_P_CTL_IMASK;
     ctx->hw_timer->P_CTL |=  CNTBASE_P_CTL_ENABLE;
@@ -58,7 +82,7 @@ static int disable(fwk_id_t dev_id)
 {
     struct dev_ctx *ctx;
 
-    ctx = ctx_table + fwk_id_get_element_idx(dev_id);
+    ctx = mod_gtimer_ctx.table + fwk_id_get_element_idx(dev_id);
 
     ctx->hw_timer->P_CTL |=  CNTBASE_P_CTL_IMASK;
     ctx->hw_timer->P_CTL &= ~CNTBASE_P_CTL_ENABLE;
@@ -69,23 +93,10 @@ static int disable(fwk_id_t dev_id)
 static int get_counter(fwk_id_t dev_id, uint64_t *value)
 {
     const struct dev_ctx *ctx;
-    uint32_t counter_low;
-    uint32_t counter_high;
 
-    ctx = ctx_table + fwk_id_get_element_idx(dev_id);
+    ctx = mod_gtimer_ctx.table + fwk_id_get_element_idx(dev_id);
 
-    /*
-     * To avoid race conditions where the high half of the counter increments
-     * after it has been sampled but before the low half is sampled, the values
-     * are resampled until the high half has stabilized. This assumes that the
-     * loop is faster than the high half incrementation.
-     */
-    do {
-        counter_high = ctx->hw_timer->PCTH;
-        counter_low = ctx->hw_timer->PCTL;
-    } while (counter_high != ctx->hw_timer->PCTH);
-
-    *value = ((uint64_t)counter_high << 32) | counter_low;
+    *value = mod_gtimer_get_counter(ctx->hw_timer);
 
     return FWK_SUCCESS;
 }
@@ -111,7 +122,7 @@ static int set_timer(fwk_id_t dev_id, uint64_t timestamp)
      */
     timestamp = FWK_MAX(counter + GTIMER_MIN_TIMESTAMP, timestamp);
 
-    ctx = ctx_table + fwk_id_get_element_idx(dev_id);
+    ctx = mod_gtimer_ctx.table + fwk_id_get_element_idx(dev_id);
 
     ctx->hw_timer->P_CVALL = timestamp & 0xFFFFFFFF;
     ctx->hw_timer->P_CVALH = timestamp >> 32;
@@ -125,7 +136,7 @@ static int get_timer(fwk_id_t dev_id, uint64_t *timestamp)
     uint32_t counter_low;
     uint32_t counter_high;
 
-    ctx = ctx_table + fwk_id_get_element_idx(dev_id);
+    ctx = mod_gtimer_ctx.table + fwk_id_get_element_idx(dev_id);
 
     /* Read 64-bit timer value */
     counter_low = ctx->hw_timer->P_CVALL;
@@ -143,7 +154,7 @@ static int get_frequency(fwk_id_t dev_id, uint32_t *frequency)
     if (frequency == NULL)
         return FWK_E_PARAM;
 
-    ctx = ctx_table + fwk_id_get_element_idx(dev_id);
+    ctx = mod_gtimer_ctx.table + fwk_id_get_element_idx(dev_id);
 
     *frequency = ctx->config->frequency;
 
@@ -168,7 +179,7 @@ static int gtimer_init(fwk_id_t module_id,
                        unsigned int element_count,
                        const void *data)
 {
-    ctx_table = fwk_mm_alloc(element_count, sizeof(struct dev_ctx));
+    mod_gtimer_ctx.table = fwk_mm_alloc(element_count, sizeof(struct dev_ctx));
 
     return FWK_SUCCESS;
 }
@@ -178,7 +189,7 @@ static int gtimer_device_init(fwk_id_t element_id, unsigned int unused,
 {
     struct dev_ctx *ctx;
 
-    ctx = ctx_table + fwk_id_get_element_idx(element_id);
+    ctx = mod_gtimer_ctx.table + fwk_id_get_element_idx(element_id);
 
     ctx->config = data;
     if (ctx->config->hw_timer == 0   ||
@@ -235,7 +246,7 @@ static int gtimer_start(fwk_id_t id)
     if (!fwk_id_is_type(id, FWK_ID_TYPE_ELEMENT))
         return FWK_SUCCESS;
 
-    ctx = ctx_table + fwk_id_get_element_idx(id);
+    ctx = mod_gtimer_ctx.table + fwk_id_get_element_idx(id);
 
     if (!fwk_id_is_type(ctx->config->clock_id, FWK_ID_TYPE_NONE)) {
         /* Register for clock state notifications */
@@ -262,13 +273,12 @@ static int gtimer_process_notification(
     params = (struct clock_notification_params *)event->params;
 
     if (params->new_state == MOD_CLOCK_STATE_RUNNING) {
-        ctx = ctx_table + fwk_id_get_element_idx(event->target_id);
+        ctx = mod_gtimer_ctx.table + fwk_id_get_element_idx(event->target_id);
         gtimer_control_init(ctx);
     }
 
     return FWK_SUCCESS;
 }
-
 
 /*
  * Module descriptor
@@ -284,3 +294,29 @@ const struct fwk_module module_gtimer = {
     .process_bind_request = gtimer_process_bind_request,
     .process_notification = gtimer_process_notification,
 };
+
+static fwk_timestamp_t mod_gtimer_timestamp(const void *ctx)
+{
+    fwk_timestamp_t timestamp;
+
+    const struct mod_gtimer_dev_config *cfg = ctx;
+    const struct cntbase_reg *hw_timer = (const void *)cfg->hw_timer;
+
+    uint32_t frequency = cfg->frequency;
+    uint64_t counter = mod_gtimer_get_counter(hw_timer);
+
+    timestamp = (FWK_S(1) / frequency) * counter;
+
+    return timestamp;
+}
+
+struct fwk_time_driver mod_gtimer_driver(
+    const void **ctx,
+    const struct mod_gtimer_dev_config *cfg)
+{
+    *ctx = cfg;
+
+    return (struct fwk_time_driver){
+        .timestamp = mod_gtimer_timestamp,
+    };
+}

--- a/product/juno/scp_ramfw/config_timer.c
+++ b/product/juno/scp_ramfw/config_timer.c
@@ -16,6 +16,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 #include <fmw_cmsis.h>
 
@@ -33,13 +34,8 @@ static const struct fwk_element gtimer_element_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_element_table(fwk_id_t module_id)
-{
-    return gtimer_element_table;
-}
-
 struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_element_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_element_table),
 };
 
 static const struct fwk_element timer_element_table[] = {
@@ -53,6 +49,11 @@ static const struct fwk_element timer_element_table[] = {
     },
     [1] = { 0 },
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}
 
 static const struct fwk_element *timer_get_element_table(fwk_id_t module_id)
 {

--- a/product/juno/scp_romfw/config_timer.c
+++ b/product/juno/scp_romfw/config_timer.c
@@ -13,6 +13,7 @@
 #include <fwk_element.h>
 #include <fwk_id.h>
 #include <fwk_module.h>
+#include <fwk_time.h>
 
 static const struct fwk_element element_table[] = {
     [0] = {
@@ -28,11 +29,11 @@ static const struct fwk_element element_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *get_element_table(fwk_id_t module_id)
-{
-    return element_table;
-}
-
 struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(element_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}

--- a/product/juno/scp_romfw_bypass/config_timer.c
+++ b/product/juno/scp_romfw_bypass/config_timer.c
@@ -13,6 +13,7 @@
 #include <fwk_element.h>
 #include <fwk_id.h>
 #include <fwk_module.h>
+#include <fwk_time.h>
 
 static const struct fwk_element element_table[] = {
     [0] = {
@@ -28,11 +29,11 @@ static const struct fwk_element element_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *get_element_table(fwk_id_t module_id)
-{
-    return element_table;
-}
-
 struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(element_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}

--- a/product/n1sdp/scp_ramfw/config_timer.c
+++ b/product/n1sdp/scp_ramfw/config_timer.c
@@ -16,6 +16,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 #include <fmw_cmsis.h>
 
@@ -37,14 +38,14 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 const struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}
 
 /*
  * Timer HAL config

--- a/product/rddaniel/scp_ramfw/config_gtimer.c
+++ b/product/rddaniel/scp_ramfw/config_gtimer.c
@@ -14,6 +14,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 /*
  * Generic timer driver config
@@ -33,11 +34,11 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 const struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}

--- a/product/rddanielxlr/scp_ramfw/config_gtimer.c
+++ b/product/rddanielxlr/scp_ramfw/config_gtimer.c
@@ -14,6 +14,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 /*
  * Generic timer driver config
@@ -33,11 +34,11 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 const struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}

--- a/product/rdn1e1/scp_ramfw/config_timer.c
+++ b/product/rdn1e1/scp_ramfw/config_timer.c
@@ -16,6 +16,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 #include <fmw_cmsis.h>
 
@@ -37,14 +38,14 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 const struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}
 
 /*
  * Timer HAL config

--- a/product/rdn1e1/scp_romfw/config_gtimer.c
+++ b/product/rdn1e1/scp_romfw/config_gtimer.c
@@ -13,6 +13,7 @@
 #include <fwk_element.h>
 #include <fwk_id.h>
 #include <fwk_module.h>
+#include <fwk_time.h>
 
 /*
  * Generic timer driver config
@@ -31,11 +32,11 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 const struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}

--- a/product/sgi575/scp_ramfw/config_timer.c
+++ b/product/sgi575/scp_ramfw/config_timer.c
@@ -16,6 +16,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 #include <fmw_cmsis.h>
 
@@ -37,14 +38,14 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 const struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}
 
 /*
  * Timer HAL config

--- a/product/sgi575/scp_romfw/config_gtimer.c
+++ b/product/sgi575/scp_romfw/config_gtimer.c
@@ -13,6 +13,7 @@
 #include <fwk_element.h>
 #include <fwk_id.h>
 #include <fwk_module.h>
+#include <fwk_time.h>
 
 /*
  * Generic timer driver config
@@ -31,11 +32,11 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 const struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}

--- a/product/sgm775/scp_ramfw/config_timer.c
+++ b/product/sgm775/scp_ramfw/config_timer.c
@@ -17,6 +17,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 #include <fmw_cmsis.h>
 
@@ -39,14 +40,14 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}
 
 /*
  * Timer HAL config

--- a/product/sgm775/scp_romfw/config_timer.c
+++ b/product/sgm775/scp_romfw/config_timer.c
@@ -16,6 +16,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 /*
  * Generic timer driver config
@@ -36,14 +37,14 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}
 
 /*
  * Timer HAL config

--- a/product/sgm776/scp_ramfw/config_timer.c
+++ b/product/sgm776/scp_ramfw/config_timer.c
@@ -16,6 +16,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 #include <fmw_cmsis.h>
 
@@ -38,14 +39,14 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 const struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}
 
 /*
  * Timer HAL config

--- a/product/sgm776/scp_romfw/config_timer.c
+++ b/product/sgm776/scp_romfw/config_timer.c
@@ -16,6 +16,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 /*
  * Generic timer driver config
@@ -36,14 +37,14 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}
 
 /*
  * Timer HAL config

--- a/product/synquacer/scp_ramfw/config_timer.c
+++ b/product/synquacer/scp_ramfw/config_timer.c
@@ -15,6 +15,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 #include <fmw_cmsis.h>
 
@@ -33,14 +34,14 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}
 
 /*
  * Timer HAL config

--- a/product/synquacer/scp_romfw/config_timer.c
+++ b/product/synquacer/scp_romfw/config_timer.c
@@ -15,6 +15,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 #include <fmw_cmsis.h>
 
@@ -33,14 +34,14 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}
 
 /*
  * Timer HAL config

--- a/product/tc0/scp_ramfw/config_gtimer.c
+++ b/product/tc0/scp_ramfw/config_gtimer.c
@@ -14,6 +14,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 /*
  * Generic timer driver config
@@ -33,11 +34,11 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 const struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}

--- a/product/tc0/scp_romfw/config_gtimer.c
+++ b/product/tc0/scp_romfw/config_gtimer.c
@@ -14,6 +14,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 /*
  * Generic timer driver config
@@ -33,11 +34,11 @@ static const struct fwk_element gtimer_dev_table[] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 const struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}


### PR DESCRIPTION
This PR adds support for timestamping within the framework, and augments the logging framework with timestamp printouts generated by the generic timer on supporting platforms.