### PR TITLE
doc: Add clang-format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,70 @@
+---
+BasedOnStyle: Chromium
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: 'false'
+AlignConsecutiveDeclarations: 'false'
+AlignEscapedNewlines: 'DontAlign'
+AlignOperands: 'false'
+AlignTrailingComments: 'false'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: 'true'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: WebKit
+BreakBeforeTernaryOperators: 'false'
+ColumnLimit: '80'
+ContinuationIndentWidth: '4'
+Cpp11BracedListStyle: 'false'
+DerivePointerAlignment: 'false'
+DisableFormat: 'false'
+IncludeCategories:
+- Regex: '^<internal/(.+)\.h>$'
+  Priority: -2
+- Regex: '^<mod_(.+)_private\.h>$'
+  Priority: -1
+- Regex: '^<mod_(.+)\.h>$'
+  Priority: 0
+- Regex: '^<fwk_(.+)\.h>$'
+  Priority: 1
+- Regex: '^<fmw_(.+)\.h>$'
+  Priority: 2
+- Regex: '^<((std.+)|assert|complex|ctype|errno|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|string|tgmath|threads|time|uchar|wchar|wctype)\.h>$'
+  Priority: 3
+- Regex: '^".+"$'
+  Priority: -4
+- Regex: '^<.+>$'
+  Priority: -3
+IndentCaseLabels: 'false'
+IndentPPDirectives: 'AfterHash'
+IndentWidth: '4'
+IndentWrappedFunctionNames: 'true'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '1'
+PenaltyBreakBeforeFirstCallParameter: '0'
+PenaltyBreakComment: '300'
+PenaltyBreakFirstLessLess: '120'
+PenaltyBreakString: '1000'
+PenaltyExcessCharacter: '1000000'
+PenaltyReturnTypeOnItsOwnLine: '500000'
+PointerAlignment: Right
+SpaceAfterCStyleCast: 'false'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: 'false'
+SpacesBeforeTrailingComments: '1'
+SpacesInCStyleCastParentheses: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+TabWidth: '4'
+UseTab: Never
+
+...

--- a/doc/code_style.md
+++ b/doc/code_style.md
@@ -1,310 +1,385 @@
-Coding Style
-============
+# Coding Style
 
-A coding style has been defined to give a consistent look to the source code and
-thus help code readability and review.
+To maintain consistency within the SCP/MCP software source code a series of
+rules and guidelines have been created; these form the project's coding style.
 
-Encoding
---------
+## Style
+
+### Unicode
 
 The source code must use the UTF-8 encoding. Comments, documentation and strings
 may use non-ASCII characters when required (e.g. Greek letters used for units).
 
-Naming
-------
-Function, variable, file name and type names must:
-- Be written in lower-case
-- Have compound words separated by underline characters
-- Have descriptive names, avoiding contractions where possible
-(e.g.cluster_count instead of clus_cnt)
+### License Headers
 
-Avoid using:
-- Camel case syntax (e.g. cssClusterCount)
-- Hungarian notation, encoding types within names (e.g. int iSize)
-
-Functions, macros, types and defines must have the "fwk_" prefix (upper case for
-macros and defines) to identify framework API.
-
-Non-static names should be prefixed with the name of their translation unit to
-avoid name collisions.
-
-It is acceptable to use the following common placeholder names for loop indices:
- - `i`
- - `j`
- - `k`
-
-`xyz_idx` names are commonly used for indices that live longer than a single
-loop.
-
-License
--------
-All files must begin with a license header of the following form:
+All files must begin with a license header of the following form, where first
+year describes the year the file was first upstreamed, and the second year the
+current year (which the core team will update annually):
 
 Arm SCP/MCP Software
 Copyright (c) 2015-2020, Arm Limited and Contributors. All rights reserved.
 
 SPDX-License-Identifier: BSD-3-Clause
 
-Inclusions
-----------
-Header file inclusions should follow a consistent sequence, defined by scope
-from local to global:
+### Clang Format
 
