### PR TITLE
juno/xrp7724: Restore error on out of margin

### DIFF
--- a/product/juno/module/juno_xrp7724/src/mod_juno_xrp7724.c
+++ b/product/juno/module/juno_xrp7724/src/mod_juno_xrp7724.c
@@ -876,6 +876,8 @@ static int juno_xrp7724_psu_process_request(fwk_id_t id,
             ((adc_val - PSU_TARGET_MARGIN_MV) >
             ctx->juno_xrp7724_dev_psu.psu_set_voltage)) {
             FWK_LOG_INFO("[XRP7724] Voltage set out of margin");
+
+            status = FWK_E_DEVICE;
         } else {
             ctx->juno_xrp7724_dev_psu.current_voltage =
                 ctx->juno_xrp7724_dev_psu.psu_set_voltage;


### PR DESCRIPTION
A previous commit [1] removed the status error when the margin is out of
margin. In fact this error is required to be returned so the HAL and its logic
to handle the error can take place.

Restore the error.

[1] 7b3bf3a2fc55d4a8f1a11ea416d791652f89e5da

Change-Id: Ieeaaaf23eaea85d8bfc26f0d74281f6c6114aed3
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>