### PR TITLE
mod_scmi: Adapt available protocols

### DIFF
--- a/product/juno/scp_ramfw/config_resource_perms.c
+++ b/product/juno/scp_ramfw/config_resource_perms.c
@@ -39,17 +39,21 @@
  * Note that permissions are denied when a bit is set, the
  * permissions tables are being added for Juno as an example only.
  */
-static struct mod_res_agent_protocol_permissions
-    agent_protocol_permissions[] = {
-    [AGENT_IDX(JUNO_SCMI_AGENT_IDX_OSPM)] = {
-        .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
-    },
+static struct mod_res_agent_protocol_permissions agent_protocol_permissions[] =
+    {
+        [AGENT_IDX(JUNO_SCMI_AGENT_IDX_OSPM)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
+            },
 
-    /* PSCI agent has no access to clock protocol */
-    [AGENT_IDX(JUNO_SCMI_AGENT_IDX_PSCI)] = {
-        .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED,
-    },
-};
+        /* PSCI agent has no access to clock, perf and sensor protocol */
+        [AGENT_IDX(JUNO_SCMI_AGENT_IDX_PSCI)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_PERF_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_SENSOR_PROTOCOL_DENIED,
+            },
+    };
 
 /*
  * Messages have an index offset from 0x3 as all agents can access

--- a/product/rdn1e1/scp_ramfw/config_resource_perms.c
+++ b/product/rdn1e1/scp_ramfw/config_resource_perms.c
@@ -31,17 +31,21 @@
 /*!
  * Note that permissions are denied when a bit is set.
  */
-static struct mod_res_agent_protocol_permissions
-    agent_protocol_permissions[] = {
-    [AGENT_IDX(SCP_SCMI_AGENT_ID_OSPM)] = {
-        .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
-    },
+static struct mod_res_agent_protocol_permissions agent_protocol_permissions[] =
+    {
+        [AGENT_IDX(SCP_SCMI_AGENT_ID_OSPM)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
+            },
 
-    /* PSCI agent has no access to clock protocol */
-    [AGENT_IDX(SCP_SCMI_AGENT_ID_PSCI)] = {
-        .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED,
-    },
-};
+        /* PSCI agent has no access to clock, perf and sensor protocol */
+        [AGENT_IDX(SCP_SCMI_AGENT_ID_PSCI)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_PERF_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_SENSOR_PROTOCOL_DENIED,
+            },
+    };
 
 /*
  * Messages have an index offset from 0x3 as all agents can access

--- a/product/sgi575/scp_ramfw/config_resource_perms.c
+++ b/product/sgi575/scp_ramfw/config_resource_perms.c
@@ -31,17 +31,21 @@
 /*!
  * Note that permissions are denied when a bit is set.
  */