-- Private firmware headers (`"config_scmi.h"`)
-- Public non-project headers (`<cmsis.h>`)
-- Private module headers (`<internal/scmi.h>)
-- Public module headers (`<mod_scmi.h>)
-- Public framework headers (`<fwk_list.h>`)
-- Public architecture headers (`<arch_exceptions.h>`)
-- Public firmware headers (`<fmw_cmsis.h>`)
-- Public standard library headers (`<stddef.h>`)
+To aid in establishing a uniform style across the code-base, this project uses
+Clang Format. When contributing patches, care should be taken to ensure that
+code has been formatted according to the rules laid down in the .clang-format
+file, and that deviations occur only where the tool is unable to format code
+reasonably.
 
-For each group, order the individual headers alphabetically and separate the
-blocks logically.
+You can automatically format any staged changes with:
 
-Header files (`.h` files) should include the headers needed for them to compile
-and only these ones.
+```sh
+git clang-format
+```
 
-Translation units (`.c` files) should not rely on indirect inclusion to provide
-names they have otherwise not included themselves.
+### Braces
 
-Indentation and Scope
----------------------
-Indentation is made of spaces, 4 characters long with each line being at most 80
-characters long.
-Following K&R style, the open-brace goes on the same line as the statement:
+Conditional statements with a single line of code should not use braces,
+preferring indentation only:
 
