### PR TITLE
rules.mk: correct BUILD_PATH to allow build irrespective of format

### DIFF
--- a/tools/build_system/rules.mk
+++ b/tools/build_system/rules.mk
@@ -257,7 +257,7 @@ $(OBJ_DIR)/%.o: %.S | $$(@D)/
 	$(call show-action,AS,$<)
 	$(AS) -c $(CFLAGS) $(DEP_CFLAGS) $< -o $@
 
-$(BUILD_PATH)/%/:
+$(BUILD_PATH)%/:
 	$(call show-action,MD,$@)
 	$(MD) $@
 


### PR DESCRIPTION
Without this patch, the BUILD_PATH cannot end with a /.
With this patch, the end of BUILD_PATH does not matter.
BUILD_PATH can be automatically generated by build systems,
so it is important that any format is supported.

Change-Id: Iba306f8ac29a528fa6a7dc0a37e3c3b7ef7d0309
Signed-off-by: Usama Arif <usama.arif@arm.com>