### PR TITLE
requirements.txt: Add Clang Format 9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+clang-format==9.0.0
 pycodestyle==2.6.0


### PR DESCRIPTION
This commit adds Clang Format as a Python wheel requirement, which
allowing users to install it automatically with:

    pip install -r requirements.txt

Change-Id: If0046c8727a90957f68a5240a70678b6ec740537
Signed-off-by: Chris Kay <chris.kay@arm.com>