### PR TITLE
scmi_system_power/boards: Add default timer_id and add extra check

### DIFF
--- a/module/scmi_system_power/include/mod_scmi_system_power.h
+++ b/module/scmi_system_power/include/mod_scmi_system_power.h
@@ -63,6 +63,9 @@ struct mod_scmi_system_power_config {
 
     /*!
      * \brief Identifier of the alarm for graceful request timeout.
+     *
+     * \note This alarm is optional, if it is not used it must be set to
+     * FWK_ID_NONE
      */
     fwk_id_t alarm_id;
 

--- a/product/morello/scp_ramfw_fvp/config_scmi_system_power.c
+++ b/product/morello/scp_ramfw_fvp/config_scmi_system_power.c
@@ -15,5 +15,5 @@ const struct fwk_module_config config_scmi_system_power = {
         &(struct mod_scmi_system_power_config){
             .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
             .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0,
-        },
+            .alarm_id = FWK_ID_NONE_INIT },
 };

--- a/product/n1sdp/scp_ramfw/config_scmi_system_power.c
+++ b/product/n1sdp/scp_ramfw/config_scmi_system_power.c
@@ -11,8 +11,8 @@
 #include <fwk_module.h>
 
 const struct fwk_module_config config_scmi_system_power = {
-    .data = &((struct mod_scmi_system_power_config) {
+    .data = &((struct mod_scmi_system_power_config){
         .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
-        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0
-    }),
+        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0,
+        .alarm_id = FWK_ID_NONE_INIT }),
 };

--- a/product/rddaniel/scp_ramfw/config_scmi_system_power.c
+++ b/product/rddaniel/scp_ramfw/config_scmi_system_power.c
@@ -11,8 +11,8 @@
 #include <fwk_module.h>
 
 const struct fwk_module_config config_scmi_system_power = {
-    .data = &((struct mod_scmi_system_power_config) {
+    .data = &((struct mod_scmi_system_power_config){
         .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
-        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0
-    }),
+        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0,
+        .alarm_id = FWK_ID_NONE_INIT }),
 };

--- a/product/rddanielxlr/scp_ramfw/config_scmi_system_power.c
+++ b/product/rddanielxlr/scp_ramfw/config_scmi_system_power.c
@@ -11,8 +11,8 @@
 #include <fwk_module.h>
 
 const struct fwk_module_config config_scmi_system_power = {
-    .data = &((struct mod_scmi_system_power_config) {
+    .data = &((struct mod_scmi_system_power_config){
         .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
-        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0
-    }),
+        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0,
+        .alarm_id = FWK_ID_NONE_INIT }),
 };

--- a/product/rdn1e1/scp_ramfw/config_scmi_system_power.c
+++ b/product/rdn1e1/scp_ramfw/config_scmi_system_power.c
@@ -11,8 +11,8 @@
 #include <fwk_module.h>
 
 const struct fwk_module_config config_scmi_system_power = {
-    .data = &((struct mod_scmi_system_power_config) {
+    .data = &((struct mod_scmi_system_power_config){
         .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
-        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0
-    }),
+        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0,
+        .alarm_id = FWK_ID_NONE_INIT }),
 };

--- a/product/sgi575/scp_ramfw/config_scmi_system_power.c
+++ b/product/sgi575/scp_ramfw/config_scmi_system_power.c
@@ -11,8 +11,8 @@
 #include <fwk_module.h>
 
 const struct fwk_module_config config_scmi_system_power = {
-    .data = &((struct mod_scmi_system_power_config) {
+    .data = &((struct mod_scmi_system_power_config){
         .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
-        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0
-    }),
+        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0,
+        .alarm_id = FWK_ID_NONE_INIT }),
 };

--- a/product/sgm775/scp_ramfw/config_scmi_system_power.c
+++ b/product/sgm775/scp_ramfw/config_scmi_system_power.c
@@ -15,5 +15,6 @@
 struct fwk_module_config config_scmi_system_power = {
     .data = &((struct mod_scmi_system_power_config){
         .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
-        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0 }),
+        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0,
+        .alarm_id = FWK_ID_NONE_INIT }),
 };

--- a/product/sgm776/scp_ramfw/config_scmi_system_power.c
+++ b/product/sgm776/scp_ramfw/config_scmi_system_power.c
@@ -15,5 +15,6 @@
 struct fwk_module_config config_scmi_system_power = {
     .data = &((struct mod_scmi_system_power_config){
         .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
-        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0 }),
+        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0,
+        .alarm_id = FWK_ID_NONE_INIT }),
 };

--- a/product/synquacer/scp_ramfw/config_scmi_system_power.c
+++ b/product/synquacer/scp_ramfw/config_scmi_system_power.c
@@ -13,5 +13,6 @@
 const struct fwk_module_config config_scmi_system_power = {
     .data = &((struct mod_scmi_system_power_config){
         .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
-        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0 }),
+        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0,
+        .alarm_id = FWK_ID_NONE_INIT }),
 };

--- a/product/tc0/scp_ramfw/config_scmi_system_power.c
+++ b/product/tc0/scp_ramfw/config_scmi_system_power.c
@@ -13,5 +13,7 @@
 const struct fwk_module_config config_scmi_system_power = {
     .data = &((struct mod_scmi_system_power_config){
         .system_view = MOD_SCMI_SYSTEM_VIEW_FULL,
-        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0 }),
+        .system_suspend_state = MOD_SYSTEM_POWER_POWER_STATE_SLEEP0,
+        .alarm_id = FWK_ID_NONE_INIT }),
+
 };


### PR DESCRIPTION
When SCMI notifications are supported a timer is required to handle
graceful request. If this feature is not used timer_id must be
set to FWK_ID_NONE.
This patch also adds check for FWK_ID_NONE to prevent a binding
with no configuration set.

Change-Id: I25f982c2e8d686ac80dd0ebc2d9e64eac1522f3c
Signed-off-by: Leandro Belli <leandro.belli@arm.com>