### PR TITLE
Topics/gp/reset domain

### DIFF
--- a/module/reset_domain/include/mod_reset_domain.h
+++ b/module/reset_domain/include/mod_reset_domain.h
@@ -1,0 +1,266 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     Reset domain HAL.
+ */
+
+#ifndef MOD_RESET_DOMAIN_H
+#define MOD_RESET_DOMAIN_H
+
+#include <fwk_id.h>
+#include <fwk_module_idx.h>
+#include <stdint.h>
+
+/*!
+ * \addtogroup GroupModules Modules
+ * \{
+ */
+
+/*!
+ * \defgroup GroupResetDomain Reset Domain HAL
+ *
+ * \details Support for setting the state of reset domains.
+ *
+ * \{
+ */
+
+/*!
+ * \brief API indices.
+ */
+enum mod_reset_domain_api_type {
+    /*!
+     * \brief HAL API.
+     *
+     * \note This API identifier implements the mod_reset_domain_api interface.
+     */
+    MOD_RESET_DOMAIN_API_TYPE_HAL,
+
+    /*!
+     * \brief Number of defined APIs.
+     */
+    MOD_RESET_DOMAIN_API_COUNT,
+};
+
+/*!
+ * \brief Reset domain modes.
+ */
+enum mod_reset_domain_mode {
+    /*!
+     * \brief Indicates whether auto reset mode is supported by a reset domain.
+     */
+    MOD_RESET_DOMAIN_AUTO_RESET = (1UL << 0),
+
+    /*!
+     * \brief Indicates whether async auto reset mode is supported
+     *     by a reset domain.
+     */
+    MOD_RESET_DOMAIN_MODE_AUTO_RESET_ASYNC = (1UL << 1),
+
+    /*!
+     * \brief Indicates whether explicit reset mode is supported by a reset
+     *     domain
+     */
+    MOD_RESET_DOMAIN_MODE_EXPLICIT_ASSERT = (1UL << 2),
+
+    /*!
+     * \brief Indicates whether explicit reset mode is supported by a reset
+     *     domain
+     */
+    MOD_RESET_DOMAIN_MODE_EXPLICIT_DEASSERT = (1UL << 3),
+};
+
+
+/*!
+ * \brief Reset domain capabilities.
+ */
+enum mod_reset_domain_capabilities {
+    /*!
+     * \brief Indicates whether notifications are supported by a reset domain.
+     */
+    MOD_RESET_DOMAIN_CAP_NOTIFICATION = (1UL << 0),
+
+    /*!
+     * \brief Indicates whether async reset is supported by a reset domain.
+     */
+    MOD_RESET_DOMAIN_CAP_ASYNC =  (1UL << 1)
+};
+
+/*!
+ * \brief Reset domain module configuration data.
+ *
+ */
+struct mod_reset_domain_config {
+    /*!
+     * \brief Identifier of the reset domain notification for auto reset status.
+     *
+     * \details Modules that are interested in the status of an auto reset of a
+     *     reset domain will use below notification identifier to subscribe to
+     *     the notification. For example, SCMI agents may request notification
+     *     for the status of an auto reset operation on a reset domain.
+     */
+    fwk_id_t notification_id;
+};
+
+/*!
+ * \brief Reset domain element configuration data.
+ */
+struct mod_reset_domain_dev_config {
+    /*! Driver identifier */
+    fwk_id_t driver_id;
+
+    /*! Driver API identifier */
+    fwk_id_t driver_api_id;
+
+     /*! Supported modes, see mod_reset_domain_mode */
+    enum mod_reset_domain_mode modes;
+
+    /*! Supported capabilities, see mod_reset_domain_capabilities */
+    enum mod_reset_domain_capabilities capabilities;
+
+    /*! Maximum time (in microseconds) required for the reset to take effect */
+    unsigned int latency;
+};
+
+/*!
+ * \brief Reset domain HAL interface.
+ *
+ * \details The interface the reset domain clients relies on to perform
+ *      actions on a reset domain.
+ */
+struct mod_reset_domain_api {
+    /*!
+     * \brief Change reset state of the domain \p element_id
+     *
+     * \param element_id Reset element identifier.
+     * \param mode Reset domain mode.
+     * \param reset_state Reset domain state as defined in SCMIv2 specification.
+     * \param cookie Context-specific value.
+     * \retval FWK_SUCCESS or one of FWK_E_* error codes.
+     */
+    int (*set_reset_state)(fwk_id_t element_id,
+                           enum mod_reset_domain_mode mode,
+                           uint32_t reset_state,
+                           uintptr_t cookie);
+};
+
+/*!
+ * \brief Reset domain driver interface.
+ *
+ * \details The interface this reset domain module relies on to perform
+ *      actions on a reset domain.
+ */
+struct mod_reset_domain_drv_api {
+    /*!
+     * \brief Change reset state of the device \p dev_id
+     *
+     * \param dev_id Reset domain driver identifier.
+     * \param mode Reset domain mode.
+     * \param reset_state Reset domain state as defined in SCMIv2 specification.
+     *
+     * \param cookie Context-specific value.
+     * \retval FWK_SUCCESS or one of FWK_E_* error codes.
+     */
+    int (*set_reset_state)(fwk_id_t dev_id,
+                           enum mod_reset_domain_mode mode,
+                           uint32_t reset_state,
+                           uintptr_t cookie);
+};
+
+/*!
+ * \brief Reset domain notification indexes.
+ */
+enum mod_reset_domain_notification_idx {
+    /*!
+     * \brief Auto reset state change notification index.
+     */
+    MOD_RESET_DOMAIN_NOTIFICATION_AUTORESET,
+
+    /*!
+     * \brief Number of notifications available.
+     */
+    MOD_RESET_DOMAIN_NOTIFICATION_IDX_COUNT
+};
+
+
+/*!
+ * \brief Reset domain auto reset notification event parameters.
+ */
+struct mod_reset_domain_notification_event_params {
+    /*!
+     * \brief Domain identifier associated with the notification.
+     */
+    uint32_t domain_id;
+
+    /*!
+     * \brief Reset state as defined in SCMIv2 specification.
+     */
+    uint32_t reset_state;
+
+    /*!
+     * \brief Context-specific value(e.g. agent_id) which is returned after
+     *     processing a set reset state request. The context-specific value
+     *     is the same value which is passed in a set_reset_state call.
+     */
+    uintptr_t cookie;
+};
+
+/*!
+ * \brief Reset domain auto reset event parameters.
+ */
+struct mod_reset_domain_autoreset_event_params {
+    /*!
+     * \brief Reset device identifier.
+     */
+    fwk_id_t dev_id;
+
+    /*!
+     * \brief Reset state as defined in SCMIv2 specification.
+     */
+    uint32_t reset_state;
+
+    /*!
+     * \brief Context-specific value(e.g. agent_id) which is returned after
+     *     processing a set reset state request. The context-specific value
+     *     is the same value which is passed in a set_reset_state call.
+     */
+    uintptr_t cookie;
+};
+
+/*!
+ * \brief Reset domain event indexes.
+ */
+enum mod_reset_domain_event_idx {
+    /*!
+     * \brief Auto reset state change event index.
+     */
+    MOD_RESET_DOMAIN_EVENT_AUTORESET,
+
+    /*!
+     * \brief Total number of events available.
+     */
+    MOD_RESET_DOMAIN_EVENT_IDX_COUNT
+};
+
+/*!
+ * Identifier auto reset event.
+ *
+ * \note The driver will send this event to this module
+ *     after completing the auto reset.
+ */
+static const fwk_id_t mod_reset_domain_autoreset_event_id =
+    FWK_ID_EVENT_INIT(FWK_MODULE_IDX_RESET_DOMAIN,
+                      MOD_RESET_DOMAIN_EVENT_AUTORESET);
+
+/*!
+ * \}
+ */
+
+/*!
+ * \}
+ */
+
+#endif /* MOD_RESET_DOMAIN_H */

