### PR TITLE
SCMI_PERF: Describe Fast Channels API should return NOT_SUPPORTED

### DIFF
--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -804,7 +804,11 @@ static int scmi_perf_describe_fast_channels(fwk_id_t service_id,
 
     domain = &(*scmi_perf_ctx.config->domains)[parameters->domain_id];
 
-    fwk_assert(domain->fast_channels_addr_scp != 0x0);
+    if (domain->fast_channels_addr_scp == 0x0) {
+        return_values.status = SCMI_NOT_SUPPORTED;
+
+        goto exit;
+    }
 
     switch (parameters->message_id) {
     case MOD_SCMI_PERF_LEVEL_GET:


### PR DESCRIPTION
If the fast channel is not implemented for the platform the
describe_fast_channels() API should return NO_SUPPORTED.

Change-Id: I9a53037831428e47f73d8e102bec120088f6ba19
Signed-off-by: Jim Quigley <jim.quigley@arm.com>