### PR TITLE
SCMI: Performance notifications and fast channels need to be separated

### DIFF
--- a/module/dvfs/include/mod_dvfs.h
+++ b/module/dvfs/include/mod_dvfs.h
@@ -84,9 +84,9 @@ struct mod_dvfs_domain_config {
     fwk_id_t notification_id;
 
     /*!
-     * \brief Notifications API identifier.
+     * \brief Updates API identifier.
      */
-    fwk_id_t notification_api_id;
+    fwk_id_t updates_api_id;
 
     /*! Delay in milliseconds before retrying a request */
     uint16_t retry_ms;
@@ -214,30 +214,36 @@ struct mod_dvfs_domain_api {
 };
 
 /*!
- * \brief DVFS notification API.
+ * \brief DVFS updates notification API.
  *
- * \details API used by the domain when a notification is required.
+ * \details API used by the domain to notify the HAL when either the
+ *      limits or level has been changed.
  */
-struct mod_dvfs_notification_api {
+struct mod_dvfs_perf_updated_api {
     /*!
-     * \brief Send a limitschanged notification for the domain.
+     * \brief Inform the HAL that the domain limits have been updated.
      *
      * \param domain_id Domain identifier.
      * \param cookie Context-specific value.
      * \param range_min Min allowed performance level.
      * \param range_max Max allowed performance level.
      */
-    void (*notify_limits)(fwk_id_t domain_id, uintptr_t cookie,
-        uint32_t range_min, uint32_t range_max);
+    void (*notify_limits_updated)(
+        fwk_id_t domain_id,
+        uintptr_t cookie,
+        uint32_t range_min,
+        uint32_t range_max);
 
     /*!
-     * \brief Send a level changed notification for the domain.
+     * \brief Inform the HAL that the domain level has been updated.
      *
      * \param domain_id Domain identifier.
      * \param cookie Context-specific value.
      * \param level The new performance level of the domain.
      */
-    void (*notify_level)(fwk_id_t domain_id, uintptr_t cookie,
+    void (*notify_level_updated)(
+        fwk_id_t domain_id,
+        uintptr_t cookie,
         uint32_t level);
 };
 

--- a/module/scmi_perf/include/mod_scmi_perf.h
+++ b/module/scmi_perf/include/mod_scmi_perf.h
@@ -137,8 +137,8 @@ enum scmi_perf_api_idx {
     /*! Index for the SCMI protocol API */
     MOD_SCMI_PERF_PROTOCOL_API,
 
-    /*! Index of the notification API */
-    MOD_SCMI_PERF_DVFS_NOTIFICATION_API,
+    /*! Index of the updates notification API */
+    MOD_SCMI_PERF_DVFS_UPDATE_API,
 
     /*! Number of APIs */
     MOD_SCMI_PERF_API_COUNT

--- a/product/juno/scp_ramfw/config_dvfs.c
+++ b/product/juno/scp_ramfw/config_dvfs.c
@@ -44,9 +44,9 @@ static const struct mod_dvfs_domain_config cpu_group_little_r0 = {
         0,
         JUNO_DVFS_ALARM_VLITTLE_IDX),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1450,
     .sustained_idx = 2,
@@ -93,9 +93,9 @@ static const struct mod_dvfs_domain_config cpu_group_little_r1 = {
         0,
         JUNO_DVFS_ALARM_VLITTLE_IDX),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1450,
     .sustained_idx = 0,
@@ -118,9 +118,9 @@ static const struct mod_dvfs_domain_config cpu_group_little_r2 = {
         0,
         JUNO_DVFS_ALARM_VLITTLE_IDX),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1450,
     .sustained_idx = 1,
@@ -154,9 +154,9 @@ static const struct mod_dvfs_domain_config cpu_group_big_r0 = {
         0,
         JUNO_DVFS_ALARM_BIG_IDX),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1450,
     .sustained_idx = 2,
@@ -202,9 +202,9 @@ static const struct mod_dvfs_domain_config cpu_group_big_r1 = {
         0,
         JUNO_DVFS_ALARM_BIG_IDX),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1450,
     .sustained_idx = 1,
@@ -238,9 +238,9 @@ static const struct mod_dvfs_domain_config cpu_group_big_r2 = {
         0,
         JUNO_DVFS_ALARM_BIG_IDX),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1450,
     .sustained_idx = 1,
@@ -274,9 +274,9 @@ static const struct mod_dvfs_domain_config gpu_r0 = {
         0,
         JUNO_DVFS_ALARM_GPU_IDX),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1450,
     .sustained_idx = 4,
@@ -323,9 +323,9 @@ static const struct mod_dvfs_domain_config gpu_r1 = {
         0,
         JUNO_DVFS_ALARM_GPU_IDX),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1450,
     .sustained_idx = 4,
@@ -372,9 +372,9 @@ static const struct mod_dvfs_domain_config gpu_r2 = {
         0,
         JUNO_DVFS_ALARM_GPU_IDX),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1450,
     .sustained_idx = 1,

--- a/product/juno/scp_ramfw/firmware.mk
+++ b/product/juno/scp_ramfw/firmware.mk
@@ -20,12 +20,6 @@ BS_FIRMWARE_HAS_STATISTICS := no
 
 BS_FIRMWARE_MODULE_HEADERS_ONLY :=
 
-ifeq ($(BS_FIRMWARE_HAS_FAST_CHANNELS),yes)
-    ifneq ($(BS_FIRMWARE_HAS_SCMI_NOTIFICATIONS),yes)
-        "error: Fast Channels requires SCMI Notifications!"
-    endif
-endif
-
 BS_FIRMWARE_MODULES := \
     log \
     pl011 \

--- a/product/rdn1e1/scp_ramfw/config_dvfs.c
+++ b/product/rdn1e1/scp_ramfw/config_dvfs.c
@@ -51,8 +51,9 @@ static const struct mod_dvfs_domain_config cpu_group0 = {
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_CPU_GROUP0),
     .alarm_id = FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0, 0),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+    .updates_api_id = FWK_ID_API_INIT(
+        FWK_MODULE_IDX_SCMI_PERF,
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1200,
     .sustained_idx = 2,
@@ -64,8 +65,9 @@ static const struct mod_dvfs_domain_config cpu_group1 = {
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_CPU_GROUP1),
     .alarm_id = FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0, 1),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+    .updates_api_id = FWK_ID_API_INIT(
+        FWK_MODULE_IDX_SCMI_PERF,
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1200,
     .sustained_idx = 2,

--- a/product/sgi575/scp_ramfw/config_dvfs.c
+++ b/product/sgi575/scp_ramfw/config_dvfs.c
@@ -48,8 +48,9 @@ static const struct mod_dvfs_domain_config cpu_group0 = {
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_CPU_GROUP0),
     .alarm_id = FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0, 0),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+    .updates_api_id = FWK_ID_API_INIT(
+        FWK_MODULE_IDX_SCMI_PERF,
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1200,
     .sustained_idx = 2,
@@ -61,8 +62,9 @@ static const struct mod_dvfs_domain_config cpu_group1 = {
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_CPU_GROUP1),
     .alarm_id = FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0, 1),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+    .updates_api_id = FWK_ID_API_INIT(
+        FWK_MODULE_IDX_SCMI_PERF,
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1200,
     .sustained_idx = 2,

--- a/product/sgm775/scp_ramfw/config_dvfs.c
+++ b/product/sgm775/scp_ramfw/config_dvfs.c
@@ -30,9 +30,9 @@ static const struct mod_dvfs_domain_config cpu_group_little = {
         0,
         CONFIG_TIMER_DVFS_CPU_GROUP_LITTLE),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1200,
     .sustained_idx = 2,
@@ -72,9 +72,9 @@ static const struct mod_dvfs_domain_config cpu_group_big = {
         0,
         CONFIG_TIMER_DVFS_CPU_GROUP_BIG),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1200,
     .sustained_idx = 2,
@@ -112,9 +112,9 @@ static const struct mod_dvfs_domain_config gpu = {
     .alarm_id =
         FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0, CONFIG_TIMER_DVFS_GPU),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1200,
     .sustained_idx = 4,

--- a/product/sgm776/scp_ramfw/config_dvfs.c
+++ b/product/sgm776/scp_ramfw/config_dvfs.c
@@ -23,9 +23,9 @@ static const struct mod_dvfs_domain_config cpu_group_little = {
     .psu_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_PSU, 0),
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, 1),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .latency = 1200,
     .sustained_idx = 2,
     .opps = (struct mod_dvfs_opp[]){ {
@@ -60,9 +60,9 @@ static const struct mod_dvfs_domain_config cpu_group_big = {
     .psu_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_PSU, 1),
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, 0),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .latency = 1200,
     .sustained_idx = 2,
     .opps = (struct mod_dvfs_opp[]){ {
@@ -97,9 +97,9 @@ static const struct mod_dvfs_domain_config gpu = {
     .psu_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_PSU, 2),
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, 2),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(
+    .updates_api_id = FWK_ID_API_INIT(
         FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .latency = 1200,
     .sustained_idx = 4,
     .opps = (struct mod_dvfs_opp[]){ {

--- a/product/tc0/scp_ramfw/config_dvfs.c
+++ b/product/tc0/scp_ramfw/config_dvfs.c
@@ -46,11 +46,12 @@ static struct mod_dvfs_opp opps[] = { {
 static const struct mod_dvfs_domain_config cpu_group = {
     .psu_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_PSU, 0),
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_CPU_GROUP0),
-    .alarm_id = FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0,
-        CONFIG_TIMER_DVFS_CPU),
+    .alarm_id =
+        FWK_ID_SUB_ELEMENT_INIT(FWK_MODULE_IDX_TIMER, 0, CONFIG_TIMER_DVFS_CPU),
     .notification_id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI_PERF),
-    .notification_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_SCMI_PERF,
-        MOD_SCMI_PERF_DVFS_NOTIFICATION_API),
+    .updates_api_id = FWK_ID_API_INIT(
+        FWK_MODULE_IDX_SCMI_PERF,
+        MOD_SCMI_PERF_DVFS_UPDATE_API),
     .retry_ms = 1,
     .latency = 1200,
     .sustained_idx = 2,


### PR DESCRIPTION
This patch allows the SCMI_PERF HAL to use whichever combination of
the SCMI Notifications and Fast Channels mechanisms (or neither) when
the DVFS module notifies it that there have been updates to the domain
performance limits or level settings.

Change-Id: I7e1c262edf33d090d21508eb8f1be293a0ab8e99
Signed-off-by: Jim Quigley <jim.quigley@arm.com>