--- a/module/reset_domain/src/Makefile
+++ b/module/reset_domain/src/Makefile
@@ -1,0 +1,11 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BS_LIB_NAME := Reset Domain
+BS_LIB_SOURCES := mod_reset_domain.c
+
+include $(BS_DIR)/lib.mk

--- a/module/reset_domain/src/mod_reset_domain.c
+++ b/module/reset_domain/src/mod_reset_domain.c
@@ -1,0 +1,187 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     Reset domain HAL
+ */
+
+#include <fwk_mm.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+#include <fwk_notification.h>
+#include <mod_reset_domain.h>
+
+/*
+ * Module and devices contexts for Reset Domain
+ */
+
+/* Device context */
+struct rd_dev_ctx {
+    const struct mod_reset_domain_dev_config *config;
+    struct mod_reset_domain_drv_api *driver_api;
+};
+
+/* Module context */
+struct mod_rd_ctx {
+    const struct mod_reset_domain_config *config;
+    struct rd_dev_ctx *dev_ctx_table;
+    unsigned int dev_count;
+};
+
+/*
+ * Internal variables
+ */
+static struct mod_rd_ctx module_reset_ctx;
+
+/*
+ * API functions
+ */
+static int set_reset_state(fwk_id_t reset_dev_id,
+                           enum mod_reset_domain_mode mode,
+                           uint32_t reset_state,
+                           uintptr_t cookie)
+{
+    struct rd_dev_ctx *reset_ctx;
+    unsigned int reset_domain_idx = fwk_id_get_element_idx(reset_dev_id);
+
+    reset_ctx = &module_reset_ctx.dev_ctx_table[reset_domain_idx];
+
+    return reset_ctx->driver_api->set_reset_state(reset_ctx->config->driver_id,
+                                                  mode, reset_state, cookie);
+}
+
+/* HAL API */
+static const struct mod_reset_domain_drv_api reset_api = {
+    .set_reset_state = set_reset_state,
+};
+
+static int reset_issued_notify(fwk_id_t dev_id,
+                               uint32_t reset_state,
+                               uintptr_t cookie)
+{
+    int domain_id = -1;
+    unsigned int i;
+    struct rd_dev_ctx *reset_ctx;
+    unsigned int notification_count;
+    struct fwk_event notification_event = {
+        .id = module_reset_ctx.config->notification_id,
+        .source_id = fwk_module_id_reset_domain,
+    };
+
+    struct mod_reset_domain_notification_event_params* params =
+        (struct mod_reset_domain_notification_event_params*)
+        notification_event.params;
+
+    /* Loop through device context table to get the associated domain_id */
+    for (i = 0; i < module_reset_ctx.dev_count; i++) {
+        reset_ctx = &module_reset_ctx.dev_ctx_table[i];
+        if (fwk_id_is_equal(reset_ctx->config->driver_id, dev_id)) {
+            domain_id = i;
+            break;
+        }
+    }
+
+    if (domain_id < 0)
+        return FWK_E_PARAM;
+
+    params->domain_id = domain_id;
+    params->reset_state = reset_state;
+    params->cookie = cookie;
+
+    return fwk_notification_notify(&notification_event, &notification_count);
+}
+
+static int rd_process_event(
+    const struct fwk_event *event,
+    struct fwk_event *resp)
+{
+    struct mod_reset_domain_autoreset_event_params* params =
+        (struct mod_reset_domain_autoreset_event_params*)event->params;
+
+    if (!fwk_id_is_equal(mod_reset_domain_autoreset_event_id,
+                         event->id))
+        return FWK_E_SUPPORT;
+
+    return reset_issued_notify(params->dev_id,
+                               params->reset_state, params->cookie);
+}
+
+/*
+ * Framework handlers
+ */
+static int rd_init(fwk_id_t module_id,
+                   unsigned int dev_count,
+                   const void *data)
+{
+    module_reset_ctx.config = (struct mod_reset_domain_config *)data;
+    module_reset_ctx.dev_ctx_table = fwk_mm_calloc(dev_count,
+                                             sizeof(struct rd_dev_ctx));
+    module_reset_ctx.dev_count = dev_count;
+
+    return FWK_SUCCESS;
+}
+
+static int rd_element_init(fwk_id_t element_id,
+                           unsigned int sub_dev_count,
+                           const void *data)
+{
+    struct rd_dev_ctx *reset_ctx = NULL;
+
+    reset_ctx = &module_reset_ctx.dev_ctx_table[
+        fwk_id_get_element_idx(element_id)];
+
+    reset_ctx->config = (const struct mod_reset_domain_dev_config *)data;
+
+    return FWK_SUCCESS;
+}
+
+static int rd_bind(fwk_id_t id, unsigned int round)
+{
+    struct rd_dev_ctx *reset_ctx = NULL;
+
+    /* Nothing to do during subsequent round of calls */
+    if (round != 0)
+        return FWK_SUCCESS;
+
+    if (!fwk_id_is_type(id, FWK_ID_TYPE_ELEMENT))
+        return FWK_SUCCESS;
+
+    reset_ctx = module_reset_ctx.dev_ctx_table + fwk_id_get_element_idx(id);
+
+    return fwk_module_bind(reset_ctx->config->driver_id,
+                           reset_ctx->config->driver_api_id,
+                           &reset_ctx->driver_api);
+}
+
+static int rd_process_bind_request(fwk_id_t source_id,
+                                   fwk_id_t target_id,
+                                   fwk_id_t api_id,
+                                   const void **api)
+{
+    switch (fwk_id_get_api_idx(api_id)) {
+    case MOD_RESET_DOMAIN_API_TYPE_HAL:
+        *api = &reset_api;
+        break;
+
+    default:
+        return FWK_E_ACCESS;
+    }
+
+    return FWK_SUCCESS;
+}
+
+const struct fwk_module module_reset_domain = {
+    .name = "Reset domain",
+    .type = FWK_MODULE_TYPE_HAL,
+    .api_count = MOD_RESET_DOMAIN_API_COUNT,
+    .notification_count = MOD_RESET_DOMAIN_NOTIFICATION_IDX_COUNT,
+    .event_count = MOD_RESET_DOMAIN_EVENT_IDX_COUNT,
+    .init = rd_init,
+    .element_init = rd_element_init,
+    .bind = rd_bind,
+    .process_bind_request = rd_process_bind_request,
+    .process_event = rd_process_event,
+};

--- a/module/scmi/include/mod_scmi_std.h
+++ b/module/scmi/include/mod_scmi_std.h
@@ -172,6 +172,28 @@ enum scmi_sensor_command_id {
 };
 
 /*!
+ * \brief SCMI Reset Domain Protocol
+ */
+#define MOD_SCMI_PROTOCOL_ID_RESET_DOMAIN UINT32_C(0x16)
+
+/*!
+ * \brief SCMI Reset Domain Management Protocol Message IDs
+ */
+enum scmi_reset_domain_command_id {
+    MOD_SCMI_RESET_DOMAIN_ATTRIBUTES = 0x03,
+    MOD_SCMI_RESET_REQUEST = 0x04,
+    MOD_SCMI_RESET_NOTIFY = 0x05,
+};
+
+/*!
+ * \brief SCMI Reset Domain Management Protocol Response IDs.
+ */
+enum scmi_reset_domain_response_id {
+    MOD_SCMI_RESET_ISSUED = 0x00,
+    MOD_SCMI_RESET_COMPLETE = 0x04,
+};
+
+/*!
  * @}
  */
 