-\code
-if (x == y) {
-    (...)
+```c
+if (condition)
+    function_call();
+```
+
+Any sequence of statements that spans multiple lines must be surrounded by
+braces:
+
+```c
+if (condition) {
+    function_call(
+        long_variable_name_x,
+        long_variable_name_y,
+        long_variable_name_z);
 }
-\endcode
+```
 
-The only exception is for functions, which push the opening brace to the
-following line:
+These rules apply independently of whether they are part of an if-else chain:
 
-\code
-void function_a(int x, int y)
-{
-  (...)
-}
-\endcode
-
-Similarly, the case and default keywords should be aligned with the switch
-statement:
-
-\code
-switch (option) {
-case 1:
-    (...)
-    break;
-default:
-    (...)
-    break;
-}
-\endcode
-
-Conditional statements with single line of code should not use braces,
-preferring indentation only. A statement that spans multiple lines must use
-braces to improve readability:
-
-\code
-if (condition_a == true)
-    function_call_a();
-
-if (condition_b == true) {
-    function_call_b(long_variable_name_x |
-                    long_variable_name_y);
-}
-\endcode
-
-In a chain of if-else statements involving multi-line and single-line blocks,
-it is acceptable to mix statements with and without braces:
-
-\code
-if (condition == [a]) {
-    function_call_a(long_variable_name_x |
-                    long_variable_name_y);
-} else if (condition == [b])
+```c
+if (condition) {
+    function_call(
+        long_variable_name_x,
+        long_variable_name_y,
+        long_variable_name_z);
+} else
     function_call_b();
-\endcode
+```
 
-Empty loop statements should use "continue" instead of empty braces or single
-semi-colon:
+Empty loop statements must use `continue`:
 
-\code
-while (condition == false)
+```c
+while (condition)
   continue;
-\endcode
+```
 
-Multi-line statements should align on the openning delimiter:
+### Operators
 
-\code
-long_variable_name = (long_variable_value << LONG_CONSTANT_POS) &
-                      LONG_CONSTANT_MASK;
-\endcode
+When using operators like `sizeof` and `alignof`, where possible use the
+value-based version over the type-based version:
 
-In case the code extends beyond 80 columns, the first line can wrap creating a
-new indented block:
-\code
-                    long_variable_name =
-                        (long_variable_value << LONG_CONSTANT_POS) &
-                         LONG_CONSTANT_MASK;
-\endcode
+```c
+int counter;
 
-When a stacked multi-line statement aligns with the next code level, leave a
-blank line to highlight the separation:
+sizeof(counter); /* Preferred over sizeof(int) */
+```
 
-\code
-if (condition_a ||
-    condition_b ||
-    condition_c) {
+### Operator Precedence
 
+Do not rely on the implicit precedence and associativity of operators. Use
+parentheses to make precedence and associativity explicit:
+
+```c
+if ((a == 'a') || (x == 'x'))
     do_something();
-}
-\endcode
+```
 
-Function definitions should follow the same approach:
-\code
-int foo(unsigned int param_a,
-        unsigned param_b,
-        unsigned param_c)
+Parentheses around a unary operator and its operand may be omitted:
+
+```c
+if (!a && *b)
+    do_something();
+```
+
+## Conventions
+
+### Header Guards
+
+All headers must be wrapped with include guards to prevent accidental multiple
+definitions of header contents. The definition name should be the upper-case
+file name followed by `_H`. An example for a file named `fwk_mm.h` follows:
+
+```c
+#ifndef FWK_MM_H
+#define FWK_MM_H
+
+(...)
+
+#endif /* FWK_MM_H */
+```
+
+### Inclusion Policy
+
+The closing `endif` statement should be followed directly by a single-line
+comment which replicates the full guard name. In long files this helps to
+clarify what is being closed.
+
+*Public* headers must be included directly *except* in the following situations:
+
+- The header is already included by the counterpart to the current C file (e.g.
+  `x/src/mod_x.c` does not need to include `<stdint.h>` if `x/include/mod_x.h`
+  includes it)
+- The header is an internal header and is included as part of another public
+  header (e.g. `x/src/mod_x.c` does not need to include `x/include/internal/x.h`
+  if another header includes it)
+
+These rules do not apply to *private* headers (headers under a `src/`
+directory).
+
+### Macros and Constants
+
+All macro and constant names must be written in upper-case to differentiate
+them from functions and non-constants.
+
+Logical groupings of constants should be defined as enumerations with a common
+prefix, so that they can be used as parameter types and in constant expressions.
+Enumerations that contain a "number of elements" value must use the `_COUNT`
+suffix, and the final enumeration value should include a comma.
+
+```c
+enum command_id {
+    COMMAND_ID_VERSION,
+    COMMAND_ID_PING,
+    COMMAND_ID_EXIT,
+    COMMAND_ID_COUNT,
+};
+
+void process_cmd(enum command_id id)
 {
-    ...
+    (...)
 }
-\endcode
+```
 
-Preprocessor statements should be aligned with the code they are related to:
+### Symbol Naming
 
-\code
-#ifdef HAS_FOO
-int foo(void)
-{
-    #ifdef HAS_BAR
-    return bar();
+Function, variable, file name and type names must:
 
-    #else
-    return -1;
+- Be written in lower-case
+- Have compound words separated by underline characters (`_`)
+- Have descriptive names, avoiding contractions where possible (e.g.
+    `cluster_count` instead of `clus_cnt`)
 
-    #endif
-}
-#endif
-\endcode
+Avoid using:
 
-Where preprocessor statements are nested and they target the same code stream,
-indentation is allowed but the hash symbol must be left aligned with the code
-stream:
+- Camel case syntax (e.g. `cssClusterCount`)
+- Hungarian notation, encoding types within names (e.g. `int iSize`)
 
-\code
-#ifdef HAS_FOO
-int foo(void)
-{
-    #ifdef HAS_BAR
-    return bar();
+The following prefixes are reserved for these components:
 
-    #else
-    #   ifdef DEFAULT_ERROR
-    return -1;
+- Architecture: `arch_`
+- Framework: `fwk_`
+- Module: `mod_`
+  - Module description: `module_`
+  - Module configuration: `config_`
+- Firmware: `fmw_`
 
-    #   else
-    return 0
+### Assertions
 
-    #   endif
-    #endif
-}
-#endif
-\endcode
+Use `fwk_assert()` to mark *invariants*. Invariants are logical assertions about
+the behaviour of the system which must hold true for the program to be valid.
+Invariants are usually easy to communicate to human readers, but not very easy
+to communicate to the compiler.
 
-__Note__ Such constructions like the example above should be avoided if
-possible.
+Use `fwk_expect()` to mark *expectations*. Expectations may fail, and they may
+or may not be handled, but they are not invariants in that they may reasonably
+occur at some point in time.
 
-Comments
---------
+### Loop Indices
+
+It is acceptable to use the following common placeholder names for loop indices:
+
+- `i`
+- `j`
+- `k`
+
+### Types
+
+Avoid defining custom types with the `typedef` keyword where possible. Names
+defined with `typedef` must use the `_t` suffix.
+
+### Comments
+
 To ensure a consistent look, the preferred style for single-line comments is to
-use the C89 style of paired forward-slashes and asterisks:
+use the C89 style of paired forward-slashes and asterisks, ending with no
+punctuation:
 
-\code
-/* A short, single-line comment. */
-\endcode
+```c
+/* A short, single-line comment */
+```
 
-For multi-line comments the same applies, adding an asterisk on each new line:
+Multi-line comments should follow a similar style, and always end with
+punctuation:
 
-\code
+```c
 /*
- * This is a multi-line comment
- * where each line starts with
- * an asterisk.
+ * This is a very, very, very, very long multi-line comment where each line
+ * starts with an asterisk and paragraphs ends with punctation.
  */
-\endcode
+```
 
-\#if 0 is preferred for commenting out blocks of code where it is necessary to
-do so.
+Doxygen comments follow only the second style, for consistency in the generated
+documentation:
 
-\code
+```c
+/*!
+ * \brief Hello, World.
+ */
+```
+
+Preprocessor `if 0` is preferred for commenting out blocks of code where it is
+necessary to do so, as these can be nested (unlike multi-line comment blocks).
+
+```c
 void function_a(int x, int y)
 {
-  (...)
+    (...)
 }
 
 #if 0
 void function_b(int x, int y)
 {
-  (...)
+    (...)
 }
 #endif
+```
 
-\endcode
+Prefer functions to function-like macros where possible. Avoid using the
+`inline` keyword, as inlining sites are better-determined by the compiler.
 
-Doxygen Comments
-----------------
+### Initialization
+
+When literals require explicit literal initialization, avoid implicit casts by
+using the proper integer literal suffix or initializer:
+
+```c
+void *p = NULL;
+unsigned int u = 0u;
+float f = 0.0f;
+double d = 0.0;
+char c = '\0';
+```
+
+Array and structure initialization should use designated initializers. These
+allow elements to be initialized using array indices or structure field names
+without a fixed ordering:
+
+```c
+uint32_t clock_frequencies[3] = {
+    [2] = 800,
+    [0] = 675,
+};
+
+struct clock clock_cpu = {
+    .name = "CPU",
+    .frequency = clock_frequencies[2],
+};
+```
+
+### Device Register Definitions
+
+The format for structures representing memory-mapped device registers is
+standardized:
+
+- Register structure names are suffixed with `_reg`
+- All register names must be capitalized
+- Non-reserved registers must be one of `FWK_R`, `FWK_W`, or `FWK_RW`
+- Bit-field masks and shifts use the `<DEVICE>_<REGISTER>_<FIELD>` name,
+  suffixed with either `_MASK` or `_POS`
+
+```c
+#include <stdint.h>
+#include <fwk_macros.h>
+
+struct my_timer_reg {
+    FWK_RW uint32_t CONFIG;
+           uint32_t RESERVED1;
+    FWK_W  uint32_t IRQ_CLEAR;
+    FWK_R  uint32_t IRQ_STATUS;
+           uint8_t  RESERVED2[0x40];
+};
+
+#define MY_TIMER_CONFIG_ENABLE UINT32_C(0x00000001)
+#define MY_TIMER_CONFIG_SLEEP UINT32_C(0x00000002)
+
+#define MY_TIMER_IRQ_STATUS_ALERT UINT32_C(0x00000001)
+```
+
+**Note:** A template file can be found in doc/template/device.h
+
+### Doxygen Comments
+
 The project APIs are documented using Doxygen comments.
 
 It is mandatory to document every API exposed to other elements of the project.
 By default, the provided Doxygen configuration omits undocumented elements from
-the compiled documentation. APIs are documented in the header files exposing
-them.
+the compiled documentation.
 
 At a minimum:
-- All functions and structures must have at least a "\brief" tag.
-- All functions must document their parameters (if any) with the "\param" tag.
-- All functions should use the "\return" or "\retval" tags to document their
-return value. When the return is void, simply give "None" as the return value.
+
+- All functions and structures must have at least a `brief` tag
+- All functions must document their parameters (if any) with the `param` tag
+  - Input parameters must use `param[in]`
+  - Output parameters must use `param[out]`
+  - Input/output parameters must use `param[in, out]`
+- All functions returning a value should use the `return` and, optionally, the
+  `retval` tag to document their return value
+  - `return` should document what the *type* of the return value represents
+  - `retval` should document what *individual return values* represent
 
 Alignment and indentation:
-- Documentation must also obey the 80 columns limit.
+
+- Documentation must also obey the 80 column limit
 - Multiple lines of documentation on an entry (e.g. details) must be indented
-using the equivalent of two 4-space based tabs (see example below).
+  using the equivalent of two 4-space based tabs from the first column (see
+  example below)
 
 Function documentation example:
-\code
+
+```c
 /*!
  * \brief Enable the watchdog.
  *
- * \details This function enables the watchdog. If m_wdog_set_interval() has
+ * \details This function enables the watchdog. If mod_wdog_set_interval() has
  *      not been called beforehand then the watchdog defaults to a 500
  *      millisecond timeout period.
- *
- * \return None.
  */
-void m_wdog_enable(void);
-\endcode
+void mod_wdog_enable(void);
+```
 
 Structure documentation example:
-\code
+
+```c
 /*!
- * \brief Queue item
+ * \brief A structure example.
+ *
+ * \details This is an example of a structure for the code style documentation.
  */
-typedef struct _fwk_dlinks_t {
-    /*! Pointer to the next item */
-    struct _fwk_dlinks_t *next;
+struct mod_structure {
+    /*!
+     * \brief Example field.
+     */
+    unsigned int example;
+};
+```
 
-    /*! Pointer to the previous item */
-    struct _fwk_dlinks_t *prev;
-} fwk_dlinks_t;
-\endcode
+## Python
 
-Python based tools
-------------------
+Python based tools must follow the [PEP8][pep8] specification. This is enforced
+with the `pycodestyle` tool.
 
-Python based tools must follow the
-[PEP8](https://www.python.org/dev/peps/pep-0008/) specification.
+Python code must be linted with `pylint`.
+
+[pep8]: https://www.python.org/dev/peps/pep-0008

--- a/doc/template/device.h
+++ b/doc/template/device.h
@@ -11,11 +11,11 @@
 #ifndef <DEVICE>_H
 #define <DEVICE>_H
 
-#    include <fwk_macros.h>
+#include <fwk_macros.h>
 
-#    include <stdint.h>
+#include <stdint.h>
 
-typedef struct {
+struct device_reg {
     /* Readable and writable register */
     FWK_RW uint32_t <REGISTER NAME>;
            uint32_t RESERVED1;
@@ -26,10 +26,10 @@ typedef struct {
     /* Read-only register */
     FWK_R  uint32_t <REGISTER NAME>;
            uint32_t RESERVED2[0x40];
-} <DEVICE NAME>_reg_t;
+};
 
 /* Register bit definitions */
-#define <REGISTER NAME>_<FIELD> UINT32_C(0x00000001)
-#define <REGISTER NAME>_<FIELD> UINT32_C(0x00000002)
+#define <DEVICE>_<REGISTER NAME>_<FIELD> UINT32_C(0x00000001)
+#define <DEVICE>_<REGISTER NAME>_<FIELD> UINT32_C(0x00000002)
 
 #endif /* <DEVICE>_H */


### PR DESCRIPTION
This patch updates the code style documentation, adjusting it to fit
existing established but undocumented rules, as well as introducing new
ones for consistency.

It also introduces a clang-format configuration, which becomes the de
jure code style arbitrator. This configuration uses a style very close
to the existing style, with some minor tweaks in places where a single
existing style was unestablished.

Change-Id: I7a6ae117a721d7e258df01a302c5a0fb18bc3133
Signed-off-by: Chris Kay <chris.kay@arm.com>