### PR TITLE
build: Remove packed attribute from data structs

### DIFF
--- a/module/scmi/include/internal/scmi.h
+++ b/module/scmi/include/internal/scmi.h
@@ -79,7 +79,7 @@ enum scmi_channel_type {
 /*!
  * \brief Generic platform-to-agent PROTOCOL_VERSION structure.
  */
-struct __attribute((packed)) scmi_protocol_version_p2a {
+struct scmi_protocol_version_p2a {
     int32_t status;
     uint32_t version;
 };
@@ -87,7 +87,7 @@ struct __attribute((packed)) scmi_protocol_version_p2a {
 /*!
  * \brief Generic platform-to-agent PROTOCOL_ATTRIBUTES structure.
  */
-struct __attribute((packed)) scmi_protocol_attributes_p2a {
+struct scmi_protocol_attributes_p2a {
     int32_t status;
     uint32_t attributes;
 };
@@ -95,14 +95,14 @@ struct __attribute((packed)) scmi_protocol_attributes_p2a {
 /*!
  * \brief Generic agent-to-platform PROTOCOL_MESSAGE_ATTRIBUTES structure.
  */
-struct __attribute((packed)) scmi_protocol_message_attributes_a2p {
+struct scmi_protocol_message_attributes_a2p {
     uint32_t message_id;
 };
 
 /*!
  * \brief Generic platform-to-agent PROTOCOL_MESSAGE_ATTRIBUTES structure.
  */
-struct __attribute((packed)) scmi_protocol_message_attributes_p2a {
+struct scmi_protocol_message_attributes_p2a {
     int32_t status;
     uint32_t attributes;
 };

--- a/module/scmi/include/internal/scmi_base.h
+++ b/module/scmi/include/internal/scmi_base.h
@@ -33,7 +33,7 @@
 /*
  * BASE_DISCOVER_VENDOR
  */
-struct __attribute((packed)) scmi_base_discover_vendor_p2a {
+struct scmi_base_discover_vendor_p2a {
     int32_t status;
     char vendor_identifier[16];
 };
@@ -41,7 +41,7 @@ struct __attribute((packed)) scmi_base_discover_vendor_p2a {
 /*
  * BASE_DISCOVER_SUB_VENDOR
  */
-struct __attribute((packed)) scmi_base_discover_sub_vendor_p2a {
+struct scmi_base_discover_sub_vendor_p2a {
     int32_t status;
     char sub_vendor_identifier[16];
 };
@@ -54,11 +54,11 @@ struct __attribute((packed)) scmi_base_discover_sub_vendor_p2a {
 /*
  * BASE_DISCOVER_LIST_PROTOCOLS
  */
-struct __attribute((packed)) scmi_base_discover_list_protocols_a2p {
+struct scmi_base_discover_list_protocols_a2p {
     uint32_t skip;
 };
 
-struct __attribute((packed)) scmi_base_discover_list_protocols_p2a {
+struct scmi_base_discover_list_protocols_p2a {
     int32_t status;
     uint32_t num_protocols;
     uint32_t protocols[];
@@ -67,11 +67,11 @@ struct __attribute((packed)) scmi_base_discover_list_protocols_p2a {
 /*
  * BASE_DISCOVER_AGENT
  */
-struct __attribute((packed)) scmi_base_discover_agent_a2p {
+struct scmi_base_discover_agent_a2p {
     uint32_t agent_id;
 };
 
-struct __attribute((packed)) scmi_base_discover_agent_p2a {
+struct scmi_base_discover_agent_p2a {
     int32_t status;
     char name[16];
 };

--- a/module/scmi_apcore/include/internal/scmi_apcore.h
+++ b/module/scmi_apcore/include/internal/scmi_apcore.h
@@ -42,13 +42,13 @@ enum scmi_apcore_command_id {
 #define SCMI_APCORE_RESET_ADDRESS_SET_LOCK_MASK \
     (UINT32_C(0x1) << SCMI_APCORE_RESET_ADDRESS_SET_LOCK_POS)
 
-struct __attribute((packed)) scmi_apcore_reset_address_set_a2p {
+struct scmi_apcore_reset_address_set_a2p {
     uint32_t reset_address_low;
     uint32_t reset_address_high;
     uint32_t attributes;
 };
 
-struct __attribute((packed)) scmi_apcore_reset_address_set_p2a {
+struct scmi_apcore_reset_address_set_p2a {
     int32_t status;
 };
 
@@ -61,7 +61,7 @@ struct __attribute((packed)) scmi_apcore_reset_address_set_p2a {
 #define SCMI_APCORE_RESET_ADDRESS_GET_LOCK_MASK \
     (UINT32_C(0x1) << SCMI_APCORE_RESET_ADDRESS_GET_LOCK_POS)
 
-struct __attribute((packed)) scmi_apcore_reset_address_get_p2a {
+struct scmi_apcore_reset_address_get_p2a {
     int32_t status;
     uint32_t reset_address_low;
     uint32_t reset_address_high;

--- a/module/scmi_clock/include/internal/scmi_clock.h
+++ b/module/scmi_clock/include/internal/scmi_clock.h
@@ -71,7 +71,7 @@ struct event_request_params {
 /*
  * Generic p2a
  */
-struct __attribute((packed)) scmi_clock_generic_p2a {
+struct scmi_clock_generic_p2a {
     int32_t status;
 };
 
@@ -112,13 +112,13 @@ struct __attribute((packed)) scmi_clock_generic_p2a {
             SCMI_CLOCK_ATTRIBUTES_ENABLED_MASK) \
     )
 
-struct __attribute((packed)) scmi_clock_attributes_a2p {
+struct scmi_clock_attributes_a2p {
     uint32_t clock_id;
 };
 
 #define SCMI_CLOCK_NAME_LENGTH_MAX 16
 
-struct __attribute((packed)) scmi_clock_attributes_p2a {
+struct scmi_clock_attributes_p2a {
     int32_t status;
     uint32_t attributes;
     char clock_name[SCMI_CLOCK_NAME_LENGTH_MAX];
@@ -128,11 +128,11 @@ struct __attribute((packed)) scmi_clock_attributes_p2a {
  * Clock Rate Get
  */
 
-struct __attribute((packed)) scmi_clock_rate_get_a2p {
+struct scmi_clock_rate_get_a2p {
     uint32_t clock_id;
 };
 
-struct __attribute((packed)) scmi_clock_rate_get_p2a {
+struct scmi_clock_rate_get_p2a {
     int32_t status;
     uint32_t rate[2];
 };
@@ -159,13 +159,13 @@ struct __attribute((packed)) scmi_clock_rate_get_p2a {
 #define SCMI_CLOCK_RATE_SET_ROUND_AUTO_MASK \
     (UINT32_C(0x1) << SCMI_CLOCK_RATE_SET_ROUND_AUTO_POS)
 
-struct __attribute((packed)) scmi_clock_rate_set_a2p {
+struct scmi_clock_rate_set_a2p {
     uint32_t flags;
     uint32_t clock_id;
     uint32_t rate[2];
 };
 
-struct __attribute((packed)) scmi_clock_rate_set_p2a {
+struct scmi_clock_rate_set_p2a {
     int32_t status;
 };
 
@@ -178,12 +178,12 @@ struct __attribute((packed)) scmi_clock_rate_set_p2a {
 #define SCMI_CLOCK_CONFIG_SET_ENABLE_MASK \
     (UINT32_C(0x1) << SCMI_CLOCK_CONFIG_SET_ENABLE_POS)
 
-struct __attribute((packed)) scmi_clock_config_set_a2p {
+struct scmi_clock_config_set_a2p {
     uint32_t clock_id;
     uint32_t attributes;
 };
 
-struct __attribute((packed)) scmi_clock_config_set_p2a {
+struct scmi_clock_config_set_p2a {
     int32_t status;
 };
 
@@ -222,17 +222,17 @@ struct __attribute((packed)) scmi_clock_config_set_p2a {
      (((MAILBOX_SIZE) - sizeof(struct scmi_clock_describe_rates_p2a))   \
         / sizeof(struct scmi_clock_rate)) : 0)
 
-struct __attribute((packed)) scmi_clock_rate {
+struct scmi_clock_rate {
     uint32_t low;
     uint32_t high;
 };
 
-struct __attribute((packed)) scmi_clock_describe_rates_a2p {
+struct scmi_clock_describe_rates_a2p {
     uint32_t clock_id;
     uint32_t rate_index;
 };
 
-struct __attribute((packed)) scmi_clock_describe_rates_p2a {
+struct scmi_clock_describe_rates_p2a {
     int32_t status;
     uint32_t num_rates_flags;
     struct scmi_clock_rate rates[];

--- a/module/scmi_perf/include/internal/scmi_perf.h
+++ b/module/scmi_perf/include/internal/scmi_perf.h
@@ -49,7 +49,7 @@ enum scmi_perf_notification_id {
             SCMI_PERF_PROTOCOL_ATTRIBUTES_NUM_DOMAINS_MASK) \
     )
 
-struct __attribute((packed)) scmi_perf_protocol_attributes_p2a {
+struct scmi_perf_protocol_attributes_p2a {
     int32_t status;
     uint32_t attributes;
     uint32_t statistics_address_low;
@@ -106,7 +106,7 @@ struct __attribute((packed)) scmi_perf_protocol_attributes_p2a {
             SCMI_PERF_DOMAIN_ATTRIBUTES_FAST_CHANNEL_MASK) \
     )
 
-struct __attribute((packed)) scmi_perf_domain_attributes_a2p {
+struct scmi_perf_domain_attributes_a2p {
     uint32_t domain_id;
 };
 
@@ -114,7 +114,7 @@ struct __attribute((packed)) scmi_perf_domain_attributes_a2p {
 #define SCMI_PERF_DOMAIN_RATE_LIMIT_MASK \
     (UINT32_C(0xFFFFF) << SCMI_PERF_DOMAIN_RATE_LIMIT_POS)
 
-struct __attribute((packed)) scmi_perf_domain_attributes_p2a {
+struct scmi_perf_domain_attributes_p2a {
     int32_t status;
     uint32_t attributes;
     uint32_t rate_limit;
@@ -140,13 +140,13 @@ struct __attribute((packed)) scmi_perf_domain_attributes_p2a {
     (((LATENCY) << SCMI_PERF_LEVEL_ATTRIBUTES_POS) & \
         SCMI_PERF_LEVEL_ATTRIBUTES_MASK)
 
-struct __attribute((packed)) scmi_perf_level {
+struct scmi_perf_level {
     uint32_t performance_level;
     uint32_t power_cost;
     uint32_t attributes;
 };
 
-struct __attribute((packed)) scmi_perf_describe_levels_a2p {
+struct scmi_perf_describe_levels_a2p {
     uint32_t domain_id;
     uint32_t level_index;
 };
@@ -165,7 +165,7 @@ struct __attribute((packed)) scmi_perf_describe_levels_a2p {
      (((REMAINING_LEVELS) << SCMI_PERF_NUM_LEVELS_REMAINING_LEVELS_POS) & \
         SCMI_PERF_NUM_LEVELS_REMAINING_LEVELS_MASK))
 
-struct __attribute((packed)) scmi_perf_describe_levels_p2a {
+struct scmi_perf_describe_levels_p2a {
     int32_t status;
     uint32_t num_levels;
 
@@ -176,13 +176,13 @@ struct __attribute((packed)) scmi_perf_describe_levels_p2a {
  * PERFORMANCE_LIMITS_SET
  */
 
-struct __attribute((packed)) scmi_perf_limits_set_a2p {
+struct scmi_perf_limits_set_a2p {
     uint32_t domain_id;
     uint32_t range_max;
     uint32_t range_min;
 };
 
-struct __attribute((packed)) scmi_perf_limits_set_p2a {
+struct scmi_perf_limits_set_p2a {
     int32_t status;
 };
 
@@ -190,11 +190,11 @@ struct __attribute((packed)) scmi_perf_limits_set_p2a {
  * PERFORMANCE_LIMITS_GET
  */
 
-struct __attribute((packed)) scmi_perf_limits_get_a2p {
+struct scmi_perf_limits_get_a2p {
     uint32_t domain_id;
 };
 
-struct __attribute((packed)) scmi_perf_limits_get_p2a {
+struct scmi_perf_limits_get_p2a {
     int32_t status;
     uint32_t range_max;
     uint32_t range_min;
@@ -204,12 +204,12 @@ struct __attribute((packed)) scmi_perf_limits_get_p2a {
  * PERFORMANCE_LEVEL_SET
  */
 
-struct __attribute((packed)) scmi_perf_level_set_a2p {
+struct scmi_perf_level_set_a2p {
     uint32_t domain_id;
     uint32_t performance_level;
 };
 
-struct __attribute((packed)) scmi_perf_level_set_p2a {
+struct scmi_perf_level_set_p2a {
     int32_t status;
 };
 
@@ -217,11 +217,11 @@ struct __attribute((packed)) scmi_perf_level_set_p2a {
  * PERFORMANCE_LEVEL_GET
  */
 
-struct __attribute((packed)) scmi_perf_level_get_a2p {
+struct scmi_perf_level_get_a2p {
     uint32_t domain_id;
 };
 
-struct __attribute((packed)) scmi_perf_level_get_p2a {
+struct scmi_perf_level_get_p2a {
     int32_t status;
     uint32_t performance_level;
 };
@@ -232,12 +232,12 @@ struct __attribute((packed)) scmi_perf_level_get_p2a {
 
 #define SCMI_PERF_NOTIFY_LIMITS_NOTIFY_ENABLE_MASK UINT32_C(0x1)
 
-struct __attribute((packed)) scmi_perf_notify_limits_a2p {
+struct scmi_perf_notify_limits_a2p {
     uint32_t domain_id;
     uint32_t notify_enable;
 };
 
-struct __attribute((packed)) scmi_perf_notify_limits_p2a {
+struct scmi_perf_notify_limits_p2a {
     int32_t status;
 };
 
@@ -247,19 +247,19 @@ struct __attribute((packed)) scmi_perf_notify_limits_p2a {
 
 #define SCMI_PERF_NOTIFY_LEVEL_NOTIFY_ENABLE_MASK UINT32_C(0x1)
 
-struct __attribute((packed)) scmi_perf_notify_level_a2p {
+struct scmi_perf_notify_level_a2p {
     uint32_t domain_id;
     uint32_t notify_enable;
 };
 
-struct __attribute((packed)) scmi_perf_notify_level_p2a {
+struct scmi_perf_notify_level_p2a {
     int32_t status;
 };
 
 /*
  * PERFORMANCE_LEVEL_CHANGED
  */
-struct __attribute((packed)) scmi_perf_level_changed {
+struct scmi_perf_level_changed {
     uint32_t agent_id;
     uint32_t domain_id;
     uint32_t performance_level;
@@ -268,7 +268,7 @@ struct __attribute((packed)) scmi_perf_level_changed {
 /*
  * PERFORMANCE_LIMITS_CHANGED
  */
-struct __attribute((packed)) scmi_perf_limits_changed {
+struct scmi_perf_limits_changed {
     uint32_t agent_id;
     uint32_t domain_id;
     uint32_t range_min;
@@ -279,12 +279,12 @@ struct __attribute((packed)) scmi_perf_limits_changed {
  * PERFORMANCE_DESCRIBE_FASTCHANNEL
  */
 
-struct __attribute((packed)) scmi_perf_describe_fc_a2p {
+struct scmi_perf_describe_fc_a2p {
     uint32_t domain_id;
     uint32_t message_id;
 };
 
-struct __attribute((packed)) scmi_perf_describe_fc_p2a {
+struct scmi_perf_describe_fc_p2a {
     int32_t status;
     uint32_t attributes;
     uint32_t rate_limit;

--- a/module/scmi_power_domain/include/internal/scmi_power_domain.h
+++ b/module/scmi_power_domain/include/internal/scmi_power_domain.h
@@ -35,7 +35,7 @@
  * PROTOCOL_ATTRIBUTES
  */
 
-struct __attribute((packed)) scmi_pd_protocol_attributes_p2a {
+struct scmi_pd_protocol_attributes_p2a {
     int32_t status;
     uint32_t attributes;
     uint32_t statistics_address_low;
@@ -47,14 +47,14 @@ struct __attribute((packed)) scmi_pd_protocol_attributes_p2a {
  * POWER_DOMAIN_ATTRIBUTES
  */
 
-struct __attribute((packed)) scmi_pd_power_domain_attributes_a2p {
+struct scmi_pd_power_domain_attributes_a2p {
     uint32_t domain_id;
 };
 
 #define SCMI_PD_POWER_STATE_SET_ASYNC    (1 << 30)
 #define SCMI_PD_POWER_STATE_SET_SYNC     (1 << 29)
 
-struct __attribute((packed)) scmi_pd_power_domain_attributes_p2a {
+struct scmi_pd_power_domain_attributes_p2a {
     int32_t status;
     uint32_t attributes;
     uint8_t name[16];
@@ -68,13 +68,13 @@ struct __attribute((packed)) scmi_pd_power_domain_attributes_p2a {
 #define SCMI_PD_POWER_STATE_SET_FLAGS_MASK (1 << 0)
 #define SCMI_PD_POWER_STATE_SET_POWER_STATE_MASK UINT32_C(0x4FFFFFFF)
 
-struct __attribute((packed)) scmi_pd_power_state_set_a2p {
+struct scmi_pd_power_state_set_a2p {
     uint32_t flags;
     uint32_t domain_id;
     uint32_t power_state;
 };
 
-struct __attribute((packed)) scmi_pd_power_state_set_p2a {
+struct scmi_pd_power_state_set_p2a {
     int32_t status;
 };
 
@@ -82,11 +82,11 @@ struct __attribute((packed)) scmi_pd_power_state_set_p2a {
  * POWER_STATE_GET
  */
 
-struct __attribute((packed)) scmi_pd_power_state_get_a2p {
+struct scmi_pd_power_state_get_a2p {
     uint32_t domain_id;
 };
 
-struct __attribute((packed)) scmi_pd_power_state_get_p2a {
+struct scmi_pd_power_state_get_p2a {
     int32_t status;
     uint32_t power_state;
 };
@@ -95,12 +95,12 @@ struct __attribute((packed)) scmi_pd_power_state_get_p2a {
  * POWER_STATE_NOTIFY
  */
 
-struct __attribute((packed)) scmi_pd_power_state_notify_a2p {
+struct scmi_pd_power_state_notify_a2p {
     uint32_t domain_id;
     uint32_t notify_enable;
 };
 
-struct __attribute((packed)) scmi_pd_power_state_notify_p2a {
+struct scmi_pd_power_state_notify_p2a {
     int32_t status;
 };
 

--- a/module/scmi_reset_domain/include/internal/scmi_reset_domain.h
+++ b/module/scmi_reset_domain/include/internal/scmi_reset_domain.h
@@ -31,7 +31,7 @@
  * PROTOCOL_ATTRIBUTES
  */
 
-struct __attribute((packed)) scmi_reset_domain_protocol_attributes_p2a {
+struct scmi_reset_domain_protocol_attributes_p2a {
     int32_t status;
     uint32_t attributes;
 };
@@ -46,11 +46,11 @@ struct __attribute((packed)) scmi_reset_domain_protocol_attributes_p2a {
 /* Macro for scmi_reset_domain_attributes_p2a:name */
 #define SCMI_RESET_DOMAIN_ATTR_NAME_SZ  16
 
-struct __attribute((packed)) scmi_reset_domain_attributes_a2p {
+struct scmi_reset_domain_attributes_a2p {
     uint32_t domain_id;
 };
 
-struct __attribute((packed)) scmi_reset_domain_attributes_p2a {
+struct scmi_reset_domain_attributes_p2a {
     int32_t status;
     uint32_t flags;
     uint32_t latency;
@@ -66,13 +66,13 @@ struct __attribute((packed)) scmi_reset_domain_attributes_p2a {
 #define SCMI_RESET_DOMAIN_EXPLICIT   (1 << 1)
 #define SCMI_RESET_DOMAIN_AUTO       (1 << 0)
 
-struct __attribute((packed)) scmi_reset_domain_request_a2p {
+struct scmi_reset_domain_request_a2p {
     uint32_t domain_id;
     uint32_t flags;
     uint32_t reset_state;
 };
 
-struct __attribute((packed)) scmi_reset_domain_request_p2a {
+struct scmi_reset_domain_request_p2a {
     int32_t status;
 };
 
@@ -83,12 +83,12 @@ struct __attribute((packed)) scmi_reset_domain_request_p2a {
 /* Values for scmi_reset_notify_p2a:flags */
 #define SCMI_RESET_DOMAIN_DO_NOTIFY  (1 << 0)
 
-struct __attribute((packed)) scmi_reset_domain_notify_a2p {
+struct scmi_reset_domain_notify_a2p {
     uint32_t domain_id;
     uint32_t notify_enable;
 };
 
-struct __attribute((packed)) scmi_reset_domain_notify_p2a {
+struct scmi_reset_domain_notify_p2a {
     int32_t status;
 };
 
@@ -96,7 +96,7 @@ struct __attribute((packed)) scmi_reset_domain_notify_p2a {
  * RESET_COMPLETE
  */
 
-struct __attribute((packed)) scmi_reset_domain_complete_p2a {
+struct scmi_reset_domain_complete_p2a {
     int32_t status;
     uint32_t domain_id;
 };
@@ -105,7 +105,7 @@ struct __attribute((packed)) scmi_reset_domain_complete_p2a {
  * RESET_ISSUED
  */
 
-struct __attribute((packed)) scmi_reset_domain_issued_p2a {
+struct scmi_reset_domain_issued_p2a {
     uint32_t agent_id;
     uint32_t domain_id;
     uint32_t reset_state;

--- a/module/scmi_sensor/include/internal/scmi_sensor.h
+++ b/module/scmi_sensor/include/internal/scmi_sensor.h
@@ -29,7 +29,7 @@
  * PROTOCOL_ATTRIBUTES
  */
 
-struct __attribute((packed)) scmi_sensor_protocol_attributes_p2a {
+struct scmi_sensor_protocol_attributes_p2a {
     int32_t status;
     uint32_t attributes;
     uint32_t sensor_reg_address_low;
@@ -43,12 +43,12 @@ struct __attribute((packed)) scmi_sensor_protocol_attributes_p2a {
 
 #define SCMI_SENSOR_PROTOCOL_READING_GET_ASYNC_FLAG_MASK    (1 << 0)
 
-struct __attribute((packed)) scmi_sensor_protocol_reading_get_a2p {
+struct scmi_sensor_protocol_reading_get_a2p {
     uint32_t sensor_id;
     uint32_t flags;
 };
 
-struct __attribute((packed)) scmi_sensor_protocol_reading_get_p2a {
+struct scmi_sensor_protocol_reading_get_p2a {
     int32_t status;
     uint32_t sensor_value_low;
     uint32_t sensor_value_high;
@@ -127,18 +127,18 @@ struct __attribute((packed)) scmi_sensor_protocol_reading_get_p2a {
 
 #define SCMI_SENSOR_NAME_LEN    16
 
-struct __attribute((packed)) scmi_sensor_desc {
+struct scmi_sensor_desc {
     uint32_t sensor_id;
     uint32_t sensor_attributes_low;
     uint32_t sensor_attributes_high;
     char sensor_name[SCMI_SENSOR_NAME_LEN];
 };
 
-struct __attribute((packed)) scmi_sensor_protocol_description_get_a2p {
+struct scmi_sensor_protocol_description_get_a2p {
     uint32_t desc_index;
 };
 
-struct __attribute((packed)) scmi_sensor_protocol_description_get_p2a {
+struct scmi_sensor_protocol_description_get_p2a {
     int32_t status;
     uint32_t num_sensor_flags;
     struct scmi_sensor_desc sensor_desc[];

--- a/module/scmi_system_power/include/internal/scmi_system_power.h
+++ b/module/scmi_system_power/include/internal/scmi_system_power.h
@@ -38,12 +38,12 @@ enum scmi_system_state {
     SCMI_SYSTEM_STATE_MAX
 };
 
-struct __attribute((packed)) scmi_sys_power_state_set_a2p {
+struct scmi_sys_power_state_set_a2p {
     uint32_t flags;
     uint32_t system_state;
 };
 
-struct __attribute((packed)) scmi_sys_power_state_set_p2a {
+struct scmi_sys_power_state_set_p2a {
     int32_t status;
 };
 
@@ -51,7 +51,7 @@ struct __attribute((packed)) scmi_sys_power_state_set_p2a {
  * SYSTEM_POWER_STATE_GET
  */
 
-struct __attribute((packed)) scmi_sys_power_state_get_p2a {
+struct scmi_sys_power_state_get_p2a {
     int32_t status;
     uint32_t system_state;
 };
@@ -62,11 +62,11 @@ struct __attribute((packed)) scmi_sys_power_state_get_p2a {
 
 #define STATE_NOTIFY_FLAGS_MASK 0x1
 
-struct __attribute((packed)) scmi_sys_power_state_notify_a2p {
+struct scmi_sys_power_state_notify_a2p {
     uint32_t flags;
 };
 
-struct __attribute((packed)) scmi_sys_power_state_notify_p2a {
+struct scmi_sys_power_state_notify_p2a {
     int32_t status;
 };
 
@@ -74,7 +74,7 @@ struct __attribute((packed)) scmi_sys_power_state_notify_p2a {
  * SYSTEM_POWER_STATE_NOTIFIER
  */
 
-struct __attribute((packed)) scmi_sys_power_state_notifier {
+struct scmi_sys_power_state_notifier {
     uint32_t agent_id;
     uint32_t flags;
     uint32_t system_state;

--- a/module/smt/include/internal/smt.h
+++ b/module/smt/include/internal/smt.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 
-struct __attribute((packed)) mod_smt_memory {
+struct mod_smt_memory {
     uint32_t reserved0;
     uint32_t status;
     uint64_t reserved1;

--- a/product/n1sdp/module/n1sdp_smt/include/internal/smt.h
+++ b/product/n1sdp/module/n1sdp_smt/include/internal/smt.h
@@ -10,7 +10,7 @@
 
 #include <stdint.h>
 
-struct __attribute((packed)) mod_smt_memory {
+struct mod_smt_memory {
     uint32_t reserved0;
     uint32_t status;
     uint64_t reserved1;


### PR DESCRIPTION
This patch removes the __attribute((packed)) from all data structs.
The attribute is not required as all structs have correct internal
alignment.

Change-Id: I038e7c4e661133a8ee4915eb8abb45086145b93e
Signed-off-by: Jim Quigley <jim.quigley@arm.com>