--- a/module/scmi_reset_domain/include/internal/scmi_reset_domain.h
+++ b/module/scmi_reset_domain/include/internal/scmi_reset_domain.h
@@ -1,0 +1,122 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *      System Control and Management Interface (SCMI) support for Reset Domain
+ *      Management Protocol.
+ */
+
+#ifndef INTERNAL_SCMI_RESET_DOMAIN_H
+#define INTERNAL_SCMI_RESET_DOMAIN_H
+
+/*!
+ * \addtogroup GroupModules Modules
+ * \{
+ */
+
+/*!
+ * \defgroup GroupSCMI_RESET SCMI Reset Domain Management Protocol.
+ * \{
+ */
+
+#define SCMI_PROTOCOL_VERSION_RESET_DOMAIN  UINT32_C(0x20000)
+
+#define SCMI_RESET_STATE_ARCH               (0 << 31)
+#define SCMI_RESET_STATE_IMPL               (1 << 31)
+
+/*
+ * PROTOCOL_ATTRIBUTES
+ */
+
+struct __attribute((packed)) scmi_reset_domain_protocol_attributes_p2a {
+    int32_t status;
+    uint32_t attributes;
+};
+
+/* Value for scmi_reset_domain_attributes_p2a:flags */
+#define SCMI_RESET_DOMAIN_ATTR_ASYNC    (1UL << 31)
+#define SCMI_RESET_DOMAIN_ATTR_NOTIF    (1UL << 30)
+
+/* Value for scmi_reset_domain_attributes_p2a:latency */
+#define SCMI_RESET_DOMAIN_ATTR_LATENCY_UNSUPPORTED  0xFFFFFFFF
+
+/* Macro for scmi_reset_domain_attributes_p2a:name */
+#define SCMI_RESET_DOMAIN_ATTR_NAME_SZ  16
+
+struct __attribute((packed)) scmi_reset_domain_attributes_a2p {
+    uint32_t domain_id;
+};
+
+struct __attribute((packed)) scmi_reset_domain_attributes_p2a {
+    int32_t status;
+    uint32_t flags;
+    uint32_t latency;
+    uint8_t name[SCMI_RESET_DOMAIN_ATTR_NAME_SZ];
+};
+
+/*
+ * RESET
+ */
+
+/* Values for scmi_reset_domain_request_p2a:flags */
+#define SCMI_RESET_DOMAIN_ASYNC      (1 << 2)
+#define SCMI_RESET_DOMAIN_EXPLICIT   (1 << 1)
+#define SCMI_RESET_DOMAIN_AUTO       (1 << 0)
+
+struct __attribute((packed)) scmi_reset_domain_request_a2p {
+    uint32_t domain_id;
+    uint32_t flags;
+    uint32_t reset_state;
+};
+
+struct __attribute((packed)) scmi_reset_domain_request_p2a {
+    int32_t status;
+};
+
+/*
+ * RESET_NOTIFY
+ */
+
+/* Values for scmi_reset_notify_p2a:flags */
+#define SCMI_RESET_DOMAIN_DO_NOTIFY  (1 << 0)
+
+struct __attribute((packed)) scmi_reset_domain_notify_a2p {
+    uint32_t domain_id;
+    uint32_t notify_enable;
+};
+
+struct __attribute((packed)) scmi_reset_domain_notify_p2a {
+    int32_t status;
+};
+
+/*
+ * RESET_COMPLETE
+ */
+
+struct __attribute((packed)) scmi_reset_domain_complete_p2a {
+    int32_t status;
+    uint32_t domain_id;
+};
+
+/*
+ * RESET_ISSUED
+ */
+
+struct __attribute((packed)) scmi_reset_domain_issued_p2a {
+    uint32_t agent_id;
+    uint32_t domain_id;
+    uint32_t reset_state;
+};
+
+/*!
+ * \}
+ */
+
+/*!
+ * \}
+ */
+
+#endif /* INTERNAL_SCMI_RESET_DOMAIN_H */

