### PR TITLE
tools: Display correct name for rcar's compiler

### DIFF
--- a/tools/ci.py
+++ b/tools/ci.py
@@ -436,7 +436,7 @@ def main():
         'MODE=debug ' \
         'make clean all -j'
     result = subprocess.call(cmd, shell=True)
-    results.append(('Product rcar debug build (ARM)', result))
+    results.append(('Product rcar debug build (GCC-AArch64)', result))
 
     cmd = \
         'CC=aarch64-none-elf-gcc ' \
@@ -444,7 +444,7 @@ def main():
         'MODE=release ' \
         'make clean all -j'
     result = subprocess.call(cmd, shell=True)
-    results.append(('Product rcar release build (ARM)', result))
+    results.append(('Product rcar release build (GCC-AArch64)', result))
 
     banner('Tests summary')
 


### PR DESCRIPTION
In tools/ci.py we build rcar platform with aarch64-none-elf-gcc, but
we display it as 'ARM'.

Correct this by replacing ARM with GCC-AArch64.

Change-Id: I7c4de86f6cd4a2a007263703edee7a7c71dfa8f6
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>