### PR TITLE
SCMI_PERF: Domain fast channel attribute should only be set if channe…

### DIFF
--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -288,7 +288,8 @@ static int scmi_perf_domain_attributes_handler(fwk_id_t service_id,
     notifications = true;
 #endif
 #ifdef BUILD_HAS_FAST_CHANNELS
-    fast_channels = true;
+    if (domain->fast_channels_addr_scp != 0x0)
+        fast_channels = true;
 #endif
     return_values = (struct scmi_perf_domain_attributes_p2a) {
         .status = SCMI_SUCCESS,


### PR DESCRIPTION
…l available

The domain fast channel attribute should only be set to true if the fast
channel is available for that domain.

Change-Id: I24333d80937a83ee8272877ca418cf5d1f687f58
Signed-off-by: Jim Quigley <jim.quigley@arm.com>