### PR TITLE
scmi_sensor: Fix get readings invalid flags response

### DIFF
--- a/module/scmi_sensor/src/mod_scmi_sensor.c
+++ b/module/scmi_sensor/src/mod_scmi_sensor.c
@@ -352,8 +352,14 @@ static int scmi_sensor_reading_get_handler(fwk_id_t service_id,
         goto exit;
     }
 
-    /* Reject asynchronous read requests for now */
     flags = parameters->flags;
+    if ((flags & ~SCMI_SENSOR_PROTOCOL_READING_GET_ASYNC_FLAG_MASK) != 0) {
+        return_values.status = SCMI_INVALID_PARAMETERS;
+        status = FWK_SUCCESS;
+        goto exit;
+    }
+
+    /* Reject asynchronous read requests for now */
     if (flags & SCMI_SENSOR_PROTOCOL_READING_GET_ASYNC_FLAG_MASK) {
         return_values.status = SCMI_NOT_SUPPORTED;
         status = FWK_SUCCESS;


### PR DESCRIPTION
The READING_GET command currently accepts any value
in the bits 31:1 in its flags. According to the SCMI
v2 specs these bits are reserved and must be zero.
This commit ensures that the command returns
SCMI_INVALID_PARAMETERS when any of those bits are set.

Change-Id: I8d0c486d6aa0a2df8c13b8d3f7319606402dd729
Signed-off-by: Luca Vizzarro <Luca.Vizzarro@arm.com>