--- a/module/scmi_reset_domain/include/mod_scmi_reset_domain.h
+++ b/module/scmi_reset_domain/include/mod_scmi_reset_domain.h
@@ -1,0 +1,118 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *      SCMI Reset Domain Protocol Support.
+ */
+
+#ifndef MOD_SCMI_RESET_DOMAIN_H
+#define MOD_SCMI_RESET_DOMAIN_H
+
+#include <fwk_id.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/*!
+ * \ingroup GroupModules Modules
+ * \defgroup GroupSCMI_RESET SCMI Reset Domain Management Protocol
+ * \{
+ */
+
+/*!
+ * \brief Permission flags governing the ability to use certain SCMI commands
+ *     to interact with a reset domain.
+ *
+ * \details Setting a permission flag for a reset domain enables the
+ *      corresponding functionality for any agent that has visibilty of the
+ *      reset domain through it's reset domain device table.
+ */
+enum mod_scmi_reset_domain_permissions {
+    /*! No permissions (at least one must be granted) */
+    MOD_SCMI_RESET_DOMAIN_PERM_INVALID = 0,
+
+    /*! The reset domain's attributes can be queried */
+    MOD_SCMI_RESET_DOMAIN_PERM_ATTRIBUTES = (1 << 0),
+
+    /*! The permission to reset the domain */
+    MOD_SCMI_RESET_DOMAIN_PERM_RESET = (1 << 1),
+};
+
+/*!
+ * \brief Reset domain device.
+ *
+ * \details Reset domain device structures are used in per-agent reset device
+ *      tables. Each contains an identifier of an element that will be bound
+ *      to in order to use the reset device.
+ */
+struct mod_scmi_reset_domain_device {
+    /*!
+     * \brief Reset element identifier.
+     *
+     * \details The module that owns the element must implement the Reset API
+     *      that is defined by the \c reset module.
+     */
+    fwk_id_t element_id;
+
+    /*! Mask of permission flags defined by reset domain configuration */
+   uint8_t permissions;
+
+};
+
+/*!
+ * \brief Agent descriptor.
+ *
+ * \details Describes an agent that uses the SCMI Reset Domain protocol.
+ *      Provides a pointer to the agent's reset device table and the number of
+ *      devices within the table.
+ */
+struct mod_scmi_reset_domain_agent {
+    /*! Pointer to a table of reset devices that are visible to the agent */
+    const struct mod_scmi_reset_domain_device *device_table;
+
+    /*!
+     * \brief The number of \c mod_scmi_reset_domain_device structures in the
+     *      table pointed to by \c device_table.
+     */
+    uint8_t agent_domain_count;
+};
+
+/*!
+ * \brief Module configuration.
+ */
+struct mod_scmi_reset_domain_config {
+    /*!
+     * \brief Pointer to the table of agent descriptors, used to provide
+     *      per-agent views of reset in the system.
+     */
+    const struct mod_scmi_reset_domain_agent *agent_table;
+
+    /*! Number of agents in \ref agent_table */
+    unsigned int agent_count;
+
+};
+
+/*!
+ * \brief SCMI Reset Domain APIs.
+ *
+ * \details APIs exported by SCMI Reset Domain Protocol.
+ */
+enum scmi_reset_domain_api_idx {
+    /*! Index for the SCMI protocol API */
+    MOD_SCMI_RESET_DOMAIN_PROTOCOL_API,
+
+    /*! Number of APIs */
+    MOD_SCMI_RESET_DOMAIN_API_COUNT
+};
+
+/*!
+ * \}
+ */
+
+/*!
+ * \}
+ */
+
+#endif /* MOD_SCMI_RESET_DOMAIN_H */

--- a/module/scmi_reset_domain/src/Makefile
+++ b/module/scmi_reset_domain/src/Makefile
@@ -1,0 +1,11 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BS_LIB_NAME := SCMI Reset Domain Protocol
+BS_LIB_SOURCES := mod_scmi_reset_domain.c
+
+include $(BS_DIR)/lib.mk

--- a/module/scmi_reset_domain/src/mod_scmi_reset_domain.c
+++ b/module/scmi_reset_domain/src/mod_scmi_reset_domain.c
@@ -1,0 +1,624 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     SCMI Reset Domain management protocol support.
+ */
+
+#include <fwk_assert.h>
+#include <fwk_macros.h>
+#include <fwk_mm.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+#include <fwk_notification.h>
+#include <fwk_status.h>
+#include <internal/scmi_reset_domain.h>
+#include <mod_reset_domain.h>
+#include <mod_scmi.h>
+#include <mod_scmi_reset_domain.h>
+#include <string.h>
+
+#ifdef BUILD_HAS_SCMI_NOTIFICATIONS
+struct agent_notifications {
+    /*
+     * Track whether an agent is requesting notification on reset operation.
+     */
+    fwk_id_t *reset_notification;
+};
+#endif
+
+struct scmi_rd_ctx {
+    /*! SCMI Reset Module Configuration */
+    const struct mod_scmi_reset_domain_config *config;
+
+    /* Bound module APIs */
+    const struct mod_scmi_from_protocol_api *scmi_api;
+    const struct mod_reset_domain_api *reset_api;
+
+    /*! Number of reset domains available on platform */
+    uint8_t plat_reset_domain_count;
+
+#ifdef BUILD_HAS_SCMI_NOTIFICATIONS
+    /* Agent notifications table */
+    struct agent_notifications **agent_notifications;
+    fwk_id_t notification_id;
+#endif
+};
+
+static int protocol_version_handler(fwk_id_t service_id,
+                                    const uint32_t *payload);
+
+static int protocol_attributes_handler(fwk_id_t service_id,
+                                       const uint32_t *payload);
+static int protocol_message_attributes_handler(fwk_id_t service_id,
+                                               const uint32_t *payload);
+static int reset_attributes_handler(fwk_id_t service_id,
+                                    const uint32_t *payload);
+static int reset_request_handler(fwk_id_t service_id,
+                                 const uint32_t *payload);
+#ifdef BUILD_HAS_SCMI_NOTIFICATIONS
+static int reset_notify_handler(fwk_id_t service_id,
+                                const uint32_t *payload);
+#endif
+
+/*
+ * Internal variables
+ */
+
+static struct scmi_rd_ctx scmi_rd_ctx;
+
+static int (*msg_handler_table[])(fwk_id_t, const uint32_t *) = {
+    [MOD_SCMI_PROTOCOL_VERSION] = protocol_version_handler,
+    [MOD_SCMI_PROTOCOL_ATTRIBUTES] = protocol_attributes_handler,
+    [MOD_SCMI_PROTOCOL_MESSAGE_ATTRIBUTES] =
+         protocol_message_attributes_handler,
+    [MOD_SCMI_RESET_DOMAIN_ATTRIBUTES] = reset_attributes_handler,
+    [MOD_SCMI_RESET_REQUEST] = reset_request_handler,
+#ifdef BUILD_HAS_SCMI_NOTIFICATIONS
+    [MOD_SCMI_RESET_NOTIFY] = reset_notify_handler,
+#endif
+};
+
+static unsigned int payload_size_table[] = {
+    [MOD_SCMI_PROTOCOL_VERSION] = 0,
+    [MOD_SCMI_PROTOCOL_ATTRIBUTES] = 0,
+    [MOD_SCMI_PROTOCOL_MESSAGE_ATTRIBUTES] =
+         sizeof(struct scmi_protocol_message_attributes_a2p),
+    [MOD_SCMI_RESET_DOMAIN_ATTRIBUTES] =
+         sizeof(struct scmi_reset_domain_attributes_a2p),
+    [MOD_SCMI_RESET_REQUEST] = sizeof(struct scmi_reset_domain_request_a2p),
+#ifdef BUILD_HAS_SCMI_NOTIFICATIONS
+    [MOD_SCMI_RESET_NOTIFY] = sizeof(struct scmi_reset_domain_notify_a2p),
+#endif
+};
+
+/*
+ * Reset domain management protocol implementation
+ */
+
+static int protocol_version_handler(fwk_id_t service_id,
+                                    const uint32_t *payload)
+{
+    struct scmi_protocol_version_p2a outmsg = {
+        .status = SCMI_SUCCESS,
+        .version = SCMI_PROTOCOL_VERSION_RESET_DOMAIN,
+    };
+
+    scmi_rd_ctx.scmi_api->respond(service_id, &outmsg, sizeof(outmsg));
+
+    return FWK_SUCCESS;
+}
+
+static int protocol_attributes_handler(fwk_id_t service_id,
+                                       const uint32_t *payload)
+{
+    struct scmi_reset_domain_protocol_attributes_p2a outmsg = {
+        .status = SCMI_SUCCESS,
+    };
+    int status = 0;
+    unsigned int agent_id = 0;
+
+    status = scmi_rd_ctx.scmi_api->get_agent_id(service_id, &agent_id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    if (agent_id >= scmi_rd_ctx.config->agent_count)
+        return FWK_E_PARAM;
+
+    outmsg.attributes = scmi_rd_ctx.config->
+                            agent_table[agent_id].agent_domain_count;
+
+    scmi_rd_ctx.scmi_api->respond(service_id, &outmsg, sizeof(outmsg));
+
+    return FWK_SUCCESS;
+}
+
+static int protocol_message_attributes_handler(fwk_id_t service_id,
+                                               const uint32_t *payload)
+{
+    struct scmi_protocol_message_attributes_p2a outmsg = {
+        .status = SCMI_NOT_FOUND,
+    };
+    size_t outmsg_size = sizeof(outmsg.status);
+    struct scmi_protocol_message_attributes_a2p params = { 0 };
+
+    params = *(const struct scmi_protocol_message_attributes_a2p *)payload;
+
+    if ((params.message_id < FWK_ARRAY_SIZE(msg_handler_table)) &&
+        msg_handler_table[params.message_id]) {
+        outmsg.status = SCMI_SUCCESS;
+        outmsg_size = sizeof(outmsg);
+    }
+
+    scmi_rd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
+
+    return FWK_SUCCESS;
+}
+
+/*
+ * Given a service identifier, retrieve a agent identifier
+ */
+static int get_agent_id(fwk_id_t service_id, unsigned int* agent_id)
+{
+    int status;
+
+    status = scmi_rd_ctx.scmi_api->get_agent_id(service_id, agent_id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    if (*agent_id >= scmi_rd_ctx.config->agent_count)
+        return FWK_E_PARAM;
+
+    return FWK_SUCCESS;
+}
+
+/*
+ * Given a service identifier, retrieve a pointer to its agent's
+ * \c mod_scmi_reset_domain_agent structure within the agent table.
+ */
+static int get_agent_entry(fwk_id_t service_id,
+                           const struct mod_scmi_reset_domain_agent **agent)
+{
+    int status = 0;
+    unsigned int agent_id = 0;
+
+    status = get_agent_id(service_id, &agent_id);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    *agent = &scmi_rd_ctx.config->agent_table[agent_id];
+
+    return FWK_SUCCESS;
+}
+
+static int get_reset_device(fwk_id_t service_id,
+                            unsigned int domain_id,
+                            const struct mod_scmi_reset_domain_device **device)
+{
+    int status;
+    const struct mod_scmi_reset_domain_agent *agent_entry = NULL;
+
+    status = get_agent_entry(service_id, &agent_entry);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    if (domain_id >= agent_entry->agent_domain_count)
+        return FWK_E_RANGE;
+
+    *device = &agent_entry->device_table[domain_id];
+
+    fwk_assert(fwk_module_is_valid_element_id((*device)->element_id));
+
+    if (!fwk_module_is_valid_element_id((*device)->element_id))
+        return FWK_E_PANIC;
+
+    return FWK_SUCCESS;
+}
+
+static int reset_attributes_handler(fwk_id_t service_id,
+                                    const uint32_t *payload)
+{
+    const struct mod_scmi_reset_domain_device *reset_device = NULL;
+    struct mod_reset_domain_dev_config *reset_dev_config = NULL;
+    struct scmi_reset_domain_attributes_a2p params = { 0 };
+    struct scmi_reset_domain_attributes_p2a outmsg = {
+        .status = SCMI_GENERIC_ERROR,
+    };
+    size_t outmsg_size = sizeof(outmsg.status);
+    int status = FWK_SUCCESS;
+
+    params = *(const struct scmi_reset_domain_attributes_a2p *)payload;
+
+    status = get_reset_device(service_id, params.domain_id, &reset_device);
+    if (status != FWK_SUCCESS) {
+        outmsg.status = SCMI_NOT_FOUND;
+        goto exit;
+    }
+
+    reset_dev_config = (struct mod_reset_domain_dev_config *)
+                           fwk_module_get_data(reset_device->element_id);
+    /*
+     * Currently: no support for async reset.
+     */
+    outmsg.flags &= ~SCMI_RESET_DOMAIN_ATTR_ASYNC;
+
+    if (reset_dev_config->capabilities & MOD_RESET_DOMAIN_CAP_NOTIFICATION)
+        outmsg.flags |= SCMI_RESET_DOMAIN_ATTR_NOTIF;
+
+    outmsg.latency = reset_dev_config->latency;
+
+    strncpy((char *)outmsg.name, fwk_module_get_name(reset_device->element_id),
+            sizeof(outmsg.name) - 1);
+
+    outmsg.status = SCMI_SUCCESS;
+    outmsg_size = sizeof(outmsg);
+
+exit:
+    scmi_rd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
+
+    return status;
+}
+
+static int reset_request_handler(fwk_id_t service_id,
+                                 const uint32_t *payload)
+{
+    int status;
+    unsigned int agent_id;
+    struct mod_reset_domain_dev_config *reset_dev_config;
+    struct scmi_reset_domain_request_a2p params = { 0 };
+    struct scmi_reset_domain_request_p2a outmsg = {
+        .status = SCMI_NOT_FOUND
+    };
+    enum mod_reset_domain_mode mode = MOD_RESET_DOMAIN_MODE_EXPLICIT_DEASSERT;
+
+    size_t outmsg_size = sizeof(outmsg.status);
+    const struct mod_reset_domain_api *reset_api = scmi_rd_ctx.reset_api;
+    const struct mod_scmi_reset_domain_device *reset_device = NULL;
+
+    params = *(const struct scmi_reset_domain_request_a2p *)payload;
+
+    status = scmi_rd_ctx.scmi_api->get_agent_id(service_id, &agent_id);
+    if (status != FWK_SUCCESS)
+        goto exit;
+
+    if (params.domain_id >= scmi_rd_ctx.plat_reset_domain_count) {
+        status = FWK_E_PARAM;
+        goto exit;
+    }
+
+    status = get_reset_device(service_id, params.domain_id, &reset_device);
+    if (status != FWK_SUCCESS)
+        goto exit;
+
+    reset_dev_config = (struct mod_reset_domain_dev_config *)
+                       fwk_module_get_data(reset_device->element_id);
+
+    /* Check if explicit assert is requested.
+     * Note, valid request in flags
+     *       b000 Explicit de-assert request.
+     *       b001 Auto Reset request.
+     *       b010 Explicit reset request.
+     *       b101 Auto Reset Async.
+     */
+    if (!(params.flags & SCMI_RESET_DOMAIN_AUTO)) {
+        /* If auto reset is not requested then check if device supports explicit
+         * assert/de-assert reset.
+         */
+        if (!(reset_dev_config->modes &
+            (MOD_RESET_DOMAIN_MODE_EXPLICIT_ASSERT |
+            MOD_RESET_DOMAIN_MODE_EXPLICIT_DEASSERT))) {
+
+            outmsg.status = SCMI_NOT_SUPPORTED;
+            goto exit;
+        } else {
+           if (params.flags & SCMI_RESET_DOMAIN_EXPLICIT)
+               mode = MOD_RESET_DOMAIN_MODE_EXPLICIT_ASSERT;
+        }
+    } else {
+        mode = SCMI_RESET_DOMAIN_AUTO;
+    }
+
+    /* Handle async reset request. */
+    if (params.flags & SCMI_RESET_DOMAIN_ASYNC) {
+        /* Async reset request is valid only in auto reset mode
+         */
+        if (!(params.flags & SCMI_RESET_DOMAIN_AUTO)) {
+            outmsg.status = SCMI_INVALID_PARAMETERS;
+            goto exit;
+        }
+
+        /* Return not supported as associated device does not support
+         * Async reset.
+         */
+        if (!(reset_dev_config->modes &
+            MOD_RESET_DOMAIN_MODE_AUTO_RESET_ASYNC)) {
+
+            outmsg.status = SCMI_NOT_SUPPORTED;
+            goto exit;
+        } else {
+            mode |= MOD_RESET_DOMAIN_MODE_AUTO_RESET_ASYNC;
+        }
+    }
+
+    outmsg.status = SCMI_NOT_SUPPORTED;
+    status = reset_api->set_reset_state(reset_device->element_id,
+                                        mode,
+                                        params.reset_state,
+                                        (uintptr_t)agent_id);
+    if (status != FWK_SUCCESS) {
+        if (status == FWK_E_STATE)
+            outmsg.status = SCMI_HARDWARE_ERROR;
+        goto exit;
+    }
+
+    outmsg.status = SCMI_SUCCESS;
+    outmsg_size = sizeof(outmsg);
+
+exit:
+    scmi_rd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
+
+    return status;
+}
+
+#ifdef BUILD_HAS_SCMI_NOTIFICATIONS
+static int reset_notify_handler(fwk_id_t service_id,
+                                const uint32_t *payload)
+{
+    unsigned int agent_id;
+    int status;
+    unsigned int domain_id;
+    const struct scmi_reset_domain_notify_a2p *parameters;
+    struct scmi_reset_domain_notify_p2a outmsg = {
+        .status = SCMI_GENERIC_ERROR,
+    };
+
+    status = get_agent_id(service_id, &agent_id);
+    if (status != FWK_SUCCESS)
+        goto exit;
+
+    parameters = (const struct scmi_reset_domain_notify_a2p *)payload;
+
+    domain_id = parameters->domain_id;
+    if (domain_id >= scmi_rd_ctx.config->
+        agent_table[agent_id].agent_domain_count) {
+        status = FWK_SUCCESS;
+        outmsg.status = SCMI_NOT_FOUND;
+        goto exit;
+    }
+
+    if (parameters->notify_enable)
+        scmi_rd_ctx.agent_notifications[domain_id]->
+            reset_notification[agent_id] = service_id;
+    else
+        scmi_rd_ctx.agent_notifications[domain_id]->
+            reset_notification[agent_id] = FWK_ID_NONE;
+
+    outmsg.status = SCMI_SUCCESS;
+
+exit:
+    scmi_rd_ctx.scmi_api->respond(service_id, &outmsg,
+                                  (outmsg.status == SCMI_SUCCESS) ?
+                                  sizeof(outmsg) :
+                                  sizeof(outmsg.status));
+
+    return status;
+}
+
+static void scmi_reset_issued_notify(uint32_t domain_id,
+                                     uint32_t reset_state,
+                                     uintptr_t cookie)
+{
+    struct scmi_reset_domain_issued_p2a reset_issued = {
+         .agent_id = (uint32_t)cookie
+    };
+    fwk_id_t service_id;
+    unsigned int i;
+
+    /* note: skip agent 0, platform agent */
+    for (i = 1; i < scmi_rd_ctx.config->agent_count; i++) {
+        service_id =
+            scmi_rd_ctx.agent_notifications[domain_id]->reset_notification[i];
+
+        if (!fwk_id_is_equal(service_id, FWK_ID_NONE)) {
+            reset_issued.domain_id = domain_id;
+            reset_issued.reset_state = reset_state;
+
+            scmi_rd_ctx.scmi_api->notify(service_id,
+                                         MOD_SCMI_PROTOCOL_ID_RESET_DOMAIN,
+                                         MOD_SCMI_RESET_ISSUED,
+                                         &reset_issued, sizeof(reset_issued));
+        }
+    }
+}
+#endif
+/*
+ * SCMI module -> SCMI reset module interface
+ */
+static int scmi_reset_get_scmi_protocol_id(fwk_id_t protocol_id,
+                                           uint8_t *scmi_protocol_id)
+{
+    *scmi_protocol_id = MOD_SCMI_PROTOCOL_ID_RESET_DOMAIN;
+
+    return FWK_SUCCESS;
+}
+
+static int scmi_reset_message_handler(fwk_id_t protocol_id,
+                                      fwk_id_t service_id,
+                                      const uint32_t *payload,
+                                      size_t payload_size,
+                                      unsigned int message_id)
+{
+    int32_t return_value;
+
+    static_assert(FWK_ARRAY_SIZE(msg_handler_table) ==
+                  FWK_ARRAY_SIZE(payload_size_table),
+                  "[SCMI] reset domain protocol table sizes not consistent");
+
+    fwk_assert(payload != NULL);
+
+    if (message_id >= FWK_ARRAY_SIZE(msg_handler_table)) {
+        return_value = SCMI_NOT_SUPPORTED;
+        goto error;
+    }
+
+    if (payload_size != payload_size_table[message_id]) {
+        return_value = SCMI_PROTOCOL_ERROR;
+        goto error;
+    }
+
+    return msg_handler_table[message_id](service_id, payload);
+
+error:
+    scmi_rd_ctx.scmi_api->respond(service_id,
+                                  &return_value, sizeof(return_value));
+    return FWK_SUCCESS;
+}
+
+static struct mod_scmi_to_protocol_api scmi_reset_mod_scmi_to_protocol_api = {
+    .get_scmi_protocol_id = scmi_reset_get_scmi_protocol_id,
+    .message_handler = scmi_reset_message_handler
+};
+
+/*
+ * Framework handlers
+ */
+
+static int scmi_reset_init(fwk_id_t module_id,
+                           unsigned int element_count,
+                           const void *data)
+{
+    const struct mod_scmi_reset_domain_config *config;
+
+    config = (const struct mod_scmi_reset_domain_config *)data;
+
+    if ((config == NULL) || (config->agent_table == NULL))
+        return FWK_E_PARAM;
+
+    scmi_rd_ctx.config = config;
+
+    return FWK_SUCCESS;
+}
+
+#ifdef BUILD_HAS_SCMI_NOTIFICATIONS
+static int scmi_reset_init_notifications(unsigned int scmi_reset_domains)
+{
+    unsigned int i, j;
+
+    fwk_assert(scmi_rd_ctx.config->agent_count != 0);
+
+    scmi_rd_ctx.agent_notifications = fwk_mm_calloc(
+        scmi_reset_domains, sizeof(struct agent_notifications *));
+
+    for (i = 0; i < scmi_reset_domains; i++) {
+        scmi_rd_ctx.agent_notifications[i] =
+            fwk_mm_calloc(1, sizeof(struct agent_notifications));
+        scmi_rd_ctx.agent_notifications[i]->reset_notification =
+            fwk_mm_calloc(scmi_rd_ctx.config->agent_count, sizeof(fwk_id_t));
+    }
+
+    for (i = 0; i < scmi_reset_domains; i++) {
+        for (j = 0; j < scmi_rd_ctx.config->agent_count; j++) {
+            scmi_rd_ctx.agent_notifications[i]->reset_notification[j] =
+                FWK_ID_NONE;
+        }
+    }
+
+    return FWK_SUCCESS;
+}
+#endif
+
+static int scmi_reset_bind(fwk_id_t id, unsigned int round)
+{
+    int status;
+
+    if (round == 1)
+        return FWK_SUCCESS;
+
+    status = fwk_module_bind(FWK_ID_MODULE(FWK_MODULE_IDX_SCMI),
+                             FWK_ID_API(FWK_MODULE_IDX_SCMI,
+                                        MOD_SCMI_API_IDX_PROTOCOL),
+                             &scmi_rd_ctx.scmi_api);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    scmi_rd_ctx.plat_reset_domain_count = fwk_module_get_element_count(
+        FWK_ID_MODULE(FWK_MODULE_IDX_RESET_DOMAIN));
+    if (scmi_rd_ctx.plat_reset_domain_count == 0)
+        return FWK_E_SUPPORT;
+
+#ifdef BUILD_HAS_SCMI_NOTIFICATIONS
+    status = scmi_reset_init_notifications(scmi_rd_ctx.plat_reset_domain_count);
+    if (status != FWK_SUCCESS)
+        return status;
+#endif
+
+    return fwk_module_bind(FWK_ID_MODULE(FWK_MODULE_IDX_RESET_DOMAIN),
+                           FWK_ID_API(FWK_MODULE_IDX_RESET_DOMAIN, 0),
+                           &scmi_rd_ctx.reset_api);
+}
+
+static int scmi_reset_process_bind_request(fwk_id_t source_id,
+                                           fwk_id_t target_id,
+                                           fwk_id_t api_id, const void **api)
+{
+    switch (fwk_id_get_api_idx(api_id)) {
+    case MOD_SCMI_RESET_DOMAIN_PROTOCOL_API:
+        *api = &scmi_reset_mod_scmi_to_protocol_api;
+        break;
+
+    default:
+        return FWK_E_ACCESS;
+    }
+
+    return FWK_SUCCESS;
+}
+
+#if defined(BUILD_HAS_SCMI_NOTIFICATIONS) && defined(BUILD_HAS_NOTIFICATION)
+static int scmi_reset_process_notification(const struct fwk_event *event,
+    struct fwk_event *resp_event)
+{
+    struct mod_reset_domain_notification_event_params* params =
+        (struct mod_reset_domain_notification_event_params*)event->params;
+
+    if (!fwk_id_is_equal(scmi_rd_ctx.notification_id,
+                         event->id))
+        return FWK_E_SUPPORT;
+
+    scmi_reset_issued_notify(params->domain_id, params->reset_state,
+                             params->cookie);
+
+    return FWK_SUCCESS;
+}
+
+static int scmi_reset_start(fwk_id_t id)
+{
+    struct mod_reset_domain_config *config;
+    config = (struct mod_reset_domain_config*)fwk_module_get_data(
+        FWK_ID_MODULE(FWK_MODULE_IDX_RESET_DOMAIN)
+        );
+
+    scmi_rd_ctx.notification_id = config->notification_id;
+
+    return fwk_notification_subscribe(
+        scmi_rd_ctx.notification_id,
+        FWK_ID_MODULE(FWK_MODULE_IDX_RESET_DOMAIN),
+        id);
+}
+#endif
+
+/* SCMI Reset Domain Management Protocol Definition */
+const struct fwk_module module_scmi_reset_domain = {
+    .name = "SCMI Reset Domain Management Protocol",
+    .api_count = MOD_SCMI_RESET_DOMAIN_API_COUNT,
+    .type = FWK_MODULE_TYPE_PROTOCOL,
+    .init = scmi_reset_init,
+    .bind = scmi_reset_bind,
+    .process_bind_request = scmi_reset_process_bind_request,
+#if defined(BUILD_HAS_SCMI_NOTIFICATIONS) && defined(BUILD_HAS_NOTIFICATION)
+    .start = scmi_reset_start,
+    .process_notification = scmi_reset_process_notification,
+#endif
+};

--- a/product/juno/module/juno_reset_domain/include/mod_juno_reset_domain.h
+++ b/product/juno/module/juno_reset_domain/include/mod_juno_reset_domain.h
@@ -1,0 +1,72 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     JUNO Reset Domain module.
+ */
+
+#ifndef MOD_JUNO_RESET_DOMAIN_H
+#define MOD_JUNO_RESET_DOMAIN_H
+
+#include <fwk_id.h>
+#include <stdint.h>
+
+/*!
+ * \addtogroup GroupModules Modules
+ * \{
+ */
+
+/*!
+ * \defgroup GroupJUNORESET JUNO RESET DOMAIN
+ *
+ * \{
+ */
+
+/*!
+ * \brief Juno Reset domain indexes.
+ *
+ */
+enum juno_reset_domain_idx {
+    /*! UART element index. */
+    JUNO_RESET_DOMAIN_IDX_UART,
+
+    /*! Number of defined elements */
+    JUNO_RESET_DOMAIN_IDX_COUNT,
+};
+
+/*!
+ * \brief Element configuration.
+ */
+struct mod_juno_reset_uart_config {
+    /*! Address of Juno VSYS Manual Reset Register.*/
+    volatile uint32_t *reset_reg;
+
+    /*! Bit Mask to enable/clear reset of the device in VSYS manual reset
+     *  register.
+     */
+    unsigned int  reset_mask;
+};
+
+/*!
+ * \brief Juno Reset Domain API indices.
+ */
+enum mod_juno_reset_domain_api_idx {
+    /*! Index of the driver API */
+    MOD_JUNO_RESET_DOMAIN_API_IDX_DRIVER,
+
+    /*! Number of APIs for the Juno reset domain driver module */
+    MOD_JUNO_RESET_DOMAIN_API_IDX_COUNT,
+};
+
+/*!
+ * \}
+ */
+
+/*!
+ * \}
+ */
+
+#endif  /* MOD_JUNO_RESET_DOMAIN_DEBUG_H */

--- a/product/juno/module/juno_reset_domain/src/Makefile
+++ b/product/juno/module/juno_reset_domain/src/Makefile
@@ -1,0 +1,11 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BS_LIB_NAME := JUNO RESET DOMAIN
+BS_LIB_SOURCES += mod_juno_reset_domain.c
+
+include $(BS_DIR)/lib.mk

--- a/product/juno/module/juno_reset_domain/src/mod_juno_reset_domain.c
+++ b/product/juno/module/juno_reset_domain/src/mod_juno_reset_domain.c
@@ -1,0 +1,192 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     JUNO Reset Domain Driver
+ *     Arm platforms don't have proper reset domains. However for completeness,
+ *     this driver demonstrates reset functionality using Juno UART as an
+ *     example reset domain peripheral. Only auto reset functionality is
+ *     implemented as explicit assert/de-assert complicates functionality of
+ *     UART peripheral.
+ */
+
+#include <fwk_assert.h>
+#include <fwk_macros.h>
+#include <fwk_mm.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+#include <fwk_thread.h>
+#include <fwk_status.h>
+#include <juno_scc.h>
+#include <mod_reset_domain.h>
+#include <mod_juno_reset_domain.h>
+#include <system_mmap.h>
+
+enum dev_state {
+    DEVICE_STATE_NORMAL = 0,
+    DEVICE_STATE_RESET = 1
+};
+
+struct juno_reset_dev_ctx {
+    void *config;
+    bool reset_state;
+};
+
+struct juno_reset_domain_module_ctx {
+    const struct mod_reset_domain_drv_input_api *drv_input_api;
+    fwk_id_t reset_domain_hal_id;
+    struct juno_reset_dev_ctx *dev_ctx_table;
+    uint32_t cookie;
+};
+
+static struct juno_reset_domain_module_ctx module_juno_reset_ctx;
+
+/* Helper functions */
+static int handle_uart_reset_set_state(struct juno_reset_dev_ctx *dev_ctx)
+{
+    int retry = 5;
+    int status = FWK_E_DEVICE;
+
+    struct mod_juno_reset_uart_config* uart_config =
+        (struct mod_juno_reset_uart_config*)dev_ctx->config;
+
+    if (dev_ctx->reset_state == DEVICE_STATE_RESET)
+        return FWK_E_STATE;
+
+    /* Reset UART device */
+    dev_ctx->reset_state = DEVICE_STATE_RESET;
+    *uart_config->reset_reg |= uart_config->reset_mask;
+
+    /* Check if reset of the device has been taken place
+     * On juno board unlikely we will see mutliple retries.
+     */
+    while (retry--) {
+        if (*uart_config->reset_reg & uart_config->reset_mask) {
+            /* We are only supporting auto reset and architecture reset
+             * so clear juno UART reset.
+             */
+            *uart_config->reset_reg &= ~uart_config->reset_mask;
+            status = FWK_SUCCESS;
+            dev_ctx->reset_state = DEVICE_STATE_NORMAL;
+            break;
+        }
+    }
+
+    return status;
+}
+
+/*
+ * Module APIs
+ */
+static int juno_set_reset_state(fwk_id_t dev_id,
+                                enum mod_reset_domain_mode mode,
+                                uint32_t reset_state,
+                                uintptr_t cookie)
+{
+    int status;
+    struct juno_reset_dev_ctx* dev_ctx;
+    struct mod_reset_domain_autoreset_event_params* params;
+    struct fwk_event autoreset_event = {
+        .id = mod_reset_domain_autoreset_event_id,
+        .target_id = fwk_module_id_reset_domain,
+    };
+    unsigned int domain_idx = fwk_id_get_element_idx(dev_id);
+
+    if (domain_idx >= JUNO_RESET_DOMAIN_IDX_COUNT)
+        return FWK_E_PARAM;
+
+    dev_ctx = &module_juno_reset_ctx.dev_ctx_table[domain_idx];
+
+    if (domain_idx == JUNO_RESET_DOMAIN_IDX_UART) {
+        status = handle_uart_reset_set_state(dev_ctx);
+        if (status != FWK_SUCCESS)
+            return status;
+
+        params = (struct mod_reset_domain_autoreset_event_params*)
+                 autoreset_event.params;
+        params->dev_id = dev_id;
+        params->reset_state = reset_state;
+        params->cookie = cookie;
+        fwk_thread_put_event(&autoreset_event);
+    }
+
+    return FWK_SUCCESS;
+}
+
+static struct mod_reset_domain_drv_api juno_reset_domain_drv_api = {
+    .set_reset_state = juno_set_reset_state,
+};
+
+/*
+ * Framework handlers
+ */
+static int juno_reset_domain_init(fwk_id_t module_id,
+                                  unsigned int element_count,
+                                  const void *data)
+{
+    /* This module supports only one reset device
+     */
+    fwk_assert(element_count == 1);
+    module_juno_reset_ctx.dev_ctx_table = fwk_mm_calloc(element_count,
+                                             sizeof(struct juno_reset_dev_ctx));
+
+    return FWK_SUCCESS;
+}
+
+static int juno_reset_domain_element_init(fwk_id_t element_id,
+                                          unsigned int sub_element_count,
+                                          const void *data)
+{
+    struct juno_reset_dev_ctx* dev_ctx = NULL;
+
+    dev_ctx = &module_juno_reset_ctx.dev_ctx_table[
+        fwk_id_get_element_idx(element_id)];
+    dev_ctx->config = (void*)data;
+
+    return FWK_SUCCESS;
+}
+
+static int juno_reset_domain_bind(fwk_id_t id, unsigned int round)
+{
+   return FWK_SUCCESS;
+}
+
+static int juno_reset_domain_process_bind_request(fwk_id_t source_id,
+                                                  fwk_id_t target_id,
+                                                  fwk_id_t api_id,
+                                                  const void **api)
+{
+    fwk_id_t mod_juno_reset_domain_api_id_driver =
+        FWK_ID_API_INIT(FWK_MODULE_IDX_JUNO_RESET_DOMAIN,
+                        MOD_JUNO_RESET_DOMAIN_API_IDX_DRIVER);
+
+    if (!fwk_id_is_type(target_id, FWK_ID_TYPE_ELEMENT) ||
+        !fwk_id_is_equal(api_id, mod_juno_reset_domain_api_id_driver) ||
+        api == NULL)
+        return FWK_E_PARAM;
+
+    *api = &juno_reset_domain_drv_api;
+
+    module_juno_reset_ctx.reset_domain_hal_id = source_id;
+
+    return FWK_SUCCESS;
+}
+
+static int juno_reset_domain_start(fwk_id_t id)
+{
+    return FWK_SUCCESS;
+}
+
+struct fwk_module module_juno_reset_domain = {
+    .name = "JUNO RESET DOMAIN",
+    .type = FWK_MODULE_TYPE_DRIVER,
+    .api_count = MOD_JUNO_RESET_DOMAIN_API_IDX_COUNT,
+    .init = juno_reset_domain_init,
+    .element_init = juno_reset_domain_element_init,
+    .bind = juno_reset_domain_bind,
+    .process_bind_request = juno_reset_domain_process_bind_request,
+    .start = juno_reset_domain_start,
+};

--- a/product/juno/scp_ramfw/config_juno_reset_domain.c
+++ b/product/juno/scp_ramfw/config_juno_reset_domain.c
@@ -1,0 +1,35 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <fwk_element.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+#include <juno_scc.h>
+#include <mod_reset_domain.h>
+#include <mod_juno_reset_domain.h>
+#include <system_mmap.h>
+
+static struct fwk_element juno_reset_element_table[] = {
+    [JUNO_RESET_DOMAIN_IDX_UART] = {
+        .name = "JUNO_UART",
+        .data = &((struct mod_juno_reset_uart_config){
+            .reset_reg = &(SCC->VSYS_MANUAL_RESET),
+            .reset_mask = (0x1 << 8),
+        }),
+    },
+    [JUNO_RESET_DOMAIN_IDX_COUNT] = { 0 }, /* Termination description */
+};
+
+static const struct fwk_element *get_juno_reset_domain_elem_table(
+                                     fwk_id_t module_id)
+{
+    return juno_reset_element_table;
+}
+
+struct fwk_module_config config_juno_reset_domain = {
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_juno_reset_domain_elem_table),
+};

--- a/product/juno/scp_ramfw/config_reset_domain.c
+++ b/product/juno/scp_ramfw/config_reset_domain.c
@@ -1,0 +1,53 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <fwk_element.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+
+#include <mod_reset_domain.h>
+#include <mod_scmi_reset_domain.h>
+#include <mod_juno_reset_domain.h>
+
+static const struct mod_reset_domain_config reset_domain_config = {
+#ifdef BUILD_HAS_SCMI_NOTIFICATIONS
+    .notification_id = FWK_ID_NOTIFICATION_INIT(FWK_MODULE_IDX_RESET_DOMAIN,
+                            MOD_RESET_DOMAIN_NOTIFICATION_AUTORESET),
+#endif
+};
+
+/* Configuration of the reset elements */
+static const struct fwk_element reset_domain_element_table[] = {
+    [JUNO_RESET_DOMAIN_IDX_UART] = {
+        .name = "JUNO_UART",
+        .data = &((const struct mod_reset_domain_dev_config) {
+            .driver_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_JUNO_RESET_DOMAIN,
+                                             JUNO_RESET_DOMAIN_IDX_UART),
+            .driver_api_id = FWK_ID_API_INIT(
+                                 FWK_MODULE_IDX_JUNO_RESET_DOMAIN,
+                                 MOD_JUNO_RESET_DOMAIN_API_IDX_DRIVER),
+            .modes = MOD_RESET_DOMAIN_AUTO_RESET,
+#ifdef BUILD_HAS_SCMI_NOTIFICATIONS
+            .capabilities = MOD_RESET_DOMAIN_CAP_NOTIFICATION,
+#endif
+            .latency = 0xFFFFFFFF
+        }),
+    },
+    [JUNO_RESET_DOMAIN_IDX_COUNT] = { 0 }, /* Termination description */
+};
+
+static const struct fwk_element *get_reset_domain_element_table(
+                                     fwk_id_t module_id)
+{
+    return reset_domain_element_table;
+}
+
+/* Configuration of the reset domain module */
+struct fwk_module_config config_reset_domain = {
+    .data = &reset_domain_config,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_reset_domain_element_table),
+};

