### PR TITLE
mod_scmi_perf: Fix fast channels wrong response

### DIFF
--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -911,7 +911,7 @@ static int scmi_perf_describe_fast_channels(fwk_id_t service_id,
         break;
 
     default:
-        return_values.status = SCMI_NOT_SUPPORTED;
+        return_values.status = SCMI_NOT_FOUND;
         goto exit;
 
     }


### PR DESCRIPTION
The SCMI module was wrongly responding with a
SCMI_NOT_SUPPORTED error instead of a SCMI_NOT_FOUND,
when an invalid message id was sent for the command:
DESCRIBE_FASTCHANNELS. So, the modules were not
conformant to the SCMI specs.

Change-Id: I34104224815ee74eb1303ef0793e5dff99bda14a
Signed-off-by: Luca Vizzarro <Luca.Vizzarro@arm.com>