### PR TITLE
Rcar: Disable CPP checking for Rcar platform.

### DIFF
--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -52,3 +52,6 @@ memleak:framework/test/fwk_test.c:145
 // Cppcheck does not inspect these conditions deeply enough to know that the
 // dereference can only occur if the check succeeds
 nullPointerRedundantCheck:framework/src/fwk_io.c
+
+// No checking of Rcar product
+*:product/rcar


### PR DESCRIPTION
This patch disables CI cppcheck for the Rcar product.

Change-Id: Ic9cbd4b2512bd0eb7bf79a5b3794fc8341307ea7
Signed-off-by: Jim Quigley <jim.quigley@arm.com>