### PR TITLE
fwk: fwk_thread_put_event_and_wait could process NULL event

### DIFF
--- a/framework/src/fwk_thread.c
+++ b/framework/src/fwk_thread.c
@@ -384,7 +384,8 @@ int fwk_thread_put_event_and_wait(struct fwk_event *event,
     for (;;) {
 
         if (fwk_list_is_empty(&ctx.event_queue)) {
-                process_isr();
+            process_isr();
+            continue;
         }
 
         ctx.current_event = next_event = FWK_LIST_GET(fwk_list_head(


### PR DESCRIPTION
The fwk_thread_put_event_and_wait processing could try and
use a NULL event if both the event queue and the ISR event queues
are empty.

Change-Id: I461a32c3040293c9c8928e60d01dc17bdefff4aa
Signed-off-by: Jim Quigley <jim.quigley@arm.com>