### PR TITLE
tc0/pl011: Do not subscribe to power domain notification for pl011

### DIFF
--- a/product/tc0/scp_ramfw/config_pl011.c
+++ b/product/tc0/scp_ramfw/config_pl011.c
@@ -25,9 +25,7 @@ const struct fwk_module_config config_pl011 = {
                     .baud_rate_bps = 115200,
                     .clock_rate_hz = 24 * FWK_MHZ,
                     .clock_id = FWK_ID_NONE_INIT,
-                    .pd_id = FWK_ID_ELEMENT_INIT(
-                        FWK_MODULE_IDX_POWER_DOMAIN,
-                        PD_STATIC_DEV_IDX_SYSTOP),
+                    .pd_id = FWK_ID_NONE_INIT,
                 },
         },
 


### PR DESCRIPTION
The SYSTOP power domain is already ON in RAM firmware, therefore
do not wait for notification.

Change-Id: I9b2dc28fa2736169ce9f2dcec2e5986e5a994da5
Signed-off-by: Usama Arif <usama.arif@arm.com>