### PR TITLE
Topics/notification transitions

### DIFF
--- a/module/power_domain/include/mod_power_domain.h
+++ b/module/power_domain/include/mod_power_domain.h
@@ -174,6 +174,9 @@ struct mod_power_domain_element_config {
 
     /*! Size of the table of allowed state masks */
     size_t state_name_table_size;
+
+    /*! Disable power domain transition notifications */
+    bool disable_state_transition_notifications;
 };
 
 /*!

--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -614,6 +614,9 @@ static bool initiate_power_state_pre_transition_notification(struct pd_ctx *pd)
     };
     struct mod_pd_power_state_pre_transition_notification_params *params;
 
+    if (pd->config->disable_state_transition_notifications == true)
+        false;
+
     state = pd->requested_state;
     if (!check_power_state_pre_transition_notification(pd, state))
         return false;
@@ -1105,7 +1108,8 @@ static void process_power_state_transition_report(struct pd_ctx *pd,
     previous_state = pd->current_state;
     pd->current_state = new_state;
 
-    if (pd->power_state_transition_notification_ctx.pending_responses == 0) {
+    if (pd->power_state_transition_notification_ctx.pending_responses == 0 &&
+        pd->config->disable_state_transition_notifications == false) {
         params = (struct mod_pd_power_state_transition_notification_params *)
             notification_event.params;
         params->state = new_state;

--- a/product/juno/scp_ramfw/config_power_domain.c
+++ b/product/juno/scp_ramfw/config_power_domain.c
@@ -84,6 +84,7 @@ static struct fwk_element element_table[] = {
             .allowed_state_mask_table = core_pd_allowed_state_mask_table,
             .allowed_state_mask_table_size =
                 FWK_ARRAY_SIZE(core_pd_allowed_state_mask_table),
+            .disable_state_transition_notifications = true,
         },
     },
     [POWER_DOMAIN_IDX_BIG_CPU1] = {
@@ -100,6 +101,7 @@ static struct fwk_element element_table[] = {
             .allowed_state_mask_table = core_pd_allowed_state_mask_table,
             .allowed_state_mask_table_size =
                 FWK_ARRAY_SIZE(core_pd_allowed_state_mask_table),
+            .disable_state_transition_notifications = true,
         },
     },
     [POWER_DOMAIN_IDX_LITTLE_CPU0] = {
@@ -116,6 +118,7 @@ static struct fwk_element element_table[] = {
             .allowed_state_mask_table = core_pd_allowed_state_mask_table,
             .allowed_state_mask_table_size =
                 FWK_ARRAY_SIZE(core_pd_allowed_state_mask_table),
+            .disable_state_transition_notifications = true,
         },
     },
     [POWER_DOMAIN_IDX_LITTLE_CPU1] = {
@@ -132,6 +135,7 @@ static struct fwk_element element_table[] = {
             .allowed_state_mask_table = core_pd_allowed_state_mask_table,
             .allowed_state_mask_table_size =
                 FWK_ARRAY_SIZE(core_pd_allowed_state_mask_table),
+            .disable_state_transition_notifications = true,
         },
     },
     [POWER_DOMAIN_IDX_LITTLE_CPU2] = {
@@ -148,6 +152,7 @@ static struct fwk_element element_table[] = {
             .allowed_state_mask_table = core_pd_allowed_state_mask_table,
             .allowed_state_mask_table_size =
                 FWK_ARRAY_SIZE(core_pd_allowed_state_mask_table),
+            .disable_state_transition_notifications = true,
         },
     },
     [POWER_DOMAIN_IDX_LITTLE_CPU3] = {
@@ -164,6 +169,7 @@ static struct fwk_element element_table[] = {
             .allowed_state_mask_table = core_pd_allowed_state_mask_table,
             .allowed_state_mask_table_size =
                 FWK_ARRAY_SIZE(core_pd_allowed_state_mask_table),
+            .disable_state_transition_notifications = true,
         },
     },
     [POWER_DOMAIN_IDX_BIG_SSTOP] = {


### PR DESCRIPTION
This change allows a platform to configure pre and post state
transition notifications to be disabled for a power domain.
As an example, a change for Juno platform is also included with this
change.