### PR TITLE
module: dvfs: fix get_opp_for_voltage

### DIFF
--- a/module/dvfs/src/mod_dvfs.c
+++ b/module/dvfs/src/mod_dvfs.c
@@ -201,7 +201,7 @@ static const struct mod_dvfs_opp *get_opp_for_voltage(
     for (opp_idx = 0; opp_idx < ctx->opp_count; opp_idx++) {
         opp = &ctx->config->opps[opp_idx];
 
-        if (opp->level != voltage)
+        if (opp->voltage != voltage)
             continue;
 
         return opp;


### PR DESCRIPTION
get_opp_for_voltage() should use voltage instead of level where looking
for an OPP.

Signed-off-by: Vincent Guittot <vincent.guittot@linaro.org>