--- a/product/juno/scp_ramfw/config_scmi.c
+++ b/product/juno/scp_ramfw/config_scmi.c
@@ -105,7 +105,7 @@ static const struct mod_scmi_agent agent_table[] = {
 struct fwk_module_config config_scmi = {
     .data =
         &(struct mod_scmi_config){
-            .protocol_count_max = 5,
+            .protocol_count_max = 6,
             .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
             .agent_table = agent_table,
             .vendor_identifier = "arm",

--- a/product/juno/scp_ramfw/config_scmi_reset_domain.c
+++ b/product/juno/scp_ramfw/config_scmi_reset_domain.c
@@ -1,0 +1,41 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <fwk_id.h>
+#include <fwk_macros.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+
+#include <juno_scmi.h>
+#include <mod_scmi_reset_domain.h>
+#include <mod_juno_reset_domain.h>
+#include <mod_reset_domain.h>
+
+static const struct mod_scmi_reset_domain_device agent_device_table_ospm[] = {
+   [JUNO_RESET_DOMAIN_IDX_UART] = {
+        .element_id =
+            FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_RESET_DOMAIN,
+                                JUNO_RESET_DOMAIN_IDX_UART),
+        .permissions = MOD_SCMI_RESET_DOMAIN_PERM_ATTRIBUTES |
+                       MOD_SCMI_RESET_DOMAIN_PERM_RESET,
+    },
+};
+
+static const struct mod_scmi_reset_domain_agent agent_table[] = {
+    [JUNO_SCMI_AGENT_IDX_PSCI] = { 0 /* No access */ },
+    [JUNO_SCMI_AGENT_IDX_OSPM] = {
+        .device_table = agent_device_table_ospm,
+        .agent_domain_count = FWK_ARRAY_SIZE(agent_device_table_ospm),
+    },
+};
+
+struct fwk_module_config config_scmi_reset_domain = {
+    .data = &((struct mod_scmi_reset_domain_config) {
+        .agent_table = agent_table,
+        .agent_count = FWK_ARRAY_SIZE(agent_table),
+    }),
+};

--- a/product/juno/scp_ramfw/firmware.mk
+++ b/product/juno/scp_ramfw/firmware.mk
@@ -14,6 +14,7 @@ BS_FIRMWARE_HAS_NOTIFICATION := yes
 BS_FIRMWARE_HAS_SCMI_NOTIFICATIONS := no
 BS_FIRMWARE_HAS_FAST_CHANNELS := no
 BS_FIRMWARE_HAS_DEBUG_UNIT := yes
+BS_FIRMWARE_HAS_SCMI_RESET := no
 
 BS_FIRMWARE_MODULE_HEADERS_ONLY :=
 
@@ -58,6 +59,10 @@ ifeq ($(BS_FIRMWARE_HAS_DEBUG_UNIT),yes)
     BS_FIRMWARE_MODULES += juno_debug debug
 endif
 
+ifeq ($(BS_FIRMWARE_HAS_SCMI_RESET),yes)
+    BS_FIRMWARE_MODULES += reset_domain scmi_reset_domain juno_reset_domain
+endif
+
 BS_FIRMWARE_SOURCES := \
     juno_utils.c \
     config_sds.c \
@@ -99,6 +104,12 @@ endif
 
 ifeq ($(BS_FIRMWARE_HAS_DEBUG_UNIT),yes)
     BS_FIRMWARE_SOURCES += config_juno_debug.c config_debug.c
+endif
+
+ifeq ($(BS_FIRMWARE_HAS_SCMI_RESET),yes)
+    BS_FIRMWARE_SOURCES += config_reset_domain.c \
+        config_scmi_reset_domain.c \
+        config_juno_reset_domain.c
 endif
 
 include $(BS_DIR)/firmware.mk

--- a/tools/build_system/firmware.mk
+++ b/tools/build_system/firmware.mk
@@ -215,6 +215,12 @@ else
     BUILD_HAS_SCMI_NOTIFICATIONS := no
 endif
 
+ifeq ($(BS_FIRMWARE_HAS_SCMI_RESET),yes)
+    BUILD_HAS_SCMI_RESET := yes
+else
+    BUILD_HAS_SCMI_RESET := no
+endif
+
 # Add directories to the list of targets to build
 LIB_TARGETS_y += $(patsubst %,$(MODULES_DIR)/%/src, \
                             $(BUILD_STANDARD_MODULES))

--- a/tools/build_system/rules.mk
+++ b/tools/build_system/rules.mk
@@ -33,6 +33,10 @@ ifeq ($(BUILD_HAS_FAST_CHANNELS),yes)
     DEFINES += BUILD_HAS_FAST_CHANNELS
 endif
 
+ifeq ($(BUILD_HAS_SCMI_RESET),yes)
+    DEFINES += BUILD_HAS_SCMI_RESET
+endif
+
 export AS := $(CC)
 export LD := $(CC)
 


### PR DESCRIPTION
Added new SCMIv2 Reset Domain Management protocol, this is based on some work
done by etienne (see https://github.com/ARM-software/SCP-firmware/pull/115). It also provides an example peripheral UART of Juno board as a reset domain. Also implemented is the SCMI Notification feature.
