### PR TITLE
power_domain: Add check for get_last_core_pd_id

### DIFF
--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -1597,8 +1597,12 @@ static int pd_report_power_state_transition(fwk_id_t pd_id, unsigned int state)
 
 static int pd_get_last_core_pd_id(fwk_id_t *last_core_pd_id)
 {
+    bool ongoing = mod_pd_ctx.system_suspend.last_core_off_ongoing;
     if (last_core_pd_id == NULL)
         return FWK_E_PARAM;
+
+    if (!ongoing)
+        return FWK_E_PWRSTATE;
 
     *last_core_pd_id = mod_pd_ctx.system_suspend.last_core_pd->id;
 


### PR DESCRIPTION
This patch implements a validation check such that when the
get_last_core_pd_id() function is called by the driver, the
module returns an error if the system is not performing
system_supend.

Change-Id: Ied3a2f17b2fb471933232c8209e4d3048c4a1e8b
Signed-off-by: Leandro Belli <leandro.belli@arm.com>