### PR TITLE
module: Voltage Domain driver and related SCMIv3 protocol driver

### DIFF
--- a/module/scmi/include/mod_scmi_std.h
+++ b/module/scmi/include/mod_scmi_std.h
@@ -204,6 +204,24 @@ enum scmi_reset_domain_response_id {
 };
 
 /*!
+ * \brief SCMI Voltage Domain Protocol
+ */
+#define MOD_SCMI_PROTOCOL_ID_VOLTAGE_DOMAIN UINT32_C(0x17)
+
+/*!
+ * \brief SCMI Voltage Domain Protocol Message IDs
+ */
+enum scmi_voltd_command_id {
+    MOD_SCMI_VOLTD_DOMAIN_ATTRIBUTES = 0x003,
+    MOD_SCMI_VOLTD_DESCRIBE_LEVELS = 0x004,
+    MOD_SCMI_VOLTD_CONFIG_SET = 0x005,
+    MOD_SCMI_VOLTD_CONFIG_GET = 0x006,
+    MOD_SCMI_VOLTD_LEVEL_SET = 0x007,
+    MOD_SCMI_VOLTD_LEVEL_GET = 0x008,
+    MOD_SCMI_VOLTD_COMMAND_COUNT,
+};
+
+/*!
  * \}
  */
 

--- a/module/scmi_voltage_domain/include/internal/scmi_voltage_domain.h
+++ b/module/scmi_voltage_domain/include/internal/scmi_voltage_domain.h
@@ -1,0 +1,146 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2015-2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *      SCMI Voltage Domain Management Protocol Support
+ */
+
+#ifndef INTERNAL_SCMI_VOLTAGE_DOMAIN_H
+#define INTERNAL_SCMI_VOLTAGE_DOMAIN_H
+
+#include <mod_voltage_domain.h>
+
+#define SCMI_PROTOCOL_VERSION_VOLTD UINT32_C(0x10000)
+
+/*
+ * Generic p2a
+ */
+struct scmi_voltd_generic_p2a {
+    int32_t status;
+};
+
+/*
+ * Protocol Attributes
+ */
+
+#define SCMI_VOLTD_PROTOCOL_ATTRIBUTES_VOLTD_COUNT_MASK   UINT32_C(0xFFFF)
+#define SCMI_VOLTD_PROTOCOL_ATTRIBUTES_VOLTD_COUNT_MAX \
+    (SCMI_VOLTD_PROTOCOL_ATTRIBUTES_VOLTD_COUNT_MASK + 1)
+#define SCMI_VOLTD_PROTOCOL_ATTRIBUTES(_domain_count) \
+    ((_domain_count) & SCMI_VOLTD_PROTOCOL_ATTRIBUTES_VOLTD_COUNT_MASK)
+
+/*
+ * Voltage Domain Attributes
+ */
+
+struct scmi_voltd_attributes_a2p {
+    uint32_t domain_id;
+};
+
+#define SCMI_VOLTD_NAME_LENGTH_MAX 16
+
+struct scmi_voltd_attributes_p2a {
+    int32_t status;
+    uint32_t attributes;
+    char name[SCMI_VOLTD_NAME_LENGTH_MAX];
+};
+
+/*
+ * Get voltage level of a domain
+ */
+
+struct scmi_voltd_level_get_a2p {
+    uint32_t domain_id;
+};
+
+struct scmi_voltd_level_get_p2a {
+    int32_t status;
+    int32_t voltage_level;
+};
+
+/*
+ * Set voltage level of a domain
+ */
+
+struct scmi_voltd_level_set_a2p {
+    uint32_t domain_id;
+    uint32_t flags;
+    int32_t voltage_level;
+};
+
+struct scmi_voltd_level_set_p2a {
+    int32_t status;
+};
+
+/*
+ * Voltage Domain Config Set
+ */
+#define SCMI_VOLTD_CONFIG_MODE_MASK     0x0f
+
+struct scmi_voltd_config_set_a2p {
+    uint32_t domain_id;
+    uint32_t config;
+};
+
+struct scmi_voltd_config_set_p2a {
+    int32_t status;
+};
+
+struct scmi_voltd_config_get_a2p {
+    uint32_t domain_id;
+};
+
+struct scmi_voltd_config_get_p2a {
+    int32_t status;
+    uint32_t config;
+};
+
+/*
+ * Voltage Domain Describe Levels
+ */
+
+#define SCMI_VOLTD_LEVEL_FORMAT_RANGE     1
+#define SCMI_VOLTD_LEVEL_FORMAT_LIST      0
+
+#define SCMI_VOLTD_DESCRIBE_LEVELS_REMAINING_POS    16
+#define SCMI_VOLTD_DESCRIBE_LEVELS_FORMAT_POS       12
+#define SCMI_VOLTD_DESCRIBE_LEVELS_COUNT_POS        0
+
+#define SCMI_VOLTD_DESCRIBE_LEVELS_REMAINING_MASK \
+    (UINT32_C(0xFFFF) << SCMI_VOLTD_DESCRIBE_LEVELS_REMAINING_POS)
+#define SCMI_VOLTD_DESCRIBE_LEVELS_FORMAT_MASK \
+    (UINT32_C(0x1) << SCMI_VOLTD_DESCRIBE_LEVELS_FORMAT_POS)
+#define SCMI_VOLTD_DESCRIBE_LEVELS_COUNT_MASK \
+    (UINT32_C(0xFFF) << SCMI_VOLTD_DESCRIBE_LEVELS_COUNT_POS)
+
+#define SCMI_VOLTD_NUM_LEVELS_FLAGS(_count, _format, _remaining) \
+    ( \
+        (((_count) << SCMI_VOLTD_DESCRIBE_LEVELS_COUNT_POS) & \
+         SCMI_VOLTD_DESCRIBE_LEVELS_COUNT_MASK) | \
+        (((_remaining) << SCMI_VOLTD_DESCRIBE_LEVELS_REMAINING_POS) & \
+         SCMI_VOLTD_DESCRIBE_LEVELS_REMAINING_MASK) | \
+        (((_format) << SCMI_VOLTD_DESCRIBE_LEVELS_FORMAT_POS) & \
+         SCMI_VOLTD_DESCRIBE_LEVELS_FORMAT_MASK) \
+    )
+
+#define SCMI_VOLTD_LEVEL_RANGE_FLAGS \
+    SCMI_VOLTD_NUM_LEVELS_FLAGS(3, SCMI_VOLTD_LEVEL_FORMAT_RANGE, 0);
+
+#define SCMI_VOLTD_LEVEL_LIST_FLAGS(_cnt, _rem) \
+    SCMI_VOLTD_NUM_LEVELS_FLAGS((_cnt), SCMI_VOLTD_LEVEL_FORMAT_LIST, (_rem));
+
+struct scmi_voltd_describe_levels_a2p {
+    uint32_t domain_id;
+    uint32_t level_index;
+};
+
+struct scmi_voltd_describe_levels_p2a {
+    int32_t status;
+    uint32_t flags;
+    int32_t voltage[];
+};
+
+#endif /* INTERNAL_SCMI_VOLTAGE_DOMAIN_H */

