### PR TITLE
fwk: Remove all FWK_LOG_TRACE code when LOG_LEVEL=TRACE not set

### DIFF
--- a/framework/src/fwk_multi_thread.c
+++ b/framework/src/fwk_multi_thread.c
@@ -258,14 +258,14 @@ static int put_event(struct __fwk_thread_ctx *target_thread_ctx,
             fwk_list_push_tail(&ctx.thread_ready_queue,
                                &target_thread_ctx->slist_node);
     }
-
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
     FWK_LOG_TRACE(
         "[FWK] Sent %" PRIu32 ": %s @ %s -> %s",
         event->cookie,
         FWK_ID_STR(event->id),
         FWK_ID_STR(event->source_id),
         FWK_ID_STR(event->target_id));
-
+#endif
     return FWK_SUCCESS;
 
 error:
@@ -343,12 +343,14 @@ static void process_next_thread_event(struct __fwk_thread_ctx *thread_ctx)
                      struct fwk_event, slist_node);
     fwk_assert(event != NULL);
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
     FWK_LOG_TRACE(
         "[FWK] Processing %" PRIu32 ": %s @ %s -> %s\n",
         event->cookie,
         FWK_ID_STR(event->id),
         FWK_ID_STR(event->source_id),
         FWK_ID_STR(event->target_id));
+#endif
 
     if (event->response_requested)
         process_event_requiring_response(event);
@@ -540,12 +542,13 @@ static void get_next_isr_event(void)
 
         fwk_assert(isr_event != NULL);
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
         FWK_LOG_TRACE(
             "[FWK] Pulled ISR event (%s: %s -> %s)\n",
             FWK_ID_STR(isr_event->id),
             FWK_ID_STR(isr_event->source_id),
             FWK_ID_STR(isr_event->target_id));
-
+#endif
         target_thread_ctx = thread_get_ctx(isr_event->target_id);
 
         isr_event->is_thread_wakeup_event = is_thread_wakeup_event(

--- a/framework/src/fwk_thread.c
+++ b/framework/src/fwk_thread.c
@@ -122,12 +122,14 @@ static int put_event(struct fwk_event *event)
     else
         fwk_list_push_tail(&ctx.isr_event_queue, &allocated_event->slist_node);
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
     FWK_LOG_TRACE(
         "[FWK] Sent %" PRIu32 ": %s @ %s -> %s",
         event->cookie,
         FWK_ID_STR(event->id),
         FWK_ID_STR(event->source_id),
         FWK_ID_STR(event->target_id));
+#endif
 
     return FWK_SUCCESS;
 }
@@ -151,12 +153,14 @@ static void process_next_event(void)
     ctx.current_event = event = FWK_LIST_GET(
         fwk_list_pop_head(&ctx.event_queue), struct fwk_event, slist_node);
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
     FWK_LOG_TRACE(
         "[FWK] Processing %" PRIu32 ": %s @ %s -> %s\n",
         event->cookie,
         FWK_ID_STR(event->id),
         FWK_ID_STR(event->source_id),
         FWK_ID_STR(event->target_id));
+#endif
 
     module = fwk_module_get_ctx(event->target_id)->desc;
     process_event = event->is_notification ? module->process_notification :
@@ -213,11 +217,13 @@ static bool process_isr(void)
     if (isr_event == NULL)
         return false;
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
     FWK_LOG_TRACE(
         "[FWK] Pulled ISR event (%s: %s -> %s)\n",
         FWK_ID_STR(isr_event->id),
         FWK_ID_STR(isr_event->source_id),
         FWK_ID_STR(isr_event->target_id));
+#endif
 
     fwk_list_push_tail(&ctx.event_queue, &isr_event->slist_node);
 
@@ -384,11 +390,13 @@ int fwk_thread_put_event_and_wait(struct fwk_event *event,
     ctx.waiting_event_processing_completion = true;
     ctx.previous_event = ctx.current_event;
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
     FWK_LOG_TRACE(
         "[FWK] deprecated put_event_and_wait (%s: %s -> %s)\n",
         FWK_ID_STR(event->id),
         FWK_ID_STR(event->source_id),
         FWK_ID_STR(event->target_id));
+#endif
 
     event->is_response = false;
     event->is_delayed_response = false;

--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -298,10 +298,12 @@ static const uint32_t core_composite_state_mask_table[] = {
 static struct mod_pd_ctx mod_pd_ctx;
 static const char driver_error_msg[] = "[PD] Driver error %s (%d) in %s @%d";
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
 static const char * const default_state_name_table[] = {
     "OFF", "ON", "SLEEP", "3", "4", "5", "6", "7",
     "8", "9", "10", "11", "12", "13", "14", "15"
 };
+#endif
 
 /*
  * Utility functions
@@ -365,6 +367,7 @@ static bool is_allowed_by_children(const struct pd_ctx *pd, unsigned int state)
     return true;
 }
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
 static const char *get_state_name(const struct pd_ctx *pd, unsigned int state)
 {
     static char const unknown_name[] = "Unknown";
@@ -376,6 +379,7 @@ static const char *get_state_name(const struct pd_ctx *pd, unsigned int state)
     else
         return unknown_name;
 }
+#endif
 
 static unsigned int number_of_bits_to_shift(uint32_t mask)
 {
@@ -668,22 +672,29 @@ static int initiate_power_state_transition(struct pd_ctx *pd)
 
     if ((pd->driver_api->deny != NULL) &&
         pd->driver_api->deny(pd->driver_id, state)) {
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
         FWK_LOG_TRACE(
             "[PD] Transition of %s to state <%s> denied by driver",
             fwk_module_get_name(pd->id),
             get_state_name(pd, state));
+#endif
         return FWK_E_DEVICE;
     }
 
     status = pd->driver_api->set_state(pd->driver_id, state);
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
     if (status == FWK_SUCCESS) {
         FWK_LOG_TRACE(
             "[PD] Transition of %s from <%s> to <%s> succeeded",
             fwk_module_get_name(pd->id),
             get_state_name(pd, pd->state_requested_to_driver),
             get_state_name(pd, state));
-    } else {
+    }
+#endif
+
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_ERR
+    if (status != FWK_SUCCESS) {
         FWK_LOG_ERR(
             "[PD] Transition of %s from <%s> to <%s> failed: %s",
             fwk_module_get_name(pd->id),
@@ -691,6 +702,7 @@ static int initiate_power_state_transition(struct pd_ctx *pd)
             get_state_name(pd, state),
             fwk_status_str(status));
     }
+#endif
 
     pd->state_requested_to_driver = state;
 

--- a/product/juno/src/juno_scmi_clock.c
+++ b/product/juno/src/juno_scmi_clock.c
@@ -23,11 +23,13 @@ int mod_scmi_clock_rate_set_policy(
     fwk_id_t service_id,
     uint32_t clock_dev_id)
 {
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
     FWK_LOG_TRACE(
         "[SCMI-CLK] Set Clock Rate Policy Handler agent: %u clock: %" PRIu32
         "\n",
         fwk_id_get_element_idx(service_id),
         clock_dev_id);
+#endif
 
     *policy_status = MOD_SCMI_CLOCK_EXECUTE_MESSAGE_HANDLER;
 


### PR DESCRIPTION
The logging framework does not remove the FWK_LOG_x code completely
when LEVEL_x is not set. This can lead to embedded code or macro's
being executed unnecessarily impacting performance.

Change-Id: I741b383cb74b2cf27740640769ea8f0fcd08fa2e
Signed-off-by: Jim Quigley <jim.quigley@arm.com>