### PR TITLE
module/scmi_perf: Fix build issues for Fast Channels

### DIFF
--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -219,8 +219,8 @@ static int scmi_perf_protocol_message_attributes_handler(fwk_id_t service_id,
 
     return_values.attributes = 0;
 #ifdef BUILD_HAS_FAST_CHANNELS
-    if ((parameters->message_id <= SCMI_PERF_LEVEL_GET) &&
-        (parameters->message_id >= SCMI_PERF_LIMITS_SET))
+    if ((parameters->message_id <= MOD_SCMI_PERF_LEVEL_GET) &&
+        (parameters->message_id >= MOD_SCMI_PERF_LIMITS_SET))
         return_values.attributes = 1; /* Fast Channel available */
 #endif
 


### PR DESCRIPTION
The build is broken if BUILD_HAS_FAST_CHANNELS_IS_SET.

Change-Id: Id9ec6637788ad217c07abe38ca83b131b1845f7a
Signed-off-by: Jim Quigley <jim.quigley@arm.com>