--- a/module/scmi_voltage_domain/include/mod_scmi_voltage_domain.h
+++ b/module/scmi_voltage_domain/include/mod_scmi_voltage_domain.h
@@ -1,0 +1,118 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2015-2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *      SCMI Voltage Domain Management Protocol Support.
+ */
+
+#ifndef MOD_SCMI_VOLTAGE_DOMAIN_H
+#define MOD_SCMI_VOLTAGE_DOMAIN_H
+
+#include <fwk_id.h>
+
+#include <mod_voltage_domain.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*!
+ * \ingroup GroupModules Modules
+ * \defgroup GroupSCMI_VOLTD SCMI Voltage Domain Management Protocol
+ * \{
+ */
+
+#ifdef BUILD_HAS_RESOURCE_PERMISSIONS
+/*!
+ * \brief Permission flags governing the ability to use certain SCMI commands to
+ *      interact with a voltage domain.
+ *
+ * \details Setting a permission flag for a voltage domain enables the
+ *      corresponding functionality for any agent that has visibilty of
+ *      the voltage domain through its voltage domain device table.
+ */
+enum mod_scmi_voltd_permissions {
+    /*! No permissions (at least one must be granted) */
+    MOD_SCMI_VOLTD_PERM_INVALID = 0,
+
+    /*! The voltage domain information can be queried */
+    MOD_SCMI_VOLTD_PERM_GET_INFO = (1 << 1),
+
+    /*! The voltage domain config can be modified */
+    MOD_SCMI_VOLTD_PERM_SET_CONFIG = (1 << 2),
+
+    /*! The voltage level can be set to a new value */
+    MOD_SCMI_VOLTD_PERM_SET_LEVEL = (1 << 3),
+};
+#endif
+
+/*!
+ * \brief Voltage Domain device.
+ *
+ * \details Voltage Domain device structures are used in per-agent voltage
+ *      domain device tables. Each contains an identifier of an element that
+ *      will be bound to in order to use the voltage domain device. The
+ *      permission flags for the voltage domain are applied to any agent
+ *      that uses the device configuration in its voltage domain device
+ *      table.
+ */
+struct mod_scmi_voltd_device {
+    /*!
+     * \brief Voltage Domain element identifier.
+     *
+     * \details The module that owns the element must implement the Voltage
+     *      Domain API that is defined by the \c voltage domain module.
+     */
+    fwk_id_t element_id;
+
+    /*!
+     * \brief Exposed configuration of the domain.
+     *
+     * \details This reflects the configuration state of the voltage domain.
+     */
+    uint32_t config;
+};
+
+/*!
+ * \brief Agent descriptor.
+ *
+ * \details Describes an agent that uses the SCMI Voltage Domain Management
+ *      protocol. Provides a pointer to the agent's voltage domain device
+ *      table and the number of devices within the table.
+ */
+struct mod_scmi_voltd_agent {
+    /*! Pointer to a table of voltage domain devices visible to the agent */
+    struct mod_scmi_voltd_device *device_table;
+
+    /*!
+     * \brief The number of \c mod_scmi_voltd_device structures in the table
+     *      pointed to by \c device_table.
+     */
+    uint8_t device_count;
+};
+
+/*!
+ * \brief Module configuration.
+ */
+struct mod_scmi_voltd_config {
+    /*!
+     * \brief Pointer to the table of agent descriptors, used to provide
+     *      per-agent views of voltage domain in the system.
+     */
+    const struct mod_scmi_voltd_agent *agent_table;
+
+    /*! Number of agents in \ref agent_table */
+    size_t agent_count;
+};
+
+/*!
+ * \}
+ */
+
+/*!
+ * \}
+ */
+
+#endif /* MOD_SCMI_VOLTAGE_DOMAIN_H */

--- a/module/scmi_voltage_domain/src/Makefile
+++ b/module/scmi_voltage_domain/src/Makefile
@@ -1,0 +1,11 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BS_LIB_NAME := SCMI Voltage Domain Protocol
+BS_LIB_SOURCES := mod_scmi_voltage_domain.c
+
+include $(BS_DIR)/lib.mk

--- a/module/scmi_voltage_domain/src/mod_scmi_voltage_domain.c
+++ b/module/scmi_voltage_domain/src/mod_scmi_voltage_domain.c
@@ -660,8 +660,6 @@ static int scmi_voltd_init(fwk_id_t module_id, unsigned int element_count,
 
 static int scmi_voltd_bind(fwk_id_t id, unsigned int round)
 {
-    const unsigned int agent_count = scmi_voltd_ctx.config->agent_count;
-    unsigned int agent_idx = 0;
     int status = 0;
 
     if (round == 1)

--- a/module/scmi_voltage_domain/src/mod_scmi_voltage_domain.c
+++ b/module/scmi_voltage_domain/src/mod_scmi_voltage_domain.c
@@ -1,0 +1,710 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2015-2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     SCMI Voltage Domain Management Protocol Support.
+ */
+
+#include <internal/scmi_voltage_domain.h>
+
+#include <mod_voltage_domain.h>
+#include <mod_scmi.h>
+#include <mod_scmi_voltage_domain.h>
+
+#include <fwk_assert.h>
+#include <fwk_attributes.h>
+#include <fwk_id.h>
+#include <fwk_log.h>
+#include <fwk_macros.h>
+#include <fwk_mm.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+#include <fwk_status.h>
+#include <fwk_thread.h>
+
+#include <stdbool.h>
+#include <string.h>
+
+#ifdef BUILD_HAS_RESOURCE_PERMISSIONS
+#    include <mod_resource_perms.h>
+#endif
+
+struct voltd_operations {
+    /*
+     * Service identifier currently requesting operation from this voltage
+     * domain. A 'none' value indicates that there is no pending request.
+     */
+    fwk_id_t service_id;
+};
+
+struct scmi_voltd_ctx {
+    /*! SCMI Voltage Domain Module Configuration */
+    const struct mod_scmi_voltd_config *config;
+
+    /*!
+     * Pointer to the table of agent descriptors, used to provide per-agent
+     * views of voltage domains in the system.
+     */
+    const struct mod_scmi_voltd_agent *agent_table;
+
+    /* SCMI module API */
+    const struct mod_scmi_from_protocol_api *scmi_api;
+
+    /* Voltage domain module API */
+    const struct mod_voltd_api *voltd_api;
+
+    /* Number of domain devices */
+    int voltd_devices;
+
+    /* Pointer to a table of domain operations */
+    struct voltd_operations *voltd_ops;
+
+#ifdef BUILD_HAS_RESOURCE_PERMISSIONS
+    /* SCMI Resource Permissions API */
+    const struct mod_res_permissions_api *res_perms_api;
+#endif
+};
+
+/*
+ * SCMI Voltage Domain Message Handlers
+ */
+static int scmi_voltd_protocol_version_handler(fwk_id_t service_id,
+    const uint32_t *payload);
+static int scmi_voltd_protocol_attributes_handler(fwk_id_t service_id,
+    const uint32_t *payload);
+static int scmi_voltd_protocol_message_attributes_handler(
+    fwk_id_t service_id, const uint32_t *payload);
+static int scmi_voltd_domain_attributes_handler(fwk_id_t service_id,
+    const uint32_t *payload);
+static int scmi_voltd_config_get_handler(fwk_id_t service_id,
+    const uint32_t *payload);
+static int scmi_voltd_level_get_handler(fwk_id_t service_id,
+    const uint32_t *payload);
+static int scmi_voltd_level_set_handler(fwk_id_t service_id,
+    const uint32_t *payload);
+static int scmi_voltd_config_set_handler(fwk_id_t service_id,
+    const uint32_t *payload);
+static int scmi_voltd_describe_levels_handler(fwk_id_t service_id,
+    const uint32_t *payload);
+
+/*
+ * Internal variables. There is only 1 SCMI voltd intance.
+ */
+static struct scmi_voltd_ctx scmi_voltd_ctx;
+
+static int (*const handler_table[])(fwk_id_t, const uint32_t *) = {
+    [MOD_SCMI_PROTOCOL_VERSION] = scmi_voltd_protocol_version_handler,
+    [MOD_SCMI_PROTOCOL_ATTRIBUTES] = scmi_voltd_protocol_attributes_handler,
+    [MOD_SCMI_PROTOCOL_MESSAGE_ATTRIBUTES] =
+        scmi_voltd_protocol_message_attributes_handler,
+    [MOD_SCMI_VOLTD_DOMAIN_ATTRIBUTES] = scmi_voltd_domain_attributes_handler,
+    [MOD_SCMI_VOLTD_CONFIG_GET] = scmi_voltd_config_get_handler,
+    [MOD_SCMI_VOLTD_CONFIG_SET] = scmi_voltd_config_set_handler,
+    [MOD_SCMI_VOLTD_LEVEL_GET] = scmi_voltd_level_get_handler,
+    [MOD_SCMI_VOLTD_LEVEL_SET] = scmi_voltd_level_set_handler,
+    [MOD_SCMI_VOLTD_DESCRIBE_LEVELS] = scmi_voltd_describe_levels_handler,
+};
+
+static const unsigned int payload_size_table[] = {
+    [MOD_SCMI_PROTOCOL_VERSION] = 0,
+    [MOD_SCMI_PROTOCOL_ATTRIBUTES] = 0,
+    [MOD_SCMI_PROTOCOL_MESSAGE_ATTRIBUTES] =
+        sizeof(struct scmi_protocol_message_attributes_a2p),
+    [MOD_SCMI_VOLTD_DOMAIN_ATTRIBUTES] = sizeof(struct scmi_voltd_attributes_a2p),
+    [MOD_SCMI_VOLTD_CONFIG_GET] = sizeof(struct scmi_voltd_config_get_a2p),
+    [MOD_SCMI_VOLTD_CONFIG_SET] = sizeof(struct scmi_voltd_config_set_a2p),
+    [MOD_SCMI_VOLTD_LEVEL_GET] = sizeof(struct scmi_voltd_level_get_a2p),
+    [MOD_SCMI_VOLTD_LEVEL_SET] = sizeof(struct scmi_voltd_level_set_a2p),
+    [MOD_SCMI_VOLTD_DESCRIBE_LEVELS] =
+        sizeof(struct scmi_voltd_describe_levels_a2p),
+};
+
+/* Get SCMI VOLD agent device from incoming SCMI service ID */
+static int get_agent_entry(fwk_id_t service_id,
+                           const struct mod_scmi_voltd_agent **agent)
+{
+    int status;
+    unsigned int agent_idx;
+
+    status = scmi_voltd_ctx.scmi_api->get_agent_id(service_id, &agent_idx);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    if (agent_idx >= scmi_voltd_ctx.config->agent_count)
+        return FWK_E_PARAM;
+
+    *agent = scmi_voltd_ctx.agent_table + agent_idx;
+
+    return FWK_SUCCESS;
+}
+
+/* Get SCMI VOLD device from incoming SCMI service ID and element ID */
+static int get_device(fwk_id_t service_id, unsigned int elt_idx,
+                      const struct mod_scmi_voltd_device **out_device,
+                      const struct mod_scmi_voltd_agent **out_agent)
+{
+    int status = 0;
+    const struct mod_scmi_voltd_device *device = NULL;
+    const struct mod_scmi_voltd_agent *agent = NULL;
+
+    status = get_agent_entry(service_id, &agent);
+    if (status != FWK_SUCCESS)
+        return status;
+
+    if (elt_idx >= agent->device_count)
+        return FWK_E_RANGE;
+
+    device = &agent->device_table[elt_idx];
+    fwk_module_is_valid_element_id(device->element_id);
+
+    if (out_device)
+        *out_device = device;
+
+    if (out_agent)
+        *out_agent = agent;
+
+    return FWK_SUCCESS;
+}
+
+#ifdef BUILD_HAS_RESOURCE_PERMISSIONS
+/*
+ * SCMI Resource Permissions handler
+ */
+static unsigned int get_domain_id(const uint32_t *payload)
+{
+    /*
+     * Every SCMI Voltage Domain message is formatted with the domain ID
+     * as the first 32bit message element. We will use the voltd_attributes
+     * message as a basic format to retrieve the voltd ID to avoid
+     * unnecessary code.
+     */
+    const struct scmi_voltd_attributes_a2p *parameters =
+        (const struct scmi_voltd_attributes_a2p *)(void *)payload;
+
+    return parameters->domain_id;
+}
+
+static int scmi_voltd_permissions_handler(
+    fwk_id_t service_id,
+    const uint32_t *payload,
+    size_t payload_size,
+    unsigned int message_id)
+{
+    enum mod_res_perms_permissions perms;
+    unsigned int agent_id;
+    int status;
+
+    status = scmi_voltd_ctx.scmi_api->get_agent_id(service_id, &agent_id);
+    if (status != FWK_SUCCESS)
+        return FWK_E_ACCESS;
+
+    if (message_id < 3)
+        perms = scmi_voltd_ctx.res_perms_api->agent_has_protocol_permission(
+            agent_id, MOD_SCMI_PROTOCOL_ID_VOLTAGE_DOMAIN);
+    else
+        perms = scmi_voltd_ctx.res_perms_api->agent_has_resource_permission(
+            agent_id, MOD_SCMI_PROTOCOL_ID_VOLTAGE_DOMAIN, message_id,
+            get_domain_id(payload));
+
+    if (perms == MOD_RES_PERMS_ACCESS_ALLOWED)
+        return FWK_SUCCESS;
+
+    return FWK_E_ACCESS;
+}
+#endif
+
+/*
+ * Protocol Version
+ */
+static int scmi_voltd_protocol_version_handler(fwk_id_t service_id,
+    const uint32_t *payload)
+{
+    struct scmi_protocol_version_p2a outmsg = {
+        .status = SCMI_SUCCESS,
+        .version = SCMI_PROTOCOL_VERSION_VOLTD,
+    };
+
+    scmi_voltd_ctx.scmi_api->respond(service_id, &outmsg, sizeof(outmsg));
+    return FWK_SUCCESS;
+}
+
+/*
+ * Protocol Attributes
+ */
+static int scmi_voltd_protocol_attributes_handler(fwk_id_t service_id,
+    const uint32_t *payload)
+{
+    const struct mod_scmi_voltd_agent *agent = NULL;
+    struct scmi_protocol_attributes_p2a outmsg = {
+        .status = SCMI_GENERIC_ERROR,
+    };
+    size_t outmsg_size = sizeof(outmsg.status);
+
+    if (get_agent_entry(service_id, &agent) != FWK_SUCCESS)
+        goto exit;
+
+    fwk_assert(agent->device_count < SCMI_VOLTD_PROTOCOL_ATTRIBUTES_VOLTD_COUNT_MAX);
+    outmsg.attributes = SCMI_VOLTD_PROTOCOL_ATTRIBUTES(agent->device_count);
+    outmsg.status = SCMI_SUCCESS;
+    outmsg_size = sizeof(outmsg);
+
+exit:
+    scmi_voltd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
+    return FWK_SUCCESS;
+}
+
+/*
+ * Protocol Message Attributes
+ */
+static int scmi_voltd_protocol_message_attributes_handler(fwk_id_t service_id,
+    const uint32_t *payload)
+{
+    const struct scmi_protocol_message_attributes_a2p *inmsg;
+    unsigned int msg_id;
+    struct scmi_protocol_message_attributes_p2a outmsg = {
+        .status = SCMI_NOT_FOUND,
+    };
+    size_t outmsg_size = sizeof(outmsg.status);
+
+    inmsg = (void *)payload;
+    msg_id = inmsg->message_id;
+
+    if ((msg_id < FWK_ARRAY_SIZE(handler_table)) && handler_table[msg_id]) {
+        outmsg.status = SCMI_SUCCESS;
+        outmsg_size = sizeof(outmsg);
+    }
+
+    scmi_voltd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
+    return FWK_SUCCESS;
+}
+
+/*
+ * Voltage Domain Attributes
+ */
+static int scmi_voltd_domain_attributes_handler(fwk_id_t service_id,
+                                                const uint32_t *payload)
+{
+    const struct mod_scmi_voltd_device *device = NULL;
+    const struct scmi_voltd_attributes_a2p *inmsg = NULL;
+    struct scmi_voltd_attributes_p2a outmsg = {
+        .status = SCMI_NOT_FOUND,
+    };
+    size_t outmsg_size = sizeof(outmsg.status);
+    uint32_t config = 0;
+    int status = 0;
+
+    inmsg = (const struct scmi_voltd_attributes_a2p *)(void *)payload;
+
+    status = get_device(service_id, inmsg->domain_id, &device, NULL);
+    if (status != FWK_SUCCESS)
+        goto exit;
+
+    strncpy(outmsg.name, fwk_module_get_name(device->element_id),
+            sizeof(outmsg.name));
+
+    outmsg.status = SCMI_SUCCESS;
+    outmsg_size = sizeof(outmsg);
+
+exit:
+    scmi_voltd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
+    return FWK_SUCCESS;
+}
+
+/*
+ * Voltage domain configuration state
+ */
+static int scmi_voltd_config_get_handler(fwk_id_t service_id,
+    const uint32_t *payload)
+{
+    int status = 0;
+    const struct mod_scmi_voltd_agent *agent = NULL;
+    const struct mod_scmi_voltd_device *device = NULL;
+    const struct scmi_voltd_config_get_a2p *inmsg = NULL;
+    struct scmi_voltd_config_get_p2a outmsg = {
+        .status = SCMI_GENERIC_ERROR,
+    };
+    size_t outmsg_size = sizeof(outmsg.status);
+    uint32_t config = 0;
+
+    inmsg = (const struct scmi_voltd_config_get_a2p*)(void *)payload;
+
+    status = get_device(service_id, inmsg->domain_id, &device, NULL);
+    if (status != FWK_SUCCESS) {
+        outmsg.status = SCMI_NOT_FOUND;
+        goto exit;
+    }
+
+    status = scmi_voltd_ctx.voltd_api->get_config(device->element_id,
+                                                  &config);
+    if (status != FWK_SUCCESS)
+        goto exit;
+
+    outmsg.config = config;
+
+    outmsg.status = SCMI_SUCCESS;
+    outmsg_size = sizeof(outmsg);
+
+exit:
+    scmi_voltd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
+    return FWK_SUCCESS;
+}
+
+static int scmi_voltd_config_set_handler(fwk_id_t service_id,
+    const uint32_t *payload)
+{
+    int status = 0;
+    const struct mod_scmi_voltd_agent *agent = NULL;
+    const struct mod_scmi_voltd_device *device = NULL;
+    const struct scmi_voltd_config_set_a2p *inmsg = NULL;
+    struct scmi_voltd_config_set_p2a outmsg = {
+        .status = SCMI_GENERIC_ERROR,
+    };
+    size_t outmsg_size = sizeof(outmsg.status);
+
+    inmsg = (const struct scmi_voltd_config_set_a2p*)payload;
+
+    status = get_device(service_id, inmsg->domain_id, &device, NULL);
+    if (status != FWK_SUCCESS) {
+        outmsg.status = SCMI_NOT_FOUND;
+        goto exit;
+    }
+
+    status = scmi_voltd_ctx.voltd_api->set_config(device->element_id,
+                                                  inmsg->config);
+    if (status != FWK_SUCCESS)
+        goto exit;
+
+    outmsg.status = SCMI_SUCCESS;
+
+exit:
+    scmi_voltd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
+    return FWK_SUCCESS;
+}
+
+/*
+ * Voltage domain voltage level
+ */
+static int scmi_voltd_level_get_handler(fwk_id_t service_id,
+                                        const uint32_t *payload)
+{
+    int status = 0;
+    const struct mod_scmi_voltd_agent *agent = NULL;
+    const struct mod_scmi_voltd_device *device = NULL;
+    const struct scmi_voltd_level_get_a2p *inmsg = NULL;
+    struct scmi_voltd_level_get_p2a outmsg = {
+        .status = SCMI_GENERIC_ERROR,
+    };
+    size_t outmsg_size = sizeof(outmsg.status);
+    int32_t level = 0;
+
+    inmsg = (const struct scmi_voltd_level_get_a2p*)payload;
+
+    status = get_device(service_id, inmsg->domain_id, &device, NULL);
+    if (status != FWK_SUCCESS) {
+        outmsg.status = SCMI_NOT_FOUND;
+        goto exit;
+    }
+
+    status = scmi_voltd_ctx.voltd_api->get_level(device->element_id, &level);
+    if (status != FWK_SUCCESS)
+        goto exit;
+
+    outmsg.voltage_level = level;
+
+    outmsg.status = SCMI_SUCCESS;
+    outmsg_size = sizeof(outmsg);
+
+exit:
+    scmi_voltd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
+    return FWK_SUCCESS;
+}
+
+static int scmi_voltd_level_set_handler(fwk_id_t service_id,
+    const uint32_t *payload)
+{
+    int status = 0;
+    const struct mod_scmi_voltd_agent *agent = NULL;
+    const struct mod_scmi_voltd_device *device = NULL;
+    const struct scmi_voltd_level_set_a2p *inmsg = NULL;
+    struct scmi_voltd_level_set_p2a outmsg = {
+        .status = SCMI_GENERIC_ERROR,
+    };
+    size_t outmsg_size = sizeof(outmsg.status);
+
+    inmsg = (const struct scmi_voltd_level_set_a2p*)payload;
+
+    status = get_device(service_id, inmsg->domain_id, &device, NULL);
+    if (status != FWK_SUCCESS) {
+        outmsg.status = SCMI_NOT_FOUND;
+        goto exit;
+    }
+
+    status = scmi_voltd_ctx.voltd_api->set_level(device->element_id,
+                                                 inmsg->voltage_level);
+    if (status != FWK_SUCCESS)
+        goto exit;
+
+    outmsg.status = SCMI_SUCCESS;
+
+exit:
+    scmi_voltd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
+    return FWK_SUCCESS;
+}
+
+/*
+ * Describe voltage domain levels
+ */
+static int scmi_voltd_describe_levels_handler(fwk_id_t service_id,
+    const uint32_t *payload)
+{
+    int status = 0;
+    const struct mod_scmi_voltd_agent *agent = NULL;
+    const struct mod_scmi_voltd_device *device = NULL;
+    const struct scmi_voltd_describe_levels_a2p *inmsg = NULL;
+    struct scmi_voltd_describe_levels_p2a outmsg = {
+        .status = SCMI_GENERIC_ERROR,
+    };
+    const struct mod_scmi_from_protocol_api *scmi_api = scmi_voltd_ctx.scmi_api;
+    const struct mod_voltd_api *voltd_api = scmi_voltd_ctx.voltd_api;
+    size_t payload_size = sizeof(outmsg);
+    size_t max_payload_size = 0;
+    size_t max_level_items = 0;
+    struct mod_voltd_info info = { };
+    uint32_t level_index = 0;
+
+    inmsg = (const struct scmi_voltd_describe_levels_a2p*)(void *)payload;
+    level_index = inmsg->level_index;
+
+    status = get_device(service_id, inmsg->domain_id, &device, NULL);
+    if (status != FWK_SUCCESS) {
+        outmsg.status = SCMI_NOT_FOUND;
+        goto exit;
+    }
+
+    /*
+     * Get the maximum payload size to determine how many voltage level
+     * entries can be returned in one response.
+     */
+    status = scmi_api->get_max_payload_size(service_id, &max_payload_size);
+    if (status != FWK_SUCCESS)
+        goto exit;
+
+    if (max_payload_size < sizeof(outmsg))
+        max_level_items = 0;
+    else
+        max_level_items = (max_payload_size - sizeof(outmsg)) / sizeof(int32_t);
+
+    status = voltd_api->get_info(device->element_id, &info);
+    if (status != FWK_SUCCESS)
+        goto exit;
+
+    if (info.level_range.level_type == MOD_VOLTD_VOLTAGE_LEVEL_DISCRETE) {
+        /* The domain has a discrete list of voltage levels */
+        int32_t level_uv = 0;
+        unsigned int i = 0;
+        unsigned int level_count = 0;
+        unsigned int remaining_levels;
+
+        if (level_index >= info.level_range.level_count) {
+            outmsg.status = SCMI_OUT_OF_RANGE;
+            goto exit;
+        }
+
+        /* Can at least one entry be returned? */
+        if (!max_level_items) {
+            status = FWK_E_SIZE;
+            goto exit;
+        }
+
+        level_count = FWK_MIN(max_level_items,
+                              info.level_range.level_count - level_index);
+
+        remaining_levels = (info.level_range.level_count - level_index) -
+                           level_count;
+
+        /* Set number of returned levels in the message payload */
+        outmsg.flags = SCMI_VOLTD_LEVEL_LIST_FLAGS(level_count,
+                                                   remaining_levels);
+
+        /* Set each level entry in the payload to the related voltage level */
+        for (i = 0; i < level_count; i++, payload_size += sizeof(level_uv)) {
+            status = voltd_api->get_level_from_index(device->element_id,
+                                                     level_index + i, &level_uv);
+            if (status != FWK_SUCCESS)
+                goto exit;
+
+            status = scmi_api->write_payload(service_id, payload_size,
+                                             &level_uv, sizeof(level_uv));
+            if (status != FWK_SUCCESS)
+                goto exit;
+        }
+    } else {
+        /* The voltage domain has a linear level stepping */
+        int32_t voltd_range[3] = {
+            info.level_range.min_uv,
+            info.level_range.max_uv,
+            info.level_range.step_uv
+        };
+
+        /* Is the payload area large enough to return the complete triplet? */
+        if (max_level_items < 3) {
+            status = FWK_E_SIZE;
+            goto exit;
+        }
+
+        outmsg.flags = SCMI_VOLTD_LEVEL_RANGE_FLAGS;
+
+        status = scmi_api->write_payload(service_id, payload_size,
+                                         &voltd_range, sizeof(voltd_range));
+        if (status != FWK_SUCCESS)
+            goto exit;
+
+        payload_size += sizeof(voltd_range);
+    }
+
+    outmsg.status = SCMI_SUCCESS;
+    status = scmi_api->write_payload(service_id, 0, &outmsg, sizeof(outmsg));
+    if (status)
+        outmsg.status = SCMI_GENERIC_ERROR;
+
+exit:
+    if (outmsg.status == SCMI_SUCCESS)
+        scmi_api->respond(service_id, NULL, payload_size);
+    else
+        scmi_api->respond(service_id, &outmsg.status, sizeof(&outmsg.status));
+
+    // Return status or return FWK_SUCCESS???
+    return status;
+}
+
+/*
+ * Dispatch SCMI message to SCMI voltd module interface
+ */
+static int scmi_voltd_get_scmi_protocol_id(fwk_id_t protocol_id,
+                                           uint8_t *scmi_protocol_id)
+{
+    *scmi_protocol_id = MOD_SCMI_PROTOCOL_ID_VOLTAGE_DOMAIN;
+
+    return FWK_SUCCESS;
+}
+
+static int scmi_voltd_message_handler(fwk_id_t protocol_id, fwk_id_t service_id,
+    const uint32_t *payload, size_t payload_size, unsigned int message_id)
+{
+    int32_t outmsg;
+
+    static_assert(FWK_ARRAY_SIZE(handler_table) ==
+        FWK_ARRAY_SIZE(payload_size_table),
+        "[SCMI] Inconsistent voltage domain management protocol table sizes");
+    fwk_assert(payload != NULL);
+
+    if (message_id >= FWK_ARRAY_SIZE(handler_table)) {
+        outmsg = SCMI_NOT_FOUND;
+        goto error;
+    }
+
+    if (payload_size != payload_size_table[message_id]) {
+        outmsg = SCMI_PROTOCOL_ERROR;
+        goto error;
+    }
+
+#ifdef BUILD_HAS_RESOURCE_PERMISSIONS
+    if (scmi_voltd_permissions_handler(service_id, payload, payload_size,
+                                       message_id) != FWK_SUCCESS) {
+        outmsg = SCMI_DENIED;
+        goto error;
+    }
+#endif
+
+    return handler_table[message_id](service_id, payload);
+
+error:
+    scmi_voltd_ctx.scmi_api->respond(service_id, &outmsg, sizeof(outmsg));
+    return FWK_SUCCESS;
+}
+
+static struct mod_scmi_to_protocol_api scmi_voltd_mod_scmi_to_protocol_api = {
+    .get_scmi_protocol_id = scmi_voltd_get_scmi_protocol_id,
+    .message_handler = scmi_voltd_message_handler
+};
+
+/*
+ * Framework handlers
+ */
+static int scmi_voltd_init(fwk_id_t module_id, unsigned int element_count,
+                           const void *data)
+{
+    int voltd_devices;
+    const struct mod_scmi_voltd_config *config =
+        (const struct mod_scmi_voltd_config *)data;
+
+    if ((config == NULL) || (config->agent_table == NULL))
+        return FWK_E_PARAM;
+
+    scmi_voltd_ctx.config = config;
+    scmi_voltd_ctx.agent_table = config->agent_table;
+
+    voltd_devices = fwk_module_get_element_count(fwk_module_id_voltage_domain);
+    if (voltd_devices == FWK_E_PARAM)
+        return FWK_E_PANIC;
+
+    scmi_voltd_ctx.voltd_devices = voltd_devices;
+    scmi_voltd_ctx.voltd_ops = fwk_mm_calloc((unsigned int)voltd_devices,
+                                             sizeof(struct voltd_operations));
+
+    return FWK_SUCCESS;
+}
+
+static int scmi_voltd_bind(fwk_id_t id, unsigned int round)
+{
+    const unsigned int agent_count = scmi_voltd_ctx.config->agent_count;
+    unsigned int agent_idx = 0;
+    int status = 0;
+
+    if (round == 1)
+        return FWK_SUCCESS;
+
+    status = fwk_module_bind(FWK_ID_MODULE(FWK_MODULE_IDX_SCMI),
+                             FWK_ID_API(FWK_MODULE_IDX_SCMI,
+                                        MOD_SCMI_API_IDX_PROTOCOL),
+                             &scmi_voltd_ctx.scmi_api);
+    if (status != FWK_SUCCESS)
+        return status;
+
+#ifdef BUILD_HAS_RESOURCE_PERMISSIONS
+    status = fwk_module_bind(FWK_ID_MODULE(FWK_MODULE_IDX_RESOURCE_PERMS),
+                             FWK_ID_API(FWK_MODULE_IDX_RESOURCE_PERMS,
+                                        MOD_RES_PERM_RESOURCE_PERMS),
+                             &scmi_voltd_ctx.res_perms_api);
+    if (status != FWK_SUCCESS)
+        return status;
+#endif
+
+    return fwk_module_bind(FWK_ID_MODULE(FWK_MODULE_IDX_VOLTAGE_DOMAIN),
+                           FWK_ID_API(FWK_MODULE_IDX_VOLTAGE_DOMAIN, 0),
+                           &scmi_voltd_ctx.voltd_api);
+}
+
+static int scmi_voltd_process_bind_request(fwk_id_t source_id,
+    fwk_id_t target_id, fwk_id_t api_id, const void **api)
+{
+    if (!fwk_id_is_equal(source_id, FWK_ID_MODULE(FWK_MODULE_IDX_SCMI)))
+        return FWK_E_ACCESS;
+
+    *api = &scmi_voltd_mod_scmi_to_protocol_api;
+
+    return FWK_SUCCESS;
+}
+
+/* SCMI Voltage Domain Management Protocol Definition */
+const struct fwk_module module_scmi_voltage_domain = {
+    .name = "SCMI Voltage Domain Management Protocol",
+    .api_count = 1,
+    .type = FWK_MODULE_TYPE_PROTOCOL,
+    .init = scmi_voltd_init,
+    .bind = scmi_voltd_bind,
+    .process_bind_request = scmi_voltd_process_bind_request,
+};

--- a/module/voltage_domain/include/mod_voltage_domain.h
+++ b/module/voltage_domain/include/mod_voltage_domain.h
@@ -1,0 +1,325 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOD_VOLTAGE_DOMAIN_H
+#define MOD_VOLTAGE_DOMAIN_H
+
+#include <fwk_element.h>
+#include <fwk_id.h>
+#include <fwk_module_idx.h>
+
+#include <stdint.h>
+
+/*!
+ * \addtogroup GroupModules Modules
+ * @{
+ */
+
+/*!
+ * \defgroup GroupVoltageDomain Voltage domain HAL
+ *
+ * \details A Hardware Abstraction Layer for configuring voltage
+ * domains regulators.
+ *
+ * @{
+ */
+
+/*! Mask for voltage domain mode type in domain configuration */
+#define MOD_VOLTD_MODE_TYPE_MASK        BIT(3)
+
+/*! Mask value for implementation mode type in domain configuration */
+#define MOD_VOLTD_MODE_TYPE_IMPL        BIT(3)
+
+/*! Mask value for architecture mode type in domain configuration */
+#define MOD_VOLTD_MODE_TYPE_ARCH        0
+
+/*! Enabled domain configuration mode */
+#define MOD_VOLTD_MODE_ON               7
+
+/*! Disabled domain configuration mode */
+#define MOD_VOLTD_MODE_OFF              0
+
+/*!
+ * \brief APIs that the module makes available to entities requesting binding.
+ */
+enum mod_voltd_api_type {
+    /*! Voltage Domaon (voltd) HAL */
+    MOD_VOLTD_API_TYPE_HAL,
+
+    /*! Number of defined APIs */
+    MOD_VOLTD_API_COUNT,
+};
+
+/*!
+ * \brief Voltage level description types.
+ */
+enum mod_voltd_voltage_level_type {
+    /*! The voltage domain has a discrete set of rates that it can attain */
+    MOD_VOLTD_VOLTAGE_LEVEL_DISCRETE,
+
+    /*! The voltage domain has a continuous range of rates with a constant step */
+    MOD_VOLTD_VOLTAGE_LEVEL_CONTINUOUS,
+};
+
+/*!
+ * \brief Voltage domain element configuration data.
+ */
+struct mod_voltd_dev_config {
+    /*! Reference to the device element within the associated driver module */
+    const fwk_id_t driver_id;
+
+    /*! Reference to the API provided by the device driver module */
+    const fwk_id_t api_id;
+};
+
+/*!
+ * \brief Range of supported levels for a voltage domain.
+ */
+struct mod_voltd_range {
+    /*! The type of level range description provided (discrete or continuous) */
+    enum mod_voltd_voltage_level_type level_type;
+
+    /*! Minimum voltage level (in uV) */
+    int min_uv;
+
+    /*! Maximum voltage level (in uV) */
+    int max_uv;
+
+    /*!
+     * The number of uV by which the level can be incremented at each step
+     * throughout the domain's range. Valid only when level_type is equal to
+     * \ref mod_voltd_voltage_level_type.MOD_VOLTD_VOLTAGE_LEVEL_CONTINUOUS.
+     */
+    int step_uv;
+
+    /*! The number of unique voltage levels that the domain can attain */
+    size_t level_count;
+};
+
+/*!
+ * \brief Voltage domain properties exposed via the get_info() API function.
+ *
+ * \details This structure is intended to store voltage domain information that
+ *     is static and which does not change during runtime. Dynamic information,
+ *     such as the current voltage domain configuration, are exposed through
+ *     functions in the voltage domain and voltage domain driver APIs.
+ */
+struct mod_voltd_info {
+    /*! Human-friendly voltage domain name */
+    const char *name;
+
+    /*! Range of supported voltage levels */
+    struct mod_voltd_range level_range;
+
+    /*! Number of discrete voltage levels supported */
+    size_t level_count;
+};
+
+/*!
+ * \brief Voltage domain driver interface.
+ */
+struct mod_voltd_drv_api {
+    /*! Name of the driver */
+    const char *name;
+
+    /*!
+     * \brief Set a new voltage level by providing a a level in microvolts.
+     *
+     * \param voltd_id Voltage domain device identifier.
+     *
+     * \param level_uv The desired voltage in microvolt.
+     *
+     * \retval FWK_PENDING The request is pending. The driver will provide the
+     *      requested value later through the driver response API.
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \return One of the standard framework error codes.
+     */
+    int (*set_level)(fwk_id_t voltd_id, int level_uv);
+
+    /*!
+     * \brief Get the current voltage level of a domain in microvolts (uV).
+     *
+     * \param voltd_id Voltage domain device identifier.
+     *
+     * \param[out] level_uv The current voltage level in microvolts.
+     *
+     * \retval FWK_PENDING The request is pending. The driver will provide the
+     *      requested value later through the driver response API.
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \return One of the standard framework error codes.
+     */
+    int (*get_level)(fwk_id_t voltd_id, int *level_uv);
+
+    /*!
+     * \brief Set the running configuration of a voltage domain.
+     *
+     * \param voltd_id Voltage domain device identifier.
+     *
+     * \param config One of the valid domain configuration IDs.
+     *
+     * \retval FWK_PENDING The request is pending. The driver will provide the
+     *      requested value later through the driver response API.
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \return One of the standard framework error codes.
+     */
+    int (*set_config)(fwk_id_t voltd_id, uint32_t config);
+
+    /*!
+     * \brief Get the running configuration of a voltage domain.
+     *
+     * \param voltd_id Voltage domain device identifier.
+     *
+     * \param[out] config The current voltage domain configuration.
+     *
+     * \retval FWK_PENDING The request is pending. The driver will provide the
+     *      requested value later through the driver response API.
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \return One of the standard framework error codes.
+     */
+    int (*get_config)(fwk_id_t voltd_id, uint32_t *config);
+
+    /*!
+     * \brief Get information a voltage domain element.
+     *
+     * \param voltd_id Voltage domain device identifier.
+     *
+     * \param[out] info The voltage domain information.
+     *
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \return One of the standard framework error codes.
+     */
+     int (*get_info)(fwk_id_t voltd_id, struct mod_voltd_info *info);
+
+    /*!
+     * \brief Get voltage level in microvolts from an index in level's range.
+     *
+     * \param elt_id Voltage domain device identifier.
+     *
+     * \param index The index into the domain level's range.
+     *
+     * \param[out] level_uv The voltage level, in microvolts, for the index.
+     *
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \return One of the standard framework error codes.
+     */
+    int (*get_level_from_index)(fwk_id_t elt_id, unsigned int index,
+                                int *level_uv);
+};
+
+/*!
+ * \brief Voltage domain interface.
+ */
+struct mod_voltd_api {
+    /*!
+     * \brief Set a new voltage level by providing a level in microvolts (uV).
+     *
+     * \param voltd_id Voltage domain device identifier.
+     *
+     * \param rate The desired voltage level in microvolts (uV).
+     *
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \retval FWK_PENDING The request is pending. The result for this operation
+     *      will be provided via a response event.
+     * \retval FWK_E_PARAM The voltage domain identifier was invalid.
+     * \retval FWK_E_SUPPORT Deferred handling of asynchronous drivers is not
+     *      supported.
+     * \return One of the standard framework error codes.
+     */
+    int (*set_level)(fwk_id_t voltd_id, int level_uv);
+
+    /*!
+     * \brief Get the current rate of a voltd in Hertz (Hz).
+     *
+     * \param voltd_id Voltage domain device identifier.
+     *
+     * \param[out] rate The current voltage level in microvolts.
+     *
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \retval FWK_PENDING The request is pending. The requested rate will be
+     *      provided via a response event.
+     * \retval FWK_E_PARAM The voltage domain identifier was invalid.
+     * \retval FWK_E_PARAM The rate pointer was NULL.
+     * \retval FWK_E_SUPPORT Deferred handling of asynchronous drivers is not
+     *      supported.
+     * \return One of the standard framework error codes.
+     */
+    int (*get_level)(fwk_id_t voltd_id, int *level_uv);
+
+    /*!
+     * \brief Set the running configuration of a voltage domain.
+     *
+     * \param voltd_id Voltage domain device identifier.
+     *
+     * \param config One of the valid voltage domain configurations.
+     *
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \retval FWK_PENDING The request is pending. The result for this operation
+     *      will be provided via a response event.
+     * \retval FWK_E_PARAM The voltage domain identifier was invalid.
+     * \retval FWK_E_SUPPORT Deferred handling of asynchronous drivers is not
+     *      supported.
+     * \return One of the standard framework error codes.
+     */
+    int (*set_config)(fwk_id_t voltd_id, uint32_t config);
+
+    /*!
+     * \brief Get the running configuration of a voltage domain.
+     *
+     * \param voltd_id Voltage domain device identifier.
+     *
+     * \param[out] config The current voltage domain configuration.
+     *
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \retval FWK_PENDING The request is pending. The requested configuration
+     *      will beprovided via a response event.
+     * \retval FWK_E_PARAM The voltage domain identifier was invalid.
+     * \retval FWK_E_PARAM The configuration pointer was NULL.
+     * \retval FWK_E_SUPPORT Deferred handling of asynchronous drivers is not
+     *      supported.
+     * \return One of the standard framework error codes.
+     */
+    int (*get_config)(fwk_id_t voltd_id, uint32_t *config);
+
+    /*!
+     * \brief Get information a voltage domain element.
+     *
+     * \param voltd_id Voltage domain device identifier.
+     *
+     * \param[out] info The voltage domain information.
+     *
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \return One of the standard framework error codes.
+     */
+     int (*get_info)(fwk_id_t voltd_id, struct mod_voltd_info *info);
+
+    /*!
+     * \brief Get a voltage level in microvolts from an index in the range.
+     *
+     * \param voltd_id Voltage domain device identifier.
+     *
+     * \param index The index into the domain's voltage level's range.
+     *
+     * \param[out] level_uv The voltage level, in microvolts.
+     *
+     * \retval FWK_SUCCESS The operation succeeded.
+     * \retval FWK_E_PARAM The voltage domain identifier was invalid.
+     * \retval FWK_E_PARAM The rate pointer was NULL.
+     * \return One of the standard framework error codes.
+     */
+    int (*get_level_from_index)(fwk_id_t voltd_id, unsigned int index,
+                                int *level_uv);
+};
+
+/*!
+ * @}
+ */
+
+/*!
+ * @}
+ */
+
+#endif /* MOD_VOLTAGE_DOMAIN_H */

--- a/module/voltage_domain/src/Makefile
+++ b/module/voltage_domain/src/Makefile
@@ -1,0 +1,11 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2020, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BS_LIB_NAME := Voltage domain/regulators HAL
+BS_LIB_SOURCES := mod_voltage_domain.c
+
+include $(BS_DIR)/lib.mk

--- a/module/voltage_domain/src/mod_voltage_domain.c
+++ b/module/voltage_domain/src/mod_voltage_domain.c
@@ -1,0 +1,217 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2017-2020, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <mod_voltage_domain.h>
+
+#include <fwk_assert.h>
+#include <fwk_id.h>
+#include <fwk_mm.h>
+#include <fwk_module.h>
+#include <fwk_status.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Device context */
+struct voltd_dev_ctx {
+    /* Pointer to the element configuration data */
+    const struct mod_voltd_dev_config *config;
+
+    /* Driver API */
+    struct mod_voltd_drv_api *api;
+};
+
+/* Module context */
+struct voltd_ctx {
+    /* Table of elements context */
+    struct voltd_dev_ctx *dev_ctx_table;
+};
+
+/* Expect a single module describing all agents */
+static struct voltd_ctx module_ctx;
+
+/*
+ * Utility functions
+ */
+
+static void get_ctx(fwk_id_t voltd_id, struct voltd_dev_ctx **ctx)
+{
+    fwk_assert(fwk_module_is_valid_element_id(voltd_id));
+
+    *ctx = &module_ctx.dev_ctx_table[fwk_id_get_element_idx(voltd_id)];
+}
+
+/*
+ * Module API functions
+ */
+
+static int voltd_set_level(fwk_id_t voltd_id, int level_uv)
+{
+    struct voltd_dev_ctx *ctx;
+
+    get_ctx(voltd_id, &ctx);
+
+    if (!ctx->api->set_level)
+        return FWK_E_SUPPORT;
+
+    return ctx->api->set_level(ctx->config->driver_id, level_uv);
+}
+
+static int voltd_get_level(fwk_id_t voltd_id, int *level_uv)
+{
+    struct voltd_dev_ctx *ctx;
+
+    get_ctx(voltd_id, &ctx);
+
+    if (level_uv == NULL)
+        return FWK_E_PARAM;
+
+    if (!ctx->api->get_level)
+        return FWK_E_SUPPORT;
+
+    return ctx->api->get_level(ctx->config->driver_id, level_uv);
+}
+
+static int voltd_set_config(fwk_id_t voltd_id, uint32_t config)
+{
+    struct voltd_dev_ctx *ctx;
+
+    get_ctx(voltd_id, &ctx);
+
+    if (!ctx->api->set_config)
+        return FWK_E_SUPPORT;
+
+    return ctx->api->set_config(ctx->config->driver_id, config);
+}
+
+static int voltd_get_config(fwk_id_t voltd_id, uint32_t *config)
+{
+    struct voltd_dev_ctx *ctx;
+
+    get_ctx(voltd_id, &ctx);
+
+    if (config == NULL)
+        return FWK_E_PARAM;
+
+    if (!ctx->api->get_config)
+        return FWK_E_SUPPORT;
+
+    return ctx->api->get_config(ctx->config->driver_id, config);
+}
+
+static int voltd_get_info(fwk_id_t voltd_id, struct mod_voltd_info *info)
+{
+    int status;
+    struct voltd_dev_ctx *ctx;
+
+    get_ctx(voltd_id, &ctx);
+
+    fwk_assert(info);
+
+    status = ctx->api->get_info(ctx->config->driver_id, info);
+
+    if (status == FWK_SUCCESS && info->name == NULL)
+        info->name = fwk_module_get_name(voltd_id);
+
+    return status;
+}
+
+static int voltd_get_level_from_index(fwk_id_t dev_id, unsigned int index,
+                                      int *level_uv)
+{
+    struct voltd_dev_ctx *ctx = NULL;
+
+    get_ctx(dev_id, &ctx);
+
+    if (level_uv == NULL)
+        return FWK_E_PARAM;
+
+    return ctx->api->get_level_from_index(ctx->config->driver_id, index,
+                                          level_uv);
+}
+
+static const struct mod_voltd_api voltd_api = {
+    .get_config = voltd_get_config,
+    .set_config = voltd_set_config,
+    .get_level = voltd_get_level,
+    .set_level = voltd_set_level,
+    .get_info = voltd_get_info,
+    .get_level_from_index = voltd_get_level_from_index,
+};
+
+/*
+ * Framework handler functions
+ */
+
+static int voltd_init(fwk_id_t module_id, unsigned int element_count,
+                      const void *data)
+{
+    if (element_count == 0)
+        return FWK_SUCCESS;
+
+    module_ctx.dev_ctx_table = fwk_mm_calloc(element_count,
+                                             sizeof(struct voltd_dev_ctx));
+    return FWK_SUCCESS;
+}
+
+static int voltd_dev_init(fwk_id_t element_id, unsigned int sub_element_count,
+                          const void *data)
+{
+    struct voltd_dev_ctx *ctx;
+    const struct mod_voltd_dev_config *dev_config = data;
+
+    ctx = &module_ctx.dev_ctx_table[fwk_id_get_element_idx(element_id)];
+    ctx->config = dev_config;
+
+    return FWK_SUCCESS;
+}
+
+static int voltd_bind(fwk_id_t id, unsigned int round)
+{
+    struct voltd_dev_ctx *ctx;
+
+    if (round == 1)
+        return FWK_SUCCESS;
+
+    if (!fwk_id_is_type(id, FWK_ID_TYPE_ELEMENT)) {
+        /* Only element binding is supported */
+        return FWK_SUCCESS;
+    }
+
+    ctx = &module_ctx.dev_ctx_table[fwk_id_get_element_idx(id)];
+
+    return fwk_module_bind(ctx->config->driver_id,
+                           ctx->config->api_id,
+                           &ctx->api);
+}
+
+static int voltd_process_bind_request(fwk_id_t source_id, fwk_id_t target_id,
+                                      fwk_id_t api_id, const void **api)
+{
+    enum mod_voltd_api_type api_type = fwk_id_get_api_idx(api_id);
+
+    switch (api_type) {
+    case MOD_VOLTD_API_TYPE_HAL:
+        *api = &voltd_api;
+        break;
+    default:
+        return FWK_E_ACCESS;
+    }
+
+    return FWK_SUCCESS;
+}
+
+const struct fwk_module module_voltage_domain = {
+    .name = "Voltage Domain (VOLTD) HAL",
+    .type = FWK_MODULE_TYPE_HAL,
+    .api_count = MOD_VOLTD_API_COUNT,
+    .init = voltd_init,
+    .element_init = voltd_dev_init,
+    .bind = voltd_bind,
+    .process_bind_request = voltd_process_bind_request,
+};


### PR DESCRIPTION
Introduces a basic Voltage Domain driver and a SCMI voltage domain
protocol driver. SCMI voltage domain protocol is introduced in SCMI
specification v3.

Module voltage_domain is a generic HAL for voltage domains, aka power
supply regulators drivers. Based on module configuration, the module
binds each element to the voltage domain backend driver thru a generic
driver interface:
- set & get config, using SCMI voltage domain configuration format.
- set & get voltage level, in microvolt (uV)

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>