### PR TITLE
product/tc0: Fix runtime errors for tc0

### DIFF
--- a/product/tc0/scp_ramfw/config_dvfs.c
+++ b/product/tc0/scp_ramfw/config_dvfs.c
@@ -18,27 +18,27 @@
 
 static struct mod_dvfs_opp opps[] = { {
                                           .level = 946 * 1000000UL,
-                                          .frequency = 946 * FWK_MHZ,
+                                          .frequency = 946 * FWK_KHZ,
                                           .voltage = 550,
                                       },
                                       {
                                           .level = 1419 * 1000000UL,
-                                          .frequency = 1419 * FWK_MHZ,
+                                          .frequency = 1419 * FWK_KHZ,
                                           .voltage = 650,
                                       },
                                       {
                                           .level = 1893 * 1000000UL,
-                                          .frequency = 1893 * FWK_MHZ,
+                                          .frequency = 1893 * FWK_KHZ,
                                           .voltage = 750,
                                       },
                                       {
                                           .level = 2271 * 1000000UL,
-                                          .frequency = 2271 * FWK_MHZ,
+                                          .frequency = 2271 * FWK_KHZ,
                                           .voltage = 850,
                                       },
                                       {
                                           .level = 2650 * 1000000UL,
-                                          .frequency = 2650 * FWK_MHZ,
+                                          .frequency = 2650 * FWK_KHZ,
                                           .voltage = 950,
                                       },
                                       { 0 } };

--- a/product/tc0/scp_ramfw/config_resource_perms.c
+++ b/product/tc0/scp_ramfw/config_resource_perms.c
@@ -86,46 +86,10 @@ static struct mod_res_agent_msg_permissions agent_msg_permissions[] = {
         },
     };
 
-/*
- * Protocols have an index offset from SCMI_BASE protocol, 0x10
- * Note that the BASE and SYSTEM_POWER protocols are managed
- * on a protocol:command basis, there is no resource permissions
- * associated with the protocols.
- */
-static mod_res_perms_t scmi_clock_perms[][5][1] = {
-        /* SCMI_PROTOCOL_ID_CLOCK */
-        /* 0, SCMI_CLOCK_ATTRIBUTES */
-        /* 1, SCMI_CLOCK_RATE_GET */
-        /* 2, SCMI_CLOCK_RATE_SET */
-        /* 3, SCMI_CLOCK_CONFIG_SET */
-        /* 4, SCMI_CLOCK_DESCRIBE_RATES */
-        [AGENT_IDX(SCP_SCMI_AGENT_ID_OSPM)] = {
-            [MOD_RES_PERMS_SCMI_CLOCK_ATTRIBUTES_IDX][0] = 0x0,
-            /*
-             * Clocks 0, 1, 2, 4 do not allow set commands,
-             * Clocks 3 and 5 allow rate_set/config_set
-             */
-            [MOD_RES_PERMS_SCMI_CLOCK_RATE_SET_IDX][0] =
-                ((1 << 0) | (1 << 1) | (1 << 2) | (1 << 4)),
-            [MOD_RES_PERMS_SCMI_CLOCK_RATE_GET_IDX][0] =
-                ((1 << 0) | (1 << 1) | (1 << 2) | (1 << 4)),
-            [MOD_RES_PERMS_SCMI_CLOCK_CONFIG_SET_IDX][0] = 0x0,
-            [MOD_RES_PERMS_SCMI_CLOCK_DESCRIBE_RATE_IDX][0] = 0x0,
-        },
-        [AGENT_IDX(SCP_SCMI_AGENT_ID_PSCI)] = {
-            /* No access to clocks for PSCI agent, so bits [4:0] set  */
-            [MOD_RES_PERMS_SCMI_CLOCK_ATTRIBUTES_IDX][0] = 0x1f,
-            [MOD_RES_PERMS_SCMI_CLOCK_RATE_SET_IDX][0] = 0x1f,
-            [MOD_RES_PERMS_SCMI_CLOCK_RATE_GET_IDX][0] = 0x1f,
-            [MOD_RES_PERMS_SCMI_CLOCK_CONFIG_SET_IDX][0] = 0x1f,
-            [MOD_RES_PERMS_SCMI_CLOCK_DESCRIBE_RATE_IDX][0] = 0x1f,
-        },
-};
 
 static struct mod_res_agent_permission agent_permissions = {
     .agent_protocol_permissions = agent_protocol_permissions,
     .agent_msg_permissions = agent_msg_permissions,
-    .scmi_clock_perms = &scmi_clock_perms[0][0][0],
 };
 
 struct fwk_module_config config_resource_perms = {

--- a/product/tc0/scp_ramfw/config_scmi_perf.c
+++ b/product/tc0/scp_ramfw/config_scmi_perf.c
@@ -19,7 +19,6 @@ static const struct mod_scmi_perf_domain_config domains[] = {
 };
 
 const struct fwk_module_config config_scmi_perf = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(NULL),
     .data = &((struct mod_scmi_perf_config){
         .domains = &domains,
         .fast_channels_alarm_id = FWK_ID_NONE_INIT,

--- a/product/tc0/scp_romfw/config_cmn_booker.c
+++ b/product/tc0/scp_romfw/config_cmn_booker.c
@@ -94,7 +94,6 @@ static const struct mod_cmn_booker_mem_region_map mmap[] = {
 };
 
 const struct fwk_module_config config_cmn_booker = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(NULL),
     .data = &((struct mod_cmn_booker_config){
         .base = SCP_CMN_BOOKER_BASE,
         .mesh_size_x = 2,


### PR DESCRIPTION
This include:

- Changing DVFS frequencies from MHz to KHz inline with recently updated DVFS module
- Not initializing NULL elements, which is not allowed after early module context initializations
- Not setting permissions for SCMI clock, DPU requires access to SCMI clock