### PR TITLE
scmi_power_domain: Fix device set state

### DIFF
--- a/module/scmi_power_domain/src/mod_scmi_power_domain.c
+++ b/module/scmi_power_domain/src/mod_scmi_power_domain.c
@@ -517,8 +517,7 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
             goto exit;
         }
 
-        status =
-            scmi_pd_ctx.pd_api->set_state_async(pd_id, false, pd_power_state);
+        status = scmi_pd_ctx.pd_api->set_state(pd_id, pd_power_state);
         break;
 
     case MOD_PD_TYPE_SYSTEM:


### PR DESCRIPTION
This patch fixes a bug in the device set state.
For devices, the set_state api should be used and not the
set_state_async.

Change-Id: Iff76d68b4a506146d4d24ca215b4b8dd47678743
Signed-off-by: Tarek El-Sherbiny <tarek.el-sherbiny@arm.com>