### PR TITLE
mock_sensor: fix error 'status' variable undefined.

### DIFF
--- a/module/mock_sensor/src/mod_mock_sensor.c
+++ b/module/mock_sensor/src/mod_mock_sensor.c
@@ -43,7 +43,7 @@ static int get_value(fwk_id_t id, uint64_t *value)
 {
     unsigned int sensor_hal_idx;
     const struct mod_mock_sensor_dev_config *config;
-
+    int status;
     config = fwk_module_get_data(id);
 
     sensor_hal_idx = fwk_id_get_element_idx(config->sensor_hal_id);


### PR DESCRIPTION
This change fixes an undefined variable error in the get_value function.

Change-Id: Ib289094dcd945057505565e1179f6f4cf561de11
Signed-off-by: Leandro Belli <leandro.belli@arm.com>