### PR TITLE
framework: set event count from notification count

### DIFF
--- a/framework/src/fwk_module.c
+++ b/framework/src/fwk_module.c
@@ -25,7 +25,12 @@
 
 #include <stdbool.h>
 
-#define EVENT_COUNT 64
+#if FMW_NOTIFICATION_MAX > 64
+#    define EVENT_COUNT FMW_NOTIFICATION_MAX
+#else
+#    define EVENT_COUNT 64
+#endif
+
 #define BIND_ROUND_MAX 1
 
 /* Pre-runtime phase stages */


### PR DESCRIPTION
The default value of EVENT_COUNT is set to 64. On platforms that
requires larger number of notification subscriptions (192 for example),
EVENT_COUNT of 64 will not be sufficient. When platform sets the
max notification count greater than 64, set the EVENT_COUNT to
max notification count to account for additional events due to increased
notifications.

Change-Id: I9370703b47268c08d3f8bfb32b21f07b8b5370f7
Signed-off-by: Vijayenthiran Subramaniam <vijayenthiran.subramaniam@arm.com>