### PR TITLE
module/scmi_reset_domain: Fix broken build with reset enabled

### DIFF
--- a/module/scmi_reset_domain/include/internal/scmi_reset_domain.h
+++ b/module/scmi_reset_domain/include/internal/scmi_reset_domain.h
@@ -12,6 +12,8 @@
 #ifndef INTERNAL_SCMI_RESET_DOMAIN_H
 #define INTERNAL_SCMI_RESET_DOMAIN_H
 
+#include <stdint.h>
+
 /*!
  * \addtogroup GroupModules Modules
  * \{


### PR DESCRIPTION
The latest patches and rebase has revealed dependency of
internal/scmi_reset_domain.h on stdint.h. This change
fixes this.

Change-Id: I0b241d0b4d1ad5f99ce00ff99ab1a9094e2ce97d
Signed-off-by: Girish Pathak <girish.pathak@arm.com>