### PR TITLE
juno: Wrong format for LOG_LEVEL=TRACE

### DIFF
--- a/product/juno/src/juno_scmi_clock.c
+++ b/product/juno/src/juno_scmi_clock.c
@@ -14,6 +14,8 @@
 #include <fwk_log.h>
 #include <fwk_status.h>
 
+#include <inttypes.h>
+
 int mod_scmi_clock_rate_set_policy(
     enum mod_scmi_clock_policy_status *policy_status,
     enum mod_clock_round_mode *round_mode,
@@ -22,7 +24,8 @@ int mod_scmi_clock_rate_set_policy(
     uint32_t clock_dev_id)
 {
     FWK_LOG_TRACE(
-        "[SCMI-CLK] Set Clock Rate Policy Handler agent: %d clock: %d\n",
+        "[SCMI-CLK] Set Clock Rate Policy Handler agent: %u clock: %" PRIu32
+        "\n",
         fwk_id_get_element_idx(service_id),
         clock_dev_id);
 


### PR DESCRIPTION
A debug trace message has the wrong format breaking
the juno build when LOG_LEVEL=TRACE.

Change-Id: Ie901bdedb87667ec9e28359ccf43d4b9d9512275
Signed-off-by: Jim Quigley <jim.quigley@arm.com>