### PR TITLE
Add compiler-specific macro facades

### DIFF
--- a/arch/arm/armv7-m/src/arch_exceptions.c
+++ b/arch/arm/armv7-m/src/arch_exceptions.c
@@ -8,6 +8,8 @@
  *      ARMv7-M exception handlers.
  */
 
+#include <fwk_attributes.h>
+
 #include <arch_exceptions.h>
 
 #include <fmw_cmsis.h>
@@ -58,7 +60,7 @@ extern char __stackheap_end__;
 const struct {
     uintptr_t stack;
     uintptr_t exceptions[NVIC_USER_IRQ_OFFSET - 1];
-} arch_exceptions __attribute__((section(".exceptions"))) = {
+} arch_exceptions FWK_SECTION(".exceptions") = {
     .stack = (uintptr_t)(arch_exception_stack),
     .exceptions = {
         [NVIC_USER_IRQ_OFFSET + Reset_IRQn - 1] =

--- a/arch/arm/armv7-m/src/arch_handlers.c
+++ b/arch/arm/armv7-m/src/arch_handlers.c
@@ -10,6 +10,7 @@
 
 #include <cmsis_compiler.h>
 
+#include <fwk_attributes.h>
 #include <fwk_noreturn.h>
 
 #include <stdbool.h>
@@ -40,7 +41,7 @@ noreturn void arch_exception_reset(void)
 #endif
 }
 
-noreturn __attribute__((weak)) void arch_exception_invalid(void)
+noreturn FWK_WEAK void arch_exception_invalid(void)
 {
     while (true)
         __WFI();

--- a/debugger/src/cli/cli_platform_time.c
+++ b/debugger/src/cli/cli_platform_time.c
@@ -8,12 +8,14 @@
 #include <cli.h>
 #include <cli_platform.h>
 
+#include <fwk_attributes.h>
+
 #include <stdint.h>
 
-__attribute__((weak)) void cli_platform_get_time(cli_timestamp_t *t)
+FWK_WEAK void cli_platform_get_time(cli_timestamp_t *t)
 {
 }
 
-__attribute__((weak)) void cli_platform_delay_ms(uint32_t ms)
+FWK_WEAK void cli_platform_delay_ms(uint32_t ms)
 {
 }

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -872,7 +872,7 @@ EXCLUDE_PATTERNS       = */internal/*
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = FWK_ALLOC_1 FWK_ALLOC_2 FWK_ALLOC_3
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -2053,7 +2053,9 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = __attribute__(x)= \
-                         __attribute(x)=
+                         __declspec(x)= \
+                         __has_attribute(x)=1 \
+                         __has_declspec_attribute(x)=1
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
@@ -2062,7 +2064,17 @@ PREDEFINED             = __attribute__(x)= \
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      =
+EXPAND_AS_DEFINED      = FWK_ALLOC \
+                         FWK_ALLOC_SIZE1 \
+                         FWK_ALLOC_SIZE2 \
+                         FWK_ALLOC_ALIGN \
+                         FWK_WEAK \
+                         FWK_PRINTF \
+                         FWK_CONSTRUCTOR \
+                         FWK_PACKED \
+                         FWK_SECTION \
+                         FWK_DEPRECATED \
+                         FWK_NOINLINE
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have

--- a/framework/include/fwk_attributes.h
+++ b/framework/include/fwk_attributes.h
@@ -1,0 +1,291 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FWK_ATTRIBUTES_H
+#define FWK_ATTRIBUTES_H
+
+#include <fwk_macros.h>
+
+/*!
+ * \addtogroup GroupLibFramework Framework
+ * \{
+ */
+
+/*!
+ * \defgroup GroupAttributes Attributes
+ *
+ * \brief Compiler-independent attribute macros.
+ *
+ * \details This component exposes a number of compiler-specific macros in a
+ *      way that they can be used without causing compilation issues on
+ *      compilers that do not support them.
+ *
+ * @warning Where an attribute does not modify the behaviour of a well-formed
+ *      program, it may expand to nothing if the compiler in use does not
+ *      support it. However, attributes for which a lack of support may
+ *      fundamentally alter the program will not be defined on any compiler that
+ *      does not support it.
+ *
+ * \{
+ */
+
+/*!
+ * \def FWK_HAS_GNU_ATTRIBUTE
+ *
+ * \brief Check whether the compiler supports a given GNU attribute.
+ *
+ * \param[in] ATTRIBUTE Attribute name.
+ *
+ * \returns A value usable in the expression of a preprocessor `if` or `elif`
+ *      statement.
+ */
+
+#ifdef __has_attribute
+#    define FWK_HAS_GNU_ATTRIBUTE(ATTRIBUTE) __has_attribute(ATTRIBUTE)
+#else
+#    define FWK_HAS_GNU_ATTRIBUTE(ATTRIBUTE) 0
+#endif
+
+/*!
+ * \def FWK_HAS_MS_ATTRIBUTE
+ *
+ * \brief Check whether the compiler supports a given Microsoft attribute.
+ *
+ * \param[in] ATTRIBUTE Attribute name.
+ *
+ * \returns A value usable in the expression of a preprocessor `if` or `elif`
+ *      statement.
+ */
+
+#if defined(__has_declspec_attribute) && !defined(__ARMCC_VERSION)
+#    define FWK_HAS_MS_ATTRIBUTE(ATTRIBUTE) __has_declspec_attribute(ATTRIBUTE)
+#else
+#    define FWK_HAS_MS_ATTRIBUTE(ATTRIBUTE) 0
+#endif
+
+/*!
+ * \def FWK_ALLOC
+ *
+ * \brief "Allocator" attribute.
+ *
+ * \details Hints that the pointer returned by this function does not alias any
+ *      other pointer, nor do any pointers to valid objects exist within the
+ *      storage addressed by the pointer.
+ *
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-malloc-function-attribute
+ * \see https://docs.microsoft.com/en-us/cpp/cpp/allocator?view=vs-2019
+ */
+
+#if FWK_HAS_GNU_ATTRIBUTE(__malloc__)
+#    define FWK_ALLOC_1 __attribute__((__malloc__))
+#else
+#    define FWK_ALLOC_1
+#endif
+
+#if FWK_HAS_MS_ATTRIBUTE(allocator)
+#    define FWK_ALLOC_2 __declspec(allocator)
+#else
+#    define FWK_ALLOC_2
+#endif
+
+#if FWK_HAS_MS_ATTRIBUTE(restrict)
+#    define FWK_ALLOC_3 __declspec(restrict)
+#else
+#    define FWK_ALLOC_3
+#endif
+
+#define FWK_ALLOC FWK_ALLOC_1 FWK_ALLOC_2 FWK_ALLOC_3
+
+/*!
+ * \def FWK_ALLOC_SIZE1
+ *
+ * \brief "Sizing allocator" attribute.
+ *
+ * \details Hints that the pointer returned by this function has a size given
+ *      by a parameter.
+ *
+ * \param[in] SIZE_POS Position of the size parameter, 1-indexed.
+ *
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-alloc_005fsize-function-attribute
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-alloc_005fsize-variable-attribute
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html#index-alloc_005fsize-type-attribute
+ */
+
+/*!
+ * \def FWK_ALLOC_SIZE2
+ *
+ * \brief "Sizing allocator" attribute.
+ *
+ * \details Hints that the pointer returned by this function has a size given
+ *      by the product of a size and a count parameter.
+ *
+ * \param[in] SIZE_POS Position of the size parameter, 1-indexed.
+ * \param[in] COUNT_POS Position of the count parameter, 1-indexed.
+ *
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-alloc_005fsize-function-attribute
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-alloc_005fsize-variable-attribute
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html#index-alloc_005fsize-type-attribute
+ */
+
+#if FWK_HAS_GNU_ATTRIBUTE(__alloc_size__)
+#    define FWK_ALLOC_SIZE1(SIZE_POS) __attribute__((__alloc_size__(SIZE_POS)))
+#    define FWK_ALLOC_SIZE2(SIZE_POS, COUNT_POS) \
+        __attribute__((__alloc_size__(SIZE_POS, COUNT_POS)))
+#else
+#    define FWK_ALLOC_SIZE1(SIZE_POS)
+#    define FWK_ALLOC_SIZE2(SIZE_POS, COUNT_POS)
+#endif
+
+/*!
+ * \def FWK_ALLOC_ALIGN
+ *
+ * \brief "Aligning allocator" attribute.
+ *
+ * \details Hints that the pointer returned by this function has an alignment
+ *      given by a parameter.
+ *
+ * \param[in] ALIGN_POS Position of the alignment parameter, 1-indexed.
+ *
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-alloc_005falign-function-attribute
+ */
+
+#if FWK_HAS_GNU_ATTRIBUTE(__alloc_align__)
+#    define FWK_ALLOC_ALIGN(ALIGN_POS) \
+        __attribute__((__alloc_align__(ALIGN_POS)))
+#else
+#    define FWK_ALLOC_ALIGN(ALIGN_POS)
+#endif
+
+/*!
+ * \def FWK_WEAK
+ *
+ * \brief "Weak" attribute.
+ *
+ * \details Applies weak linkage to the item.
+ *
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-weak-function-attribute
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-weak-variable-attribute
+ */
+
+#if FWK_HAS_GNU_ATTRIBUTE(__weak__)
+#    define FWK_WEAK __attribute__((__weak__))
+#endif
+
+/*!
+ * \def FWK_PRINTF
+ *
+ * \brief "`printf`-like" attribute.
+ *
+ * \details Hints that the function takes a string literal with the same
+ *      semantics as the `printf` format string.
+ *
+ * \param[in] STR_POS Position of the format string parameter, 1-indexed.
+ * \param[in] VA_POS Position of the argument list, 1-indexed.
+ *
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-Wformat-3
+ */
+
+#if FWK_HAS_GNU_ATTRIBUTE(__format__)
+#    define FWK_PRINTF(STR_POS, VA_POS) \
+        __attribute__((__format__(printf, STR_POS, VA_POS)))
+#else
+#    define FWK_PRINTF(STR_POS, VA_POS)
+#endif
+
+/*!
+ * \def FWK_CONSTRUCTOR
+ *
+ * \brief "Constructor" attribute.
+ *
+ * \details Adds the function to the list of functions to be executed before
+ *      `main`.
+ *
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-constructor-function-attribute
+ */
+
+#if FWK_HAS_GNU_ATTRIBUTE(__constructor__)
+#    define FWK_CONSTRUCTOR __attribute__((__constructor__))
+#endif
+
+/*!
+ * \def FWK_PACKED
+ *
+ * \brief "Packed" attribute.
+ *
+ * \details Packs the item that this attribute is attached to.
+ *
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html#index-aligned-type-attribute
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-packed-variable-attribute
+ */
+
+#if FWK_HAS_GNU_ATTRIBUTE(__packed__)
+#    define FWK_PACKED __attribute__((__packed__))
+#endif
+
+/*!
+ * \def FWK_SECTION
+ *
+ * \brief "Linker section" attribute.
+ *
+ * \details Places the item that this attribute is attached to into a particular
+ *      linker section.
+ *
+ * \param[in] SECTION String literal representing the name of the section.
+ *
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-section-function-attribute
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-section-variable-attribute
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html#index-packed-type-attribute
+ */
+
+#if FWK_HAS_GNU_ATTRIBUTE(__section__)
+#    define FWK_SECTION(SECTION) __attribute__((__section__(SECTION)))
+#endif
+
+/*!
+ * \def FWK_DEPRECATED
+ *
+ * \brief "Deprecated" attribute.
+ *
+ * \details Marks the item that this attribute is attached to as deprecated.
+ *
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-deprecated-function-attribute
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Variable-Attributes.html#index-deprecated-variable-attribute
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Type-Attributes.html#index-deprecated-type-attribute
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Enumerator-Attributes.html#index-deprecated-enumerator-attribute
+ */
+
+#if FWK_HAS_GNU_ATTRIBUTE(__deprecated__)
+#    define FWK_DEPRECATED __attribute__((__deprecated__))
+#else
+#    define FWK_DEPRECATED
+#endif
+
+/*!
+ * \def FWK_NOINLINE
+ *
+ * \brief "Do not inline" attribute.
+ *
+ * \details Hints to the compiler that the function should not be inlined.
+ *
+ * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-noinline-function-attribute
+ */
+
+#if FWK_HAS_GNU_ATTRIBUTE(__noinline__)
+#    define FWK_NOINLINE __attribute__((__noinline__))
+#else
+#    define FWK_NOINLINE
+#endif
+
+/*!
+ * \}
+ */
+
+/*!
+ * \}
+ */
+
+#endif /* FWK_ATTRIBUTES_H */

--- a/framework/include/fwk_log.h
+++ b/framework/include/fwk_log.h
@@ -8,6 +8,7 @@
 #ifndef FWK_LOG_H
 #define FWK_LOG_H
 
+#include <fwk_attributes.h>
 #include <fwk_macros.h>
 
 #if FWK_HAS_INCLUDE(<fmw_log.h>)
@@ -408,8 +409,7 @@ const struct fwk_log_backend *fwk_log_deregister(void);
  * \param[in] format Format string.
  * \param[in] ... Associated parameters.
  */
-void fwk_log_snprintf(const char *format, ...)
-    __attribute__((format(printf, 1, 2)));
+void fwk_log_snprintf(const char *format, ...) FWK_PRINTF(1, 2);
 
 /*!
  * \internal

--- a/framework/include/fwk_log.h
+++ b/framework/include/fwk_log.h
@@ -10,7 +10,7 @@
 
 #include <fwk_macros.h>
 
-#if __has_include(<fmw_log.h>)
+#if FWK_HAS_INCLUDE(<fmw_log.h>)
 #    include <fmw_log.h>
 #endif
 

--- a/framework/include/fwk_macros.h
+++ b/framework/include/fwk_macros.h
@@ -348,6 +348,28 @@
     __FWK_MAP(FWK_COUNT_ARGS(__VA_ARGS__), MACRO, __VA_ARGS__)
 
 /*!
+ * \def FWK_HAS_INCLUDE
+ *
+ * \brief Check whether a header file with a given name exists.
+ *
+ * \details This macro uses the `__has_include` compiler extension to check
+ *      whether a given header file exists and can be included. The header
+ *      name is given by its `include` directive form (`"x.h"` or `<x.h>`).
+ *
+ * \param[in] HEADER Header name.
+ *
+ * \return An expression usable in a preprocessor `if` or `elif` expression
+ *      determining whether the header exists, or `1` if the compiler does not
+ *      support the `__has_include` extension.
+ */
+
+#ifdef __has_include
+#    define FWK_HAS_INCLUDE(HEADER) __has_include(HEADER)
+#else
+#    define FWK_HAS_INCLUDE(HEADER) 1
+#endif
+
+/*!
  * @}
  */
 

--- a/framework/include/fwk_mm.h
+++ b/framework/include/fwk_mm.h
@@ -12,6 +12,7 @@
 #define FWK_MM_H
 
 #include <fwk_align.h>
+#include <fwk_attributes.h>
 
 #include <stddef.h>
 
@@ -43,8 +44,7 @@
  * \retval NULL Allocation failed.
  * \return Pointer to a newly-allocated block of memory.
  */
-void *fwk_mm_alloc(size_t num, size_t size)
-    __attribute__((malloc, alloc_size(1, 2)));
+void *fwk_mm_alloc(size_t num, size_t size) FWK_ALLOC FWK_ALLOC_SIZE2(1, 2);
 
 /*!
  * \brief Allocate a block of memory with specified alignment.
@@ -57,7 +57,7 @@ void *fwk_mm_alloc(size_t num, size_t size)
  * \return Pointer to a newly-allocated block of memory.
  */
 void *fwk_mm_alloc_aligned(size_t num, size_t size, unsigned int alignment)
-    __attribute__((malloc, alloc_size(1, 2), alloc_align(3)));
+    FWK_ALLOC FWK_ALLOC_SIZE2(1, 2) FWK_ALLOC_ALIGN(3);
 
 /*!
  * \brief Allocate a block of memory and initialize all its bits to zero.
@@ -71,8 +71,7 @@ void *fwk_mm_alloc_aligned(size_t num, size_t size, unsigned int alignment)
  * \retval NULL Allocation failed.
  * \return Pointer to a newly-allocated block of memory.
  */
-void *fwk_mm_calloc(size_t num, size_t size)
-    __attribute__((malloc, alloc_size(1, 2)));
+void *fwk_mm_calloc(size_t num, size_t size) FWK_ALLOC FWK_ALLOC_SIZE2(1, 2);
 
 /*!
  * \brief Allocate a block of memory with specified alignment and initialize
@@ -86,7 +85,7 @@ void *fwk_mm_calloc(size_t num, size_t size)
  * \return Pointer to a newly-allocated block of memory.
  */
 void *fwk_mm_calloc_aligned(size_t num, size_t size, unsigned int alignment)
-    __attribute__((malloc, alloc_size(1, 2), alloc_align(3)));
+    FWK_ALLOC FWK_ALLOC_SIZE2(1, 2) FWK_ALLOC_ALIGN(3);
 
 /*!
  * @}

--- a/framework/include/fwk_multi_thread.h
+++ b/framework/include/fwk_multi_thread.h
@@ -8,6 +8,7 @@
 #ifndef FWK_MULTI_THREAD_H
 #define FWK_MULTI_THREAD_H
 
+#include <fwk_attributes.h>
 #include <fwk_event.h>
 #include <fwk_id.h>
 #include <fwk_thread.h>
@@ -86,9 +87,9 @@ int fwk_thread_put_event_and_wait(struct fwk_event *event,
     struct fwk_event *resp_event);
 
 #else
-int fwk_thread_put_event_and_wait(struct fwk_event *event,
-    struct fwk_event *resp_event)
-    __attribute__((deprecated));
+int fwk_thread_put_event_and_wait(
+    struct fwk_event *event,
+    struct fwk_event *resp_event) FWK_DEPRECATED;
 
 #endif
 

--- a/framework/include/fwk_notification.h
+++ b/framework/include/fwk_notification.h
@@ -13,8 +13,9 @@
 
 #include <fwk_event.h>
 #include <fwk_id.h>
+#include <fwk_macros.h>
 
-#if __has_include(<fmw_notification.h>)
+#if FWK_HAS_INCLUDE(<fmw_notification.h>)
 #    include <fmw_notification.h>
 #endif
 

--- a/framework/src/fwk_log.c
+++ b/framework/src/fwk_log.c
@@ -6,6 +6,7 @@
  */
 
 #include <fwk_assert.h>
+#include <fwk_attributes.h>
 #include <fwk_interrupt.h>
 #include <fwk_log.h>
 #include <fwk_ring.h>
@@ -238,7 +239,7 @@ void fwk_log_snprintf(const char *format, ...)
 }
 
 #ifdef FWK_LOG_BUFFERED
-__attribute((constructor)) void fwk_log_init(void)
+FWK_CONSTRUCTOR void fwk_log_init(void)
 {
     static char storage[FMW_LOG_BUFFER_SIZE];
 

--- a/framework/src/fwk_multi_thread.c
+++ b/framework/src/fwk_multi_thread.c
@@ -32,7 +32,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#if __has_include(<fmw_memory.h>)
+#if FWK_HAS_INCLUDE(<fmw_memory.h>)
 #    include <fmw_memory.h>
 #endif
 

--- a/framework/src/fwk_notification.c
+++ b/framework/src/fwk_notification.c
@@ -13,6 +13,7 @@
 #include <internal/fwk_thread.h>
 
 #include <fwk_assert.h>
+#include <fwk_attributes.h>
 #include <fwk_dlist.h>
 #include <fwk_event.h>
 #include <fwk_id.h>
@@ -146,7 +147,7 @@ static void send_notifications(struct fwk_event *notification_event,
  * Private interface functions
  */
 
-static __attribute((constructor)) void fwk_notification_init(void)
+static FWK_CONSTRUCTOR void fwk_notification_init(void)
 {
     static struct __fwk_notification_subscription
         subscriptions[FMW_NOTIFICATION_MAX];

--- a/framework/src/fwk_time.c
+++ b/framework/src/fwk_time.c
@@ -6,6 +6,7 @@
  */
 
 #include <fwk_arch.h>
+#include <fwk_attributes.h>
 #include <fwk_status.h>
 #include <fwk_time.h>
 
@@ -16,7 +17,7 @@ struct {
     const void *driver_ctx; /* Time driver context */
 } fwk_time_ctx;
 
-__attribute__((constructor)) void fwk_time_init(void)
+FWK_CONSTRUCTOR void fwk_time_init(void)
 {
     struct fwk_time_driver driver = fmw_time_driver(&fwk_time_ctx.driver_ctx);
 
@@ -68,7 +69,7 @@ fwk_duration_h_t fwk_time_duration_h(fwk_duration_ns_t duration)
     return duration / FWK_H(1);
 }
 
-__attribute__((weak)) struct fwk_time_driver fmw_time_driver(const void **ctx)
+FWK_WEAK struct fwk_time_driver fmw_time_driver(const void **ctx)
 {
     return (struct fwk_time_driver){
         .timestamp = NULL,

--- a/module/fip/include/internal/fip.h
+++ b/module/fip/include/internal/fip.h
@@ -20,6 +20,8 @@
 #ifndef INTERNAL_FIP_H
 #define INTERNAL_FIP_H
 
+#include <fwk_attributes.h>
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -157,24 +159,24 @@
  *  +----------------+
  */
 
-struct __attribute__((packed)) fip_uuid {
+struct FWK_PACKED fip_uuid {
     uint8_t u[16];
 };
 
-struct __attribute__((packed)) fip_toc_header {
+struct FWK_PACKED fip_toc_header {
     uint32_t name;
     uint32_t serial_number;
     uint64_t flags;
 };
 
-struct __attribute__((packed)) fip_toc_entry {
+struct FWK_PACKED fip_toc_entry {
     struct fip_uuid uuid;
     uint64_t offset_address;
     uint64_t size;
     uint64_t flags;
 };
 
-struct __attribute__((packed)) fip_toc {
+struct FWK_PACKED fip_toc {
     struct fip_toc_header header;
     struct fip_toc_entry entry[];
 };

--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -15,6 +15,7 @@
 #include <mod_scmi_clock.h>
 
 #include <fwk_assert.h>
+#include <fwk_attributes.h>
 #include <fwk_event.h>
 #include <fwk_id.h>
 #include <fwk_log.h>
@@ -387,7 +388,7 @@ static void set_request_respond(fwk_id_t service_id, int status)
                                      sizeof(return_values.status));
 }
 
-__attribute((weak)) int mod_scmi_clock_rate_set_policy(
+FWK_WEAK int mod_scmi_clock_rate_set_policy(
     enum mod_scmi_clock_policy_status *policy_status,
     enum mod_clock_round_mode *round_mode,
     uint64_t *rate,
@@ -399,7 +400,7 @@ __attribute((weak)) int mod_scmi_clock_rate_set_policy(
     return FWK_SUCCESS;
 }
 
-__attribute((weak)) int mod_scmi_clock_config_set_policy(
+FWK_WEAK int mod_scmi_clock_config_set_policy(
     enum mod_scmi_clock_policy_status *policy_status,
     enum mod_clock_state *state,
     fwk_id_t service_id,

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -1011,7 +1011,7 @@ static void fast_channel_callback(uintptr_t param)
 /*
  * SCMI Performance Policy Handlers
  */
-__attribute__((weak)) int scmi_perf_limits_set_policy(
+FWK_WEAK int scmi_perf_limits_set_policy(
     enum mod_scmi_perf_policy_status *policy_status,
     uint32_t *range_min,
     uint32_t *range_max,
@@ -1023,7 +1023,7 @@ __attribute__((weak)) int scmi_perf_limits_set_policy(
     return FWK_SUCCESS;
 }
 
-__attribute__((weak)) int scmi_perf_level_set_policy(
+FWK_WEAK int scmi_perf_level_set_policy(
     enum mod_scmi_perf_policy_status *policy_status,
     uint32_t *level,
     unsigned int agent_id,

--- a/module/scmi_power_domain/src/mod_scmi_power_domain.c
+++ b/module/scmi_power_domain/src/mod_scmi_power_domain.c
@@ -643,7 +643,7 @@ exit:
 /*
  * SCMI Power Domain Policy Handlers
  */
-__attribute__((weak)) int scmi_pd_power_state_set_policy(
+FWK_WEAK int scmi_pd_power_state_set_policy(
     enum mod_scmi_pd_policy_status *policy_status,
     uint32_t *state,
     unsigned int agent_id,

--- a/module/scmi_reset_domain/src/mod_scmi_reset_domain.c
+++ b/module/scmi_reset_domain/src/mod_scmi_reset_domain.c
@@ -8,21 +8,26 @@
  *     SCMI Reset Domain management protocol support.
  */
 
+#include <internal/scmi_reset_domain.h>
+
+#include <mod_reset_domain.h>
+#include <mod_scmi.h>
+#include <mod_scmi_reset_domain.h>
+
 #include <fwk_assert.h>
+#include <fwk_attributes.h>
 #include <fwk_macros.h>
 #include <fwk_mm.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
 #include <fwk_notification.h>
 #include <fwk_status.h>
-#include <internal/scmi_reset_domain.h>
-#include <mod_reset_domain.h>
+
+#include <string.h>
+
 #ifdef BUILD_HAS_RESOURCE_PERMISSIONS
 #    include <mod_resource_perms.h>
 #endif
-#include <mod_scmi.h>
-#include <mod_scmi_reset_domain.h>
-#include <string.h>
 
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS
 struct agent_notifications {
@@ -229,7 +234,7 @@ static int get_reset_device(fwk_id_t service_id,
 /*
  * Reset Request Policy Handler
  */
-__attribute__((weak)) int scmi_reset_domain_reset_request_policy(
+FWK_WEAK int scmi_reset_domain_reset_request_policy(
     enum mod_scmi_reset_domain_policy_status *policy_status,
     enum mod_reset_domain_mode *mode,
     uint32_t *reset_state,

--- a/module/scmi_system_power/src/mod_scmi_system_power.c
+++ b/module/scmi_system_power/src/mod_scmi_system_power.c
@@ -18,6 +18,7 @@
 #include <mod_timer.h>
 
 #include <fwk_assert.h>
+#include <fwk_attributes.h>
 #include <fwk_id.h>
 #include <fwk_macros.h>
 #include <fwk_mm.h>
@@ -495,7 +496,7 @@ exit:
  * Platforms can override this policy by implementing this interface in the
  * platform code.
  */
-__attribute((weak)) int scmi_sys_power_state_set_policy(
+FWK_WEAK int scmi_sys_power_state_set_policy(
     enum mod_scmi_sys_power_policy_status *policy_status,
     uint32_t *state,
     fwk_id_t service_id,

--- a/module/statistics/include/mod_stats.h
+++ b/module/statistics/include/mod_stats.h
@@ -8,6 +8,7 @@
 #ifndef MOD_STATISTICS_H
 #define MOD_STATISTICS_H
 
+#include <fwk_attributes.h>
 #include <fwk_id.h>
 #include <fwk_macros.h>
 #include <fwk_module_idx.h>
@@ -29,7 +30,7 @@
 /*!
  * \brief Statistics memory region information.
  */
-struct mod_stats_config_info {
+struct FWK_PACKED mod_stats_config_info {
     /*! AP physical address where statistics are located */
     uint64_t ap_stats_addr;
 
@@ -155,14 +156,14 @@ struct mod_stats_desc_header {
      * statistics data section. If the value is 0 then statistics are not
      * collected for this domain. */
     uint32_t domain_offset[];
-} __attribute__((packed));
+};
 
 /*!
  * \brief Performance or power level statistics data
  *
  * \note In case of power domain. Here the reference to level means power state
  */
-struct mod_stats_level_stats {
+struct FWK_PACKED mod_stats_level_stats {
     /*! The performance or power level ID. */
     uint32_t level_id;
 
@@ -175,12 +176,12 @@ struct mod_stats_level_stats {
     /*! Cumulative time of how long this level has been used. Value is in
      * microseconds. */
     uint64_t total_residency_us;
-} __attribute__((packed));
+};
 
 /*!
  * \brief Performance or power domain statistics data
  */
-struct mod_stats_domain_stats_data {
+struct FWK_PACKED mod_stats_domain_stats_data {
     /*! Holds value of total number of performance or power levels available
      * in the domain. */
     uint16_t level_count;
@@ -198,8 +199,7 @@ struct mod_stats_domain_stats_data {
     /*! Beginning of the statistics region with information for each
      * performance or power level. */
     struct mod_stats_level_stats level[];
-} __attribute__((packed));
-
+};
 
 /*!
  * \}

--- a/product/juno/include/juno_clock.h
+++ b/product/juno/include/juno_clock.h
@@ -10,6 +10,7 @@
 
 #include "juno_scc.h"
 
+#include <fwk_attributes.h>
 #include <fwk_macros.h>
 
 #include <stdint.h>
@@ -72,7 +73,7 @@ enum juno_clock_soc_ram_idx {
     JUNO_CLOCK_SOC_RAM_IDX_COUNT
 };
 
-struct juno_clock_preset {
+struct FWK_PACKED juno_clock_preset {
     /*
      * \brief Denominator value
      *
@@ -91,7 +92,7 @@ struct juno_clock_preset {
      * \note This value should be between 1 and 127
      */
     uint16_t PDIV;
-} __attribute((packed));
+};
 
 struct juno_clock_lookup {
     struct pll_reg pll;

--- a/product/n1sdp/module/n1sdp_dmc620/src/dimm_spd.h
+++ b/product/n1sdp/module/n1sdp_dmc620/src/dimm_spd.h
@@ -12,6 +12,8 @@
 #include <mod_n1sdp_dmc620.h>
 #include <mod_n1sdp_i2c.h>
 
+#include <fwk_attributes.h>
+
 #include <stdint.h>
 
 /*
@@ -210,7 +212,7 @@
  *  Address 0x000 - 0x07F
  *  This section defines parameters that are common to all DDR4 module types
  */
-struct ddr4_dram_param {
+struct FWK_PACKED ddr4_dram_param {
     /* Number of Bytes used */
     uint8_t num_bytes;
     /* SPD Revision */
@@ -337,16 +339,16 @@ struct ddr4_dram_param {
     uint8_t crc_lsb;
     /* Cyclical Redundancy Code (CRC) for Base Configuration Section, MSB */
     uint8_t crc_msb;
-} __attribute__((packed));
+};
 
-struct ddr4_spd {
-  struct ddr4_dram_param dram_param;
-  uint8_t standard_mod[64];
-  uint8_t hybrid_mod[64];
-  uint8_t hybrid_ext_func[64];
-  uint8_t mfg_info[64];
-  uint8_t end_usr[128];
-} __attribute__((packed));
+struct FWK_PACKED ddr4_spd {
+    struct ddr4_dram_param dram_param;
+    uint8_t standard_mod[64];
+    uint8_t hybrid_mod[64];
+    uint8_t hybrid_ext_func[64];
+    uint8_t mfg_info[64];
+    uint8_t end_usr[128];
+};
 
 /*
  * SPD API function prototypes

--- a/product/n1sdp/module/n1sdp_pcie/src/pcie_enumeration.c
+++ b/product/n1sdp/module/n1sdp_pcie/src/pcie_enumeration.c
@@ -21,6 +21,7 @@
 #include <mod_n1sdp_pcie.h>
 
 #include <fwk_assert.h>
+#include <fwk_attributes.h>
 #include <fwk_macros.h>
 
 #include <fmw_cmsis.h>
@@ -271,7 +272,7 @@ void pcie_bus_enumeration(struct n1sdp_pcie_dev_config *config)
 /*!
  * \brief Callee context at exception
  */
-struct __attribute((packed)) context {
+struct FWK_PACKED context {
     uint32_t r0;
     uint32_t r1;
     uint32_t r2;
@@ -301,8 +302,9 @@ struct __attribute((packed)) context {
 
 #define EXCEPTION_BUSFAULT 5
 
-__attribute__((noinline)) /* only one location where the checked load happen */
-static bool checked_read_u32(uint32_t *const value, const uint32_t *const src)
+FWK_NOINLINE /* only one location where the checked load happen */
+    static bool
+    checked_read_u32(uint32_t *const value, const uint32_t *const src)
 {
     uint32_t err;
     uint32_t dst;

--- a/product/n1sdp/module/n1sdp_scp2pcc/include/internal/n1sdp_scp2pcc.h
+++ b/product/n1sdp/module/n1sdp_scp2pcc/include/internal/n1sdp_scp2pcc.h
@@ -11,6 +11,8 @@
 #ifndef INTERNAL_N1SDP_SCP2PCC_H
 #define INTERNAL_N1SDP_SCP2PCC_H
 
+#include <fwk_attributes.h>
+
 #include <stdint.h>
 
 #define MSG_PAYLOAD_SIZE         16
@@ -20,7 +22,7 @@
 #define SCP2PCC_TYPE_SHUTDOWN    0x0001
 #define SCP2PCC_TYPE_REBOOT      0x0002
 
-struct mem_msg_packet_st {
+struct FWK_PACKED mem_msg_packet_st {
     /* Message type, lower 16 bits only. */
     unsigned int type;
     /* Valid payload size, lower 16 bits only. */
@@ -29,6 +31,6 @@ struct mem_msg_packet_st {
     unsigned int sequence;
     /* Data payload. */
     uint8_t payload[MSG_PAYLOAD_SIZE];
-} __attribute__((packed));
+};
 
 #endif /* INTERNAL_N1SDP_SCP2PCC_H */

--- a/product/n1sdp/module/scmi_ccix_config/include/internal/mod_scmi_ccix_config.h
+++ b/product/n1sdp/module/scmi_ccix_config/include/internal/mod_scmi_ccix_config.h
@@ -11,6 +11,8 @@
 #ifndef INTERNAL_SCMI_CCIX_CONFIG_H
 #define INTERNAL_SCMI_CCIX_CONFIG_H
 
+#include <fwk_attributes.h>
+
 #include <stdint.h>
 
 /*
@@ -44,15 +46,13 @@ enum scmi_ccix_config_command_id {
 #define ADDRESS_MSB_MASK        UINT64_C(0xFFFFFFFF00000000)
 #define ADDRESS_LSB_MASK        UINT64_C(0x00000000FFFFFFFF)
 
-
-struct __attribute((packed)) scmi_ccix_config_mempools_map {
+struct FWK_PACKED scmi_ccix_config_mempools_map {
     uint32_t ha_id;
     uint32_t base_msb;
     uint32_t base_lsb;
     uint32_t size_msb;
     uint32_t size_lsb;
 };
-
 
 /*
  * CCIX CONFIG GET
@@ -95,8 +95,7 @@ struct __attribute((packed)) scmi_ccix_config_mempools_map {
 #define HOST_OPT_TLP_MASK            UINT32_C(0x80000000)
 #define HOST_OPT_TLP_BIT_POS         31
 
-
-struct __attribute((packed)) scmi_ccix_config_protocol_get_p2a {
+struct FWK_PACKED scmi_ccix_config_protocol_get_p2a {
     int32_t  status;
     uint32_t agent_count;
     uint32_t host_mmap_count;
@@ -130,30 +129,29 @@ struct __attribute((packed)) scmi_ccix_config_protocol_get_p2a {
 #define MAX_PACKET_SIZE_MASK     UINT32_C(0x1C000000)
 #define MAX_PACKET_SIZE_BIT_POS  26
 
-struct __attribute((packed)) scmi_ccix_config_protocol_set_a2p {
+struct FWK_PACKED scmi_ccix_config_protocol_set_a2p {
     uint32_t agent_count;
     uint32_t config_property;
     uint32_t remote_mmap_count;
     struct scmi_ccix_config_mempools_map mem_pools[MAX_HA_MMAP_ENTRIES];
 };
 
-struct __attribute((packed)) scmi_ccix_config_protocol_set_p2a {
+struct FWK_PACKED scmi_ccix_config_protocol_set_p2a {
     int32_t status;
 };
 
 /*
  * CCIX CONFIG EXCHANGE PROTOCOL CREDIT
  */
-struct __attribute((packed)) scmi_ccix_config_protocol_credit_a2p {
+struct FWK_PACKED scmi_ccix_config_protocol_credit_a2p {
     uint32_t  link_id;
 };
 
 /*
  * CCIX CONFIG ENTER SYSTEM COHERENCY
  */
-struct __attribute((packed)) scmi_ccix_config_protocol_sys_coherency_a2p {
+struct FWK_PACKED scmi_ccix_config_protocol_sys_coherency_a2p {
     uint32_t  link_id;
 };
-
 
 #endif /* INTERNAL_SCMI_CCIX_CONFIG_H */

--- a/product/synquacer/module/scmi_vendor_ext/include/internal/scmi_vendor_ext.h
+++ b/product/synquacer/module/scmi_vendor_ext/include/internal/scmi_vendor_ext.h
@@ -11,6 +11,8 @@
 #ifndef INTERNAL_SCMI_VENDOR_EXT_H
 #define INTERNAL_SCMI_VENDOR_EXT_H
 
+#include <fwk_attributes.h>
+
 #include <stdint.h>
 
 /*!
@@ -44,7 +46,7 @@ enum scmi_vendor_ext_command_id {
 /*!
  * \brief PROTOCOL_ATTRIBUTES
  */
-struct __attribute((packed)) scmi_vendor_ext_protocol_attributes_p2a {
+struct FWK_PACKED scmi_vendor_ext_protocol_attributes_p2a {
     /*! SCMI status. */
     int32_t status;
     /*! attributes. */
@@ -75,7 +77,7 @@ struct memory_info_array {
 /*!
  * \brief memory mapping information structure.
  */
-struct __attribute((packed)) synquacer_memory_info {
+struct FWK_PACKED synquacer_memory_info {
     /*! number of memory regions. */
     uint32_t array_num;
     /*! reserved. */

--- a/product/synquacer/module/synquacer_system/src/load_secure_fw.c
+++ b/product/synquacer/module/synquacer_system/src/load_secure_fw.c
@@ -10,6 +10,7 @@
 #include <ddr_init.h>
 
 #include <fwk_assert.h>
+#include <fwk_attributes.h>
 #include <fwk_log.h>
 #include <fwk_macros.h>
 
@@ -17,37 +18,37 @@
 #include <stdint.h>
 #include <string.h>
 
-struct fip_toc_header_s {
+struct FWK_PACKED fip_toc_header_s {
     uint32_t name;
     uint32_t serial_num;
     uint64_t flags;
-} __attribute__((packed));
+};
 
 typedef struct fip_toc_header_s fip_toc_header_t;
 /* fip toc header 16 byte*/
 
-struct fip_toc_entry_s {
+struct FWK_PACKED fip_toc_entry_s {
     uint8_t uuid[16];
     uint64_t offset_addr;
     uint64_t size;
     uint64_t flags;
-} __attribute__((packed));
+};
 
 typedef struct fip_toc_entry_s fip_toc_entry_t;
 /* fip toc entry 40 byte*/
 
-struct fip_package_s {
+struct FWK_PACKED fip_package_s {
     fip_toc_header_t fip_toc_header;
     fip_toc_entry_t fip_toc_entry[5];
     uint32_t data[1];
-} __attribute__((packed));
+};
 
 typedef struct fip_package_s fip_package_t;
 
-struct arm_tf_fip_package_s {
+struct FWK_PACKED arm_tf_fip_package_s {
     fip_toc_header_t fip_toc_header;
     fip_toc_entry_t fip_toc_entry[4];
-} __attribute__((packed));
+};
 
 typedef struct arm_tf_fip_package_s arm_tf_fip_package_t;
 

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -35,3 +35,6 @@ syntaxError:product/synquacer/module/synquacer_system/src/mmu500.c:34
 
 // Cppcheck doesn't like include directives that use macros
 preprocessorErrorDirective:framework/test/fwk_module_idx.h:14
+
+// Cppcheck does not properly parse the `FWK_HAS_INCLUDE` macro
+preprocessorErrorDirective:arch/arm/src/arch_mm.c:16


### PR DESCRIPTION
This pull requests adds a number of macros that act as facades for certain compiler extensions.