-static struct mod_res_agent_protocol_permissions
-    agent_protocol_permissions[] = {
-    [AGENT_IDX(SCP_SCMI_AGENT_ID_OSPM)] = {
-        .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
-    },
+static struct mod_res_agent_protocol_permissions agent_protocol_permissions[] =
+    {
+        [AGENT_IDX(SCP_SCMI_AGENT_ID_OSPM)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
+            },
 
-    /* PSCI agent has no access to clock protocol */
-    [AGENT_IDX(SCP_SCMI_AGENT_ID_PSCI)] = {
-        .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED,
-    },
-};
+        /* PSCI agent has no access to clock, perf and sensor protocol */
+        [AGENT_IDX(SCP_SCMI_AGENT_ID_PSCI)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_PERF_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_SENSOR_PROTOCOL_DENIED,
+            },
+    };
 
 /*
  * Messages have an index offset from 0x3 as all agents can access

--- a/product/sgm775/scp_ramfw/config_resource_perms.c
+++ b/product/sgm775/scp_ramfw/config_resource_perms.c
@@ -24,17 +24,21 @@
 
 #define AGENT_IDX(agent_id) (agent_id - 1)
 
-static struct mod_res_agent_protocol_permissions
-    agent_protocol_permissions[] = {
-    [AGENT_IDX(SCMI_AGENT_ID_OSPM)] = {
-        .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
-    },
+static struct mod_res_agent_protocol_permissions agent_protocol_permissions[] =
+    {
+        [AGENT_IDX(SCMI_AGENT_ID_OSPM)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
+            },
 
-    /* PSCI agent has no access to clock protocol */
-    [AGENT_IDX(SCMI_AGENT_ID_PSCI)] = {
-        .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED,
-    },
-};
+        /* PSCI agent has no access to clock, perf and sensor protocol */
+        [AGENT_IDX(SCMI_AGENT_ID_PSCI)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_PERF_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_SENSOR_PROTOCOL_DENIED,
+            },
+    };
 
 /*
  * Messages have an index offset from 0x3 as all agents can access

--- a/product/sgm776/scp_ramfw/config_resource_perms.c
+++ b/product/sgm776/scp_ramfw/config_resource_perms.c
@@ -24,17 +24,21 @@
 
 #define AGENT_IDX(agent_id) (agent_id - 1)
 
-static struct mod_res_agent_protocol_permissions
-    agent_protocol_permissions[] = {
-    [AGENT_IDX(SCMI_AGENT_ID_OSPM)] = {
-        .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
-    },
+static struct mod_res_agent_protocol_permissions agent_protocol_permissions[] =
+    {
+        [AGENT_IDX(SCMI_AGENT_ID_OSPM)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
+            },
 
-    /* PSCI agent has no access to clock protocol */
-    [AGENT_IDX(SCMI_AGENT_ID_PSCI)] = {
-        .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED,
-    },
-};
+        /* PSCI agent has no access to clock, perf and sensor protocol */
+        [AGENT_IDX(SCMI_AGENT_ID_PSCI)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_PERF_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_SENSOR_PROTOCOL_DENIED,
+            },
+    };
 
 /*
  * Messages have an index offset from 0x3 as all agents can access

--- a/product/tc0/scp_ramfw/config_resource_perms.c
+++ b/product/tc0/scp_ramfw/config_resource_perms.c
@@ -23,17 +23,21 @@
 
 #define AGENT_IDX(agent_id) (agent_id - 1)
 
-static struct mod_res_agent_protocol_permissions
-    agent_protocol_permissions[] = {
-    [AGENT_IDX(SCP_SCMI_AGENT_ID_OSPM)] = {
-        .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
-    },
+static struct mod_res_agent_protocol_permissions agent_protocol_permissions[] =
+    {
+        [AGENT_IDX(SCP_SCMI_AGENT_ID_OSPM)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_ALL_PROTOCOLS_ALLOWED,
+            },
 
-    /* PSCI agent has no access to clock protocol */
-    [AGENT_IDX(SCP_SCMI_AGENT_ID_PSCI)] = {
-        .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED,
-    },
-};
+        /* PSCI agent has no access to clock, perf and sensor protocol */
+        [AGENT_IDX(SCP_SCMI_AGENT_ID_PSCI)] =
+            {
+                .protocols = MOD_RES_PERMS_SCMI_CLOCK_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_PERF_PROTOCOL_DENIED |
+                    MOD_RES_PERMS_SCMI_SENSOR_PROTOCOL_DENIED,
+            },
+    };
 
 /*
  * Messages have an index offset from 0x3 as all agents can access


### PR DESCRIPTION
Originally the command BASE_DISCOVER_LIST_PROTOCOLS of the base
SCMI protocol would always return all the implemented SCMI
protocols. Through the use of the resource management module,
the output can now vary according to the agent's level of
access. In this commit the PSCI agent level of access has now
been changed to the system power managament protocol only.

Change-Id: I80a9f6bb1746b62b171232b977abdb1f10d8de63
Signed-off-by: Luca Vizzarro <Luca.Vizzarro@arm.com>