### PR TITLE
fwk: Remove dependency on RTX threads

### DIFF
--- a/framework/test/test_fwk_multi_thread_create.c
+++ b/framework/test/test_fwk_multi_thread_create.c
@@ -172,7 +172,6 @@ static int test_suite_setup(void)
 
 static void test_case_setup(void)
 {
-
     fwk_mm_calloc_return_null = UINT_MAX;
     fwk_mm_calloc_call_count = 0;
     fwk_interrupt_get_current_return_val = FWK_SUCCESS;
@@ -241,7 +240,7 @@ static void test_create_thread_memory_allocation_failed(void)
     fwk_id_t id = FWK_ID_MODULE(0x1);
 
     /* Thread memory allocation failed */
-    fwk_mm_calloc_return_null = 3;
+    fwk_mm_calloc_return_null = 1;
     status = fwk_thread_create(id);
     assert(status == FWK_E_NOMEM);
 }

--- a/product/juno/scp_ramfw/rtx_config.c
+++ b/product/juno/scp_ramfw/rtx_config.c
@@ -10,6 +10,8 @@
 #include <rtx_lib.c>
 #include <rtx_os.h>
 
+#include <fwk_mm.h>
+
 #include <fmw_cmsis.h>
 
 #include <stdbool.h>
@@ -78,4 +80,19 @@ uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
     }
 
     osRtxIdleThread(object_id);
+}
+
+uint32_t osRtxMemoryInit(void *mem, uint32_t size)
+{
+    return 1;
+}
+
+void *osRtxMemoryAlloc(void *mem, uint32_t size, uint32_t type)
+{
+    return fwk_mm_alloc(1, size);
+}
+
+uint32_t osRtxMemoryFree(void *mem, void *block)
+{
+    return 1;
 }

--- a/product/n1sdp/mcp_ramfw/rtx_config.c
+++ b/product/n1sdp/mcp_ramfw/rtx_config.c
@@ -10,6 +10,8 @@
 #include <rtx_lib.c>
 #include <rtx_os.h>
 
+#include <fwk_mm.h>
+
 #include <fmw_cmsis.h>
 
 #include <stdbool.h>
@@ -35,4 +37,19 @@ __NO_RETURN void osRtxIdleThread(void *argument)
 uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
 {
     osRtxIdleThread(object_id);
+}
+
+uint32_t osRtxMemoryInit(void *mem, uint32_t size)
+{
+    return 1;
+}
+
+void *osRtxMemoryAlloc(void *mem, uint32_t size, uint32_t type)
+{
+    return fwk_mm_alloc(1, size);
+}
+
+uint32_t osRtxMemoryFree(void *mem, void *block)
+{
+    return 1;
 }

--- a/product/n1sdp/scp_ramfw/rtx_config.c
+++ b/product/n1sdp/scp_ramfw/rtx_config.c
@@ -10,6 +10,8 @@
 #include <rtx_lib.c>
 #include <rtx_os.h>
 
+#include <fwk_mm.h>
+
 #include <fmw_cmsis.h>
 
 #include <stdbool.h>
@@ -35,4 +37,19 @@ __NO_RETURN void osRtxIdleThread(void *argument)
 uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
 {
     osRtxIdleThread(object_id);
+}
+
+uint32_t osRtxMemoryInit(void *mem, uint32_t size)
+{
+    return 1;
+}
+
+void *osRtxMemoryAlloc(void *mem, uint32_t size, uint32_t type)
+{
+    return fwk_mm_alloc(1, size);
+}
+
+uint32_t osRtxMemoryFree(void *mem, void *block)
+{
+    return 1;
 }

--- a/product/rddaniel/scp_ramfw/rtx_config.c
+++ b/product/rddaniel/scp_ramfw/rtx_config.c
@@ -10,6 +10,8 @@
 #include <rtx_lib.c>
 #include <rtx_os.h>
 
+#include <fwk_mm.h>
+
 #include <fmw_cmsis.h>
 
 #include <stdbool.h>
@@ -35,4 +37,19 @@ __NO_RETURN void osRtxIdleThread(void *argument)
 uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
 {
     osRtxIdleThread(object_id);
+}
+
+uint32_t osRtxMemoryInit(void *mem, uint32_t size)
+{
+    return 1;
+}
+
+void *osRtxMemoryAlloc(void *mem, uint32_t size, uint32_t type)
+{
+    return fwk_mm_alloc(1, size);
+}
+
+uint32_t osRtxMemoryFree(void *mem, void *block)
+{
+    return 1;
 }

--- a/product/rddanielxlr/scp_ramfw/rtx_config.c
+++ b/product/rddanielxlr/scp_ramfw/rtx_config.c
@@ -10,6 +10,8 @@
 #include <rtx_lib.c>
 #include <rtx_os.h>
 
+#include <fwk_mm.h>
+
 #include <fmw_cmsis.h>
 
 #include <stdbool.h>
@@ -35,4 +37,19 @@ __NO_RETURN void osRtxIdleThread(void *argument)
 uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
 {
     osRtxIdleThread(object_id);
+}
+
+uint32_t osRtxMemoryInit(void *mem, uint32_t size)
+{
+    return 1;
+}
+
+void *osRtxMemoryAlloc(void *mem, uint32_t size, uint32_t type)
+{
+    return fwk_mm_alloc(1, size);
+}
+
+uint32_t osRtxMemoryFree(void *mem, void *block)
+{
+    return 1;
 }

--- a/product/rdn1e1/scp_ramfw/rtx_config.c
+++ b/product/rdn1e1/scp_ramfw/rtx_config.c
@@ -10,6 +10,8 @@
 #include <rtx_lib.c>
 #include <rtx_os.h>
 
