### PR TITLE
module/scmi_system_power: Fix build issue if enabled SCMI notification

### DIFF
--- a/module/scmi_system_power/src/mod_scmi_system_power.c
+++ b/module/scmi_system_power/src/mod_scmi_system_power.c
@@ -130,13 +130,13 @@ static void scmi_sys_power_state_notify(fwk_id_t service_id,
     else
         return_values.flags = 1;
 
-    for (i = 0; i < SCMI_AGENT_ID_MAX; i++) {
+    for (i = 0; i < MOD_SCMI_AGENT_ID_MAX; i++) {
         id =  scmi_sys_power_ctx.system_power_notifications[i];
         if (fwk_id_is_equal(id, FWK_ID_NONE))
             continue;
 
         scmi_sys_power_ctx.scmi_api->notify(id,
-            SCMI_PROTOCOL_ID_SYS_POWER, SCMI_SYS_POWER_STATE_SET_NOTIFY,
+            MOD_SCMI_PROTOCOL_ID_SYS_POWER, SCMI_SYS_POWER_STATE_SET_NOTIFY,
             &return_values, sizeof(return_values));
     }
 }


### PR DESCRIPTION
This change fixes a build issue if build enables
BS_FIRMWARE_HAS_SCMI_NOTIFICATIONS build macro. The build
gives undefined errors for macros SCMI_AGENT_ID_MAX and
SCMI_PROTOCOL_ID_SYS_POWER, which are recently renamed to
SCMI_AGENT_ID_MAX and MOD_SCMI_PROTOCOL_ID_SYS_POWER
respectively.

Change-Id: I1ba7d71d50bdc4a0c4913308e665840ab8a4b644
Signed-off-by: Girish Pathak <girish.pathak@arm.com>