### PR TITLE
scp_v2.7: Release notes for SCP firmware v2.7.0

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -3,6 +3,78 @@ SCP-firmware Change Log
 
 Copyright (c) 2019-2020, Arm Limited and Contributors. All rights reserved.
 
+SCP-firmware - version 2.7.0
+============================
+
+New features
+------------
+
+- Support for the following platforms has been added:
+    - Total Compute (tc0) platform
+    - Renesas R-Car
+    - RD-Daniel Config-XLR
+
+- Support for interactive debugger and CLI has been added.
+
+- New modules:
+    - Voltage Domain driver and related SCMIv3 protocol driver
+    - gtimer: Add framework time driver implementation
+    - module: statistics: add basic functionality
+    - fip: Introduce 'fip' parser module
+
+- SCMI Enhancements:
+    - SCMI: Resource Permissions Module
+    - SCMIv2: Implement SCMIv2 fast channels performance protocol API
+    - SCMIv2: Implement notifications for SCMIv2
+    - scmi_perf: Add support for performance statistics
+    - SCMI: Clock Protocol policy handler
+    - SCMI: Performance Protocol policy handler
+    - SCMI: Power Domain Protocol policy handler
+    - SCMI: System Power Protocol policy handler
+    - SCMI: Reset Domain Protocol policy handler
+    - SCMI: Base Protocol Permissions
+    - SCMI: Clock Protocol Permissions
+    - SCMI: System Power Protocol Permissions
+    - SCMI: Power Domain Protocol Permissions
+    - SCMI: Performance Protocol Permissions
+    - SCMI: Sensor Protocol Permissions
+    - SCMI: Reset Domain Protocol Permissions
+    - SCMI: Device permissions
+
+- Framework:
+    - fwk: Use standard library memory allocator
+    - fwk: Integrate logging functionality into the framework
+    - fwk/thread: Single-threaded mode for blocking events
+    - fwk: Introduce input/output component
+
+Changed
+-------
+
+- Documentation:
+    - doc: SCP Firmware Threat Model
+    - doc: Add clang-format configuration
+    - doc: Recreate Doxyfile with Doxywizard
+
+- Framework:
+    - fwk: Remove dependency on RTX threads
+    - fwk: Add support for static element tables
+    - fwk: Rework assertion logic
+    - fwk: Initialize module context structures early
+
+- Modules:
+    - bootloader: Add support for SDS-less boot
+    - DVFS: Allow inexact performance levels.
+    - DVFS/SCMI-perf: Abstract performance levels.
+    - scmi_system_power: Add graceful system power support
+    - bootloader: Unify bootloader messages
+    - module/scmi: Add SCMI notifications handling APIs
+
+Notes
+-----
+
+This release implements full SCMI v2 support but we do not guarantee complete
+compliance wth the SCMI v2.0 specification at the moment.
+
 SCP-firmware - version 2.6.0
 ============================
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-SCP-firmware - version 2.6
+SCP-firmware - version 2.7
 ==========================
 
 Copyright (c) 2011-2020, Arm Limited. All rights reserved.
@@ -46,9 +46,12 @@ Functionality
     - Performance domain management (Dynamic voltage and frequency scaling)
     - Clock management
     - Sensor management
+    - Reset domain management
+    - Voltage domain management
 - System Control and Management Interface (SCMI, platform-side)
 - Support for the GNU Arm Embedded and Arm Compiler 6 toolchains
 - Support for platforms with several control processors
+- Interactive debugging
 
 Platforms
 ---------
@@ -65,6 +68,10 @@ Virtual Platforms (FVPs):
   RdN1EdgeX2 FVP)
 - RD-Daniel Config-M reference design  (Please contact Arm directly to obtain the
   RdDaniel-CfgM FVP)
+- RD-Daniel Config-XLR reference design  (Please contact Arm directly to obtain the
+  RdDaniel-CfgXLR FVP)
+- Renesas R-Car platform
+- Total Compute (tc0) platform (Please contact Arm directly to obtain the TC0 FVP)
 
 License
 -------


### PR DESCRIPTION
This patch adds the release notes for v2.7.0. The change log lists the
major new features in the release.

Change-Id: Ia6ed47dcecf7936fd83fed8eb3acdc1ac1f5f76b
Signed-off-by: Jim Quigley <jim.quigley@arm.com>