### PR TITLE
cmn600: Fix incorrect cache group count calculation

### DIFF
--- a/module/cmn600/src/mod_cmn600.c
+++ b/module/cmn600/src/mod_cmn600.c
@@ -32,6 +32,12 @@
 
 #define MOD_NAME "[CMN600] "
 
+static inline size_t cmn600_hnf_cache_group_count(size_t hnf_count)
+{
+    return (hnf_count + CMN600_HNF_CACHE_GROUP_ENTRIES_PER_GROUP - 1) /
+        CMN600_HNF_CACHE_GROUP_ENTRIES_PER_GROUP;
+}
+
 struct cmn600_ctx *ctx;
 
 /* Chip information API */
@@ -521,7 +527,7 @@ int cmn600_setup_sam(struct cmn600_rnsam_reg *rnsam)
         }
     }
 
-    group_count = ctx->hnf_count / CMN600_HNF_CACHE_GROUP_ENTRIES_PER_GROUP;
+    group_count = cmn600_hnf_cache_group_count(ctx->hnf_count);
     for (group = 0; group < group_count; group++)
         rnsam->SYS_CACHE_GRP_HN_NODEID[group] = ctx->hnf_cache_group[group];
 
@@ -575,7 +581,7 @@ static int cmn600_setup(void)
              * HN-F nodes in the system.
              */
             ctx->hnf_cache_group = fwk_mm_calloc(
-                ctx->hnf_count / CMN600_HNF_CACHE_GROUP_ENTRIES_PER_GROUP,
+                cmn600_hnf_cache_group_count(ctx->hnf_count),
                 sizeof(*ctx->hnf_cache_group));
         }
     }


### PR DESCRIPTION
The CMN-600 module currently incorrectly calculates the HN-F cache group
count for HN-F counts less than the number of HN-F entries per HN-F
cache group.

Change-Id: If840a78b8b70b1eb8b2b77768f4e95c0d8c369b3
Signed-off-by: Chris Kay <chris.kay@arm.com>