### PR TITLE
juno/config_sensor: Fix missing pvt_sensor_elem_table_size

### DIFF
--- a/product/juno/scp_ramfw/config_sensor.c
+++ b/product/juno/scp_ramfw/config_sensor.c
@@ -314,6 +314,7 @@ static const struct fwk_element *get_sensor_element_table(fwk_id_t module_id)
 
     #if USE_FULL_SET_SENSORS
     enum juno_idx_revision rev;
+    size_t pvt_sensor_elem_table_size;
     #endif
 
     size_t sensor_elem_table_size;
@@ -343,6 +344,9 @@ static const struct fwk_element *get_sensor_element_table(fwk_id_t module_id)
                    sensor_element_table_r0,
                    sizeof(sensor_element_table_r0));
         } else {
+            pvt_sensor_elem_table_size =
+                FWK_ARRAY_SIZE(pvt_sensors_juno_r1_r2_elem_table);
+
             /*
              * Add additional sensors available on Juno R1 & R2 and the
              * termination description.


### PR DESCRIPTION
If USE_FULL_SET_SENSORS is set, then the platform may append
additional sensors, including sensors for PVTs.
This patch adds a missing declaration for the pvt table size.

Change-Id: Iaa257b474cc710e8ff3f017fcc485962f40f7780
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>