+#include <fwk_mm.h>
+
 #include <fmw_cmsis.h>
 
 #include <stdbool.h>
@@ -35,4 +37,19 @@ __NO_RETURN void osRtxIdleThread(void *argument)
 uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
 {
     osRtxIdleThread(object_id);
+}
+
+uint32_t osRtxMemoryInit(void *mem, uint32_t size)
+{
+    return 1;
+}
+
+void *osRtxMemoryAlloc(void *mem, uint32_t size, uint32_t type)
+{
+    return fwk_mm_alloc(1, size);
+}
+
+uint32_t osRtxMemoryFree(void *mem, void *block)
+{
+    return 1;
 }

--- a/product/sgi575/scp_ramfw/rtx_config.c
+++ b/product/sgi575/scp_ramfw/rtx_config.c
@@ -10,6 +10,8 @@
 #include <rtx_lib.c>
 #include <rtx_os.h>
 
+#include <fwk_mm.h>
+
 #include <fmw_cmsis.h>
 
 #include <stdbool.h>
@@ -35,4 +37,19 @@ __NO_RETURN void osRtxIdleThread(void *argument)
 uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
 {
     osRtxIdleThread(object_id);
+}
+
+uint32_t osRtxMemoryInit(void *mem, uint32_t size)
+{
+    return 1;
+}
+
+void *osRtxMemoryAlloc(void *mem, uint32_t size, uint32_t type)
+{
+    return fwk_mm_alloc(1, size);
+}
+
+uint32_t osRtxMemoryFree(void *mem, void *block)
+{
+    return 1;
 }

--- a/product/sgm775/scp_ramfw/rtx_config.c
+++ b/product/sgm775/scp_ramfw/rtx_config.c
@@ -10,6 +10,8 @@
 #include <rtx_lib.c>
 #include <rtx_os.h>
 
+#include <fwk_mm.h>
+
 #include <fmw_cmsis.h>
 
 #include <stdbool.h>
@@ -78,4 +80,19 @@ uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
     }
 
     osRtxIdleThread(object_id);
+}
+
+uint32_t osRtxMemoryInit(void *mem, uint32_t size)
+{
+    return 1;
+}
+
+void *osRtxMemoryAlloc(void *mem, uint32_t size, uint32_t type)
+{
+    return fwk_mm_alloc(1, size);
+}
+
+uint32_t osRtxMemoryFree(void *mem, void *block)
+{
+    return 1;
 }

--- a/product/sgm776/scp_ramfw/rtx_config.c
+++ b/product/sgm776/scp_ramfw/rtx_config.c
@@ -10,6 +10,8 @@
 #include <rtx_lib.c>
 #include <rtx_os.h>
 
+#include <fwk_mm.h>
+
 #include <fmw_cmsis.h>
 
 #include <stdbool.h>
@@ -78,4 +80,19 @@ uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
     }
 
     osRtxIdleThread(object_id);
+}
+
+uint32_t osRtxMemoryInit(void *mem, uint32_t size)
+{
+    return 1;
+}
+
+void *osRtxMemoryAlloc(void *mem, uint32_t size, uint32_t type)
+{
+    return fwk_mm_alloc(1, size);
+}
+
+uint32_t osRtxMemoryFree(void *mem, void *block)
+{
+    return 1;
 }

--- a/product/synquacer/scp_ramfw/rtx_config.c
+++ b/product/synquacer/scp_ramfw/rtx_config.c
@@ -13,6 +13,7 @@
 #include <mod_synquacer_system.h>
 
 #include <fwk_log.h>
+#include <fwk_mm.h>
 
 #include <fmw_cmsis.h>
 
@@ -87,4 +88,19 @@ uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
     }
 
     osRtxIdleThread(object_id);
+}
+
+uint32_t osRtxMemoryInit(void *mem, uint32_t size)
+{
+    return 1;
+}
+
+void *osRtxMemoryAlloc(void *mem, uint32_t size, uint32_t type)
+{
+    return fwk_mm_alloc(1, size);
+}
+
+uint32_t osRtxMemoryFree(void *mem, void *block)
+{
+    return 1;
 }

--- a/product/tc0/scp_ramfw/rtx_config.c
+++ b/product/tc0/scp_ramfw/rtx_config.c
@@ -10,6 +10,8 @@
 #include <rtx_lib.c>
 #include <rtx_os.h>
 
+#include <fwk_mm.h>
+
 #include <fmw_cmsis.h>
 
 #include <stdbool.h>
@@ -35,4 +37,19 @@ __NO_RETURN void osRtxIdleThread(void *argument)
 uint32_t osRtxErrorNotify(uint32_t code, void *object_id)
 {
     osRtxIdleThread(object_id);
+}
+
+uint32_t osRtxMemoryInit(void *mem, uint32_t size)
+{
+    return 1;
+}
+
+void *osRtxMemoryAlloc(void *mem, uint32_t size, uint32_t type)
+{
+    return fwk_mm_alloc(1, size);
+}
+
+uint32_t osRtxMemoryFree(void *mem, void *block)
+{
+    return 1;
 }


### PR DESCRIPTION
The multithreaded implementation of the framework currently depends
directly on Keil RTX because it directly allocates the thread control
block itself.

This change instead replaces RTX's memory allocator with the framework's
memory allocator in a way that RTX can now allocate its own threads
through the generic CMSIS-RTOS interface.

Change-Id: Ie1bf2760a8f21c38a9466ff945d553e0e293a363
Signed-off-by: Chris Kay <chris.kay@arm.com>