### PR TITLE
clang-format: Add architecture header group

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,6 +25,7 @@ ContinuationIndentWidth: '4'
 Cpp11BracedListStyle: 'false'
 DerivePointerAlignment: 'false'
 DisableFormat: 'false'
+IncludeBlocks: 'Regroup'
 IncludeCategories:
 - Regex: '^<internal/(.+)\.h>$'
   Priority: -2
@@ -34,10 +35,12 @@ IncludeCategories:
   Priority: 0
 - Regex: '^<fwk_(.+)\.h>$'
   Priority: 1
-- Regex: '^<fmw_(.+)\.h>$'
+- Regex: '^<arch_(.+)\.h>$'
   Priority: 2
-- Regex: '^<((std.+)|assert|complex|ctype|errno|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|string|tgmath|threads|time|uchar|wchar|wctype)\.h>$'
+- Regex: '^<fmw_(.+)\.h>$'
   Priority: 3
+- Regex: '^<((std.+)|assert|complex|ctype|errno|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|string|tgmath|threads|time|uchar|wchar|wctype|malloc|(sys/.+))\.h>$'
+  Priority: 4
 - Regex: '^".+"$'
   Priority: -4
 - Regex: '^<.+>$'


### PR DESCRIPTION
The first revision of `.clang-format` missed some necessary include
grouping options for the recently-introduced architecture headers.

Change-Id: I92eeeb6ee94693d129502a1ddc873f77fb0b408d
Signed-off-by: Chris Kay <chris.kay@arm.com>