### PR TITLE
SCMI: Split performance domain fast channel commands

### DIFF
--- a/module/scmi_perf/include/mod_scmi_perf.h
+++ b/module/scmi_perf/include/mod_scmi_perf.h
@@ -42,6 +42,40 @@ enum mod_scmi_perf_permissions {
 };
 
 /*!
+ * \brief Fast channels address index
+ */
+enum mod_scmi_perf_fast_channels_addr_index {
+    MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_SET,
+    MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_SET,
+    MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_GET,
+    MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_GET,
+    MOD_SMCI_PERF_FAST_CHANNEL_ADDR_INDEX_COUNT
+};
+/*!
+ *\brief Per-Domain Fast Channel Limit in shared memory.
+ */
+struct mod_scmi_perf_fast_channel_limit {
+    /*! Performance limit max. */
+    uint32_t range_max;
+    /*! Performance limit min. */
+    uint32_t range_min;
+};
+
+/*!
+ *\brief Fast channels memory offset
+ */
+enum mod_scmi_perf_fast_channel_memory_offset {
+    MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_SET = 0,
+    MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_SET = sizeof(uint32_t),
+    MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_GET =
+        sizeof(uint32_t) + sizeof(struct mod_scmi_perf_fast_channel_limit),
+    MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_GET =
+        sizeof(uint32_t) * 2 + sizeof(struct mod_scmi_perf_fast_channel_limit),
+    MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL = sizeof(uint32_t) * 2 +
+        sizeof(struct mod_scmi_perf_fast_channel_limit) * 2
+};
+
+/*!
  * \brief Performance domain configuration data.
  */
 struct mod_scmi_perf_domain_config {
@@ -55,14 +89,14 @@ struct mod_scmi_perf_domain_config {
      * \note May be set to 0x0, in which case support for fast
      *       channels is disabled for the platform.
      */
-    uint64_t fast_channels_addr_scp;
+    uint64_t *fast_channels_addr_scp;
 
-   /*!
+    /*!
      * \brief Agent Domain fast channel address
      *
      * \details Address of shared memory for the agent
      */
-    uint64_t fast_channels_addr_ap;
+    uint64_t *fast_channels_addr_ap;
 
     /*!
      * \brief Rate limit in microsecs
@@ -71,20 +105,6 @@ struct mod_scmi_perf_domain_config {
 
     /*! Flag indicating that statistics are collected for this domain */
     bool stats_collected;
-};
-
-/*!
- *\brief Domain Fast Channel
- *
- *\note Layout of the Per-Domain Fast Channel in shared memory.
- */
-struct mod_scmi_perf_fast_channel {
-    FWK_R uint32_t set_level; /*!< Performance level to be set */
-    FWK_R uint32_t set_limit_range_max; /*!< max limit to be set */
-    FWK_R uint32_t set_limit_range_min; /*!< min limit to be set */
-    FWK_W uint32_t get_level; /*!< Current performance level */
-    FWK_W uint32_t get_limit_range_max; /*!< Current limits, max */
-    FWK_W uint32_t get_limit_range_min; /*!< Current limits, min */
 };
 
 /*!

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -92,6 +92,15 @@ static unsigned int payload_size_table[] = {
     [MOD_SCMI_PERF_NOTIFY_LEVEL] = sizeof(struct scmi_perf_notify_level_a2p)
 };
 
+static unsigned int fast_channel_elem_size[] = {
+    [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_SET] = sizeof(uint32_t),
+    [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_SET] =
+        sizeof(struct mod_scmi_perf_fast_channel_limit),
+    [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_GET] = sizeof(uint32_t),
+    [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_GET] =
+        sizeof(struct mod_scmi_perf_fast_channel_limit)
+};
+
 struct perf_operations {
     /*
      * Service identifier currently requesting operation.
@@ -477,7 +486,6 @@ static int scmi_perf_limits_set_handler(fwk_id_t service_id,
         return_values.status = SCMI_SUCCESS;
         goto exit;
     }
-
     status = scmi_perf_ctx.dvfs_api->set_frequency_limits(
         domain_id, agent_id,
         &((struct mod_dvfs_frequency_limits) {
@@ -575,7 +583,6 @@ static int scmi_perf_level_set_handler(fwk_id_t service_id,
     };
     uint64_t perf_level;
     enum mod_scmi_perf_policy_status policy_status;
-
     parameters = (const struct scmi_perf_level_set_a2p *)payload;
 
     if (parameters->domain_id >= scmi_perf_ctx.domain_count) {
@@ -615,7 +622,6 @@ static int scmi_perf_level_set_handler(fwk_id_t service_id,
         return_values.status = SCMI_SUCCESS;
         goto exit;
     }
-
     status = scmi_perf_ctx.dvfs_api->set_frequency(domain_id,
         agent_id, perf_level);
 
@@ -791,7 +797,7 @@ static int scmi_perf_describe_fast_channels(fwk_id_t service_id,
     struct scmi_perf_describe_fc_p2a return_values = {
         .status = SCMI_GENERIC_ERROR,
     };
-    uint32_t chan_size, chan_offset;
+    uint32_t chan_size, chan_index;
 
     parameters = (const struct scmi_perf_describe_fc_a2p *)payload;
 
@@ -812,25 +818,27 @@ static int scmi_perf_describe_fast_channels(fwk_id_t service_id,
 
     switch (parameters->message_id) {
     case MOD_SCMI_PERF_LEVEL_GET:
-        chan_offset = offsetof(struct mod_scmi_perf_fast_channel, get_level);
-        chan_size = sizeof(uint32_t);
+        chan_index = MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_GET;
+        chan_size =
+            fast_channel_elem_size[MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_GET];
         break;
 
     case MOD_SCMI_PERF_LEVEL_SET:
-        chan_offset = offsetof(struct mod_scmi_perf_fast_channel, set_level);
-        chan_size = sizeof(uint32_t);
+        chan_index = MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_SET;
+        chan_size =
+            fast_channel_elem_size[MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_SET];
         break;
 
     case MOD_SCMI_PERF_LIMITS_SET:
-        chan_offset = offsetof(struct mod_scmi_perf_fast_channel,
-            set_limit_range_max);
-        chan_size = sizeof(uint32_t) * 2;
+        chan_index = MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_SET;
+        chan_size =
+            fast_channel_elem_size[MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_SET];
         break;
 
     case MOD_SCMI_PERF_LIMITS_GET:
-        chan_offset = offsetof(struct mod_scmi_perf_fast_channel,
-            get_limit_range_max);
-        chan_size = sizeof(uint32_t) * 2;
+        chan_index = MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_GET;
+        chan_size =
+            fast_channel_elem_size[MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_GET];
         break;
 
     default:
@@ -838,14 +846,18 @@ static int scmi_perf_describe_fast_channels(fwk_id_t service_id,
         goto exit;
 
     }
-
+    if (domain->fast_channels_addr_ap == 0x0 ||
+        domain->fast_channels_addr_ap[chan_index] == 0x0) {
+        return_values.status = SCMI_NOT_SUPPORTED;
+        goto exit;
+    }
     return_values.status = SCMI_SUCCESS;
     return_values.attributes = 0; /* Doorbell not supported */
     return_values.rate_limit = scmi_perf_ctx.fast_channels_rate_limit;
-    return_values.chan_addr_low = (uint32_t)
-        (domain->fast_channels_addr_ap & ~0UL) + chan_offset;
+    return_values.chan_addr_low =
+        (uint32_t)(domain->fast_channels_addr_ap[chan_index] & ~0UL);
     return_values.chan_addr_high =
-        (domain->fast_channels_addr_ap >> 32);
+        (domain->fast_channels_addr_ap[chan_index] >> 32);
     return_values.chan_size = chan_size;
 
 exit:
@@ -862,38 +874,38 @@ exit:
 static void fast_channel_callback(uintptr_t param)
 {
     const struct mod_scmi_perf_domain_config *domain;
-    struct mod_scmi_perf_fast_channel *fc;
+    struct mod_scmi_perf_fast_channel_limit *set_limit;
+    uint32_t *set_level;
     unsigned int i;
 
     for (i = 0; i < scmi_perf_ctx.domain_count; i++) {
         domain = &(*scmi_perf_ctx.config->domains)[i];
         if (domain->fast_channels_addr_scp != 0x0) {
-            fc = (struct mod_scmi_perf_fast_channel *)
-                ((uintptr_t)domain->fast_channels_addr_scp);
+            set_limit = (struct mod_scmi_perf_fast_channel_limit
+                             *)((uintptr_t)domain->fast_channels_addr_scp
+                                    [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_SET]);
+            set_level =
+                (uint32_t *)((uintptr_t)domain->fast_channels_addr_scp
+                                 [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_SET]);
             /*
-             * Check for set_level/set_limits request
+             * Check for set_level
              */
-            if ((fc->set_level == 0) && (fc->set_limit_range_max == 0) &&
-                (fc->set_limit_range_min == 0))
-                continue;
-
-            if (fc->set_level == fc->get_level) {
-                if ((fc->set_limit_range_max == fc->get_limit_range_max) &&
-                    (fc->set_limit_range_min == fc->get_limit_range_min))
-                    continue;
-                if ((fc->set_limit_range_max == 0) &&
-                    (fc->set_limit_range_min == 0))
+            if (set_level != 0x0 && *set_level != 0) {
+                scmi_perf_ctx.dvfs_api->set_frequency(
+                    FWK_ID_ELEMENT(FWK_MODULE_IDX_DVFS, i),
+                    0,
+                    (uint64_t)(*set_level));
+            }
+            if (set_limit != 0) {
+                if ((set_limit->range_max == 0) && (set_limit->range_min == 0))
                     continue;
                 scmi_perf_ctx.dvfs_api->set_frequency_limits(
                     FWK_ID_ELEMENT(FWK_MODULE_IDX_DVFS, i),
-                    0, &((struct mod_dvfs_frequency_limits) {
-                   .minimum = fc->set_limit_range_min,
-                   .maximum = fc->set_limit_range_max,
-                   }));
-            } else if (fc->set_level != 0) {
-                scmi_perf_ctx.dvfs_api->set_frequency(
-                    FWK_ID_ELEMENT(FWK_MODULE_IDX_DVFS, i),
-                    0, (uint64_t)fc->set_level);
+                    0,
+                    &((struct mod_dvfs_frequency_limits){
+                        .minimum = set_limit->range_min,
+                        .maximum = set_limit->range_max,
+                    }));
             }
         }
     }
@@ -1005,18 +1017,20 @@ static void scmi_perf_notify_limits(fwk_id_t domain_id,
     fwk_id_t id;
     int i, idx;
     const struct mod_scmi_perf_domain_config *domain;
-    struct mod_scmi_perf_fast_channel *fc;
+    struct mod_scmi_perf_fast_channel_limit *get_limit;
 
     idx = fwk_id_get_element_idx(domain_id);
 
     domain = &(*scmi_perf_ctx.config->domains)[idx];
     if (domain->fast_channels_addr_scp != 0x0) {
-        fc = (struct mod_scmi_perf_fast_channel *)
-            ((uintptr_t)domain->fast_channels_addr_scp);
-        fc->get_limit_range_max = range_max;
-        fc->get_limit_range_min = range_min;
+        get_limit = (struct mod_scmi_perf_fast_channel_limit
+                         *)((uintptr_t)domain->fast_channels_addr_scp
+                                [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_GET]);
+        if (get_limit != 0x0) { /* note: get_limit may not be defined */
+            get_limit->range_max = range_max;
+            get_limit->range_min = range_min;
+        }
     }
-
 
     limits_changed.agent_id = (uint32_t)cookie;
     /* note: skip agent 0, platform agent */
@@ -1046,7 +1060,7 @@ static void scmi_perf_notify_level(fwk_id_t domain_id,
     fwk_id_t id;
     int i, idx;
     const struct mod_scmi_perf_domain_config *domain;
-    struct mod_scmi_perf_fast_channel *fc;
+    uint64_t *get_level;
 #ifdef BUILD_HAS_STATISTICS
     size_t level_id;
     int status;
@@ -1064,9 +1078,10 @@ static void scmi_perf_notify_level(fwk_id_t domain_id,
 
     domain = &(*scmi_perf_ctx.config->domains)[idx];
     if (domain->fast_channels_addr_scp != 0x0) {
-        fc = (struct mod_scmi_perf_fast_channel *)
-            ((uintptr_t)domain->fast_channels_addr_scp);
-        fc->get_level = level;
+        get_level = (uint64_t *)((uintptr_t)domain->fast_channels_addr_scp
+                                     [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_GET]);
+        if (get_level != 0x0) /* note: get_level may not be defined */
+            *get_level = level;
     }
 
     level_changed.agent_id = (uint32_t)cookie;
@@ -1281,9 +1296,9 @@ static int scmi_perf_start(fwk_id_t id)
 {
     int status = FWK_SUCCESS;
     const struct mod_scmi_perf_domain_config *domain;
-    struct mod_scmi_perf_fast_channel *fc;
+    void *fc_elem;
     uint32_t fc_interval_msecs;
-    unsigned int i;
+    unsigned int i, j;
 
     /*
      * Set up the Fast Channel polling if required
@@ -1307,9 +1322,11 @@ static int scmi_perf_start(fwk_id_t id)
     for (i = 0; i < scmi_perf_ctx.domain_count; i++) {
         domain = &(*scmi_perf_ctx.config->domains)[i];
         if (domain->fast_channels_addr_scp != 0x0) {
-            fc = (struct mod_scmi_perf_fast_channel *)
-                ((uintptr_t)domain->fast_channels_addr_scp);
-            memset((void *)fc, 0, sizeof(struct mod_scmi_perf_fast_channel));
+            for (j = 0; j < MOD_SMCI_PERF_FAST_CHANNEL_ADDR_INDEX_COUNT; j++) {
+                fc_elem = (void *)(uintptr_t)domain->fast_channels_addr_scp[j];
+                if (fc_elem != 0x0)
+                    memset(fc_elem, 0, fast_channel_elem_size[j]);
+            }
         }
     }
 

--- a/product/juno/scp_ramfw/config_scmi_perf.c
+++ b/product/juno/scp_ramfw/config_scmi_perf.c
@@ -33,8 +33,46 @@ static const struct mod_scmi_perf_domain_config domains[] = {
             [JUNO_SCMI_AGENT_IDX_PSCI] = 0 /* No Access */,
         },
 #ifdef BUILD_HAS_FAST_CHANNELS
-        .fast_channels_addr_scp = SCMI_FAST_CHANNEL_BASE,
-        .fast_channels_addr_ap = SCMI_FAST_CHANNEL_BASE - EXTERNAL_DEV_BASE,
+        .fast_channels_addr_scp = (uint64_t[]) {
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_LITTLE),
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_LITTLE),
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_LITTLE),
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_LITTLE),
+        },
+        .fast_channels_addr_ap = (uint64_t[]) {
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_LITTLE)
+                - EXTERNAL_DEV_BASE,
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_LITTLE)
+                - EXTERNAL_DEV_BASE,
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_LITTLE)
+                - EXTERNAL_DEV_BASE,
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_LITTLE)
+                - EXTERNAL_DEV_BASE,
+        },
 #endif
 #ifdef BUILD_HAS_STATISTICS
         .stats_collected = true,
@@ -47,11 +85,46 @@ static const struct mod_scmi_perf_domain_config domains[] = {
             [JUNO_SCMI_AGENT_IDX_PSCI] = 0 /* No Access */,
         },
 #ifdef BUILD_HAS_FAST_CHANNELS
-        .fast_channels_addr_scp = SCMI_FAST_CHANNEL_BASE +
-            sizeof(struct mod_scmi_perf_fast_channel),
-        .fast_channels_addr_ap = SCMI_FAST_CHANNEL_BASE +
-            sizeof(struct mod_scmi_perf_fast_channel) -
-            EXTERNAL_DEV_BASE,
+.fast_channels_addr_scp = (uint64_t[]) {
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_BIG),
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_BIG),
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_BIG),
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_BIG),
+        },
+        .fast_channels_addr_ap = (uint64_t[]) {
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_BIG)
+                - EXTERNAL_DEV_BASE,
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_BIG)
+                - EXTERNAL_DEV_BASE,
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_BIG)
+                - EXTERNAL_DEV_BASE,
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_BIG)
+                - EXTERNAL_DEV_BASE,
+        },
 #endif
 #ifdef BUILD_HAS_STATISTICS
         .stats_collected = true,
@@ -64,11 +137,46 @@ static const struct mod_scmi_perf_domain_config domains[] = {
             [JUNO_SCMI_AGENT_IDX_PSCI] = 0 /* No Access */,
         },
 #ifdef BUILD_HAS_FAST_CHANNELS
-        .fast_channels_addr_scp = SCMI_FAST_CHANNEL_BASE +
-            (sizeof(struct mod_scmi_perf_fast_channel) * 2),
-        .fast_channels_addr_ap = SCMI_FAST_CHANNEL_BASE +
-            (sizeof(struct mod_scmi_perf_fast_channel) * 2) -
-            EXTERNAL_DEV_BASE,
+        .fast_channels_addr_scp = (uint64_t[]) {
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_GPU),
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_GPU),
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_GPU),
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_GPU),
+        },
+        .fast_channels_addr_ap = (uint64_t[]) {
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_GPU)
+                - EXTERNAL_DEV_BASE,
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_SET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_SET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_GPU)
+                - EXTERNAL_DEV_BASE,
+            [MOD_SMCI_PERF_FAST_CHANNEL_LEVEL_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LEVEL_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_GPU)
+                - EXTERNAL_DEV_BASE,
+            [MOD_SMCI_PERF_FAST_CHANNEL_LIMIT_GET] = SCMI_FAST_CHANNEL_BASE
+                + MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_LIMIT_GET
+                + (MOD_SMCI_PERF_FAST_CHANNEL_OFFSET_TOTAL
+                * DVFS_ELEMENT_IDX_GPU)
+                - EXTERNAL_DEV_BASE,
+        },
 #endif
 #ifdef BUILD_HAS_STATISTICS
         .stats_collected = true,


### PR DESCRIPTION
In this patch fast channels are separated in different blocks,
to allow platforms to define each fast channel command separately
Also, the fast channel memory layout has been redefined for Juno
platform

Change-Id: Ic4e51251a43a340557c3d39a3422eae6de50371d
Signed-off-by: Leandro Belli <leandro.belli@arm.com>