### PR TITLE
framework: add optional identifier support

### DIFF
--- a/framework/include/fwk_id.h
+++ b/framework/include/fwk_id.h
@@ -417,6 +417,15 @@ enum fwk_id_type {
 typedef union __fwk_id fwk_id_t;
 
 /*!
+ * \brief Generic optional identifier.
+ *
+ * \details Optionals identifiers are fwk_id_t elements which can be left
+ *      undefined. This are only intended to be used for configuration
+ *      proposes and should not be used to bypass fwk_id_t checks.
+ */
+typedef fwk_id_t fwk_optional_id_t;
+
+/*!
  * \brief Check if the identifier is of a certain identifier type.
  *
  * \param id Identifier.
@@ -447,6 +456,17 @@ enum fwk_id_type fwk_id_get_type(fwk_id_t id) FWK_CONST FWK_LEAF FWK_NOTHROW;
  * \retval false The identifiers do not refer to the same entity.
  */
 bool fwk_id_is_equal(fwk_id_t left, fwk_id_t right) FWK_CONST FWK_LEAF
+    FWK_NOTHROW;
+
+/*!
+ * \brief Check if an optional identifier is defined.
+ *
+ * \param id Optional identifier.
+ *
+ * \retval true The optional identifiers is defined.
+ * \retval false The optional identifiers is not defined.
+ */
+bool fwk_optional_id_is_defined(fwk_optional_id_t id) FWK_CONST FWK_LEAF
     FWK_NOTHROW;
 
 /*!

--- a/framework/src/fwk_id.c
+++ b/framework/src/fwk_id.c
@@ -191,6 +191,12 @@ bool fwk_id_is_equal(fwk_id_t left, fwk_id_t right)
     return left.value == right.value;
 }
 
+bool fwk_optional_id_is_defined(fwk_optional_id_t id)
+{
+    fwk_assert(id.common.type < __FWK_ID_TYPE_COUNT);
+    return id.common.type != __FWK_ID_TYPE_INVALID;
+}
+
 fwk_id_t fwk_id_build_module_id(fwk_id_t id)
 {
     fwk_assert(id.common.type != __FWK_ID_TYPE_INVALID);

--- a/framework/test/test_fwk_id_equality.c
+++ b/framework/test/test_fwk_id_equality.c
@@ -98,6 +98,20 @@ static void test_not_equal_shared_module(void)
     assert(!fwk_id_is_equal(left, right));
 }
 
+static void test_defined_optional_id(void)
+{
+    fwk_optional_id_t opt_id = FWK_ID_NONE_INIT;
+
+    assert(fwk_optional_id_is_defined(opt_id));
+}
+
+static void test_undefined_optional_id(void)
+{
+    fwk_optional_id_t opt_id = (fwk_optional_id_t){ 0 };
+
+    assert(!fwk_optional_id_is_defined(opt_id));
+}
+
 static const struct fwk_test_case_desc test_case_table[] = {
     FWK_TEST_CASE(test_equal_module_id),
     FWK_TEST_CASE(test_not_equal_module_id),
@@ -110,6 +124,8 @@ static const struct fwk_test_case_desc test_case_table[] = {
     FWK_TEST_CASE(test_equal_notification_id),
     FWK_TEST_CASE(test_not_equal_notification_id),
     FWK_TEST_CASE(test_not_equal_shared_module),
+    FWK_TEST_CASE(test_defined_optional_id),
+    FWK_TEST_CASE(test_undefined_optional_id),
 };
 
 struct fwk_test_suite_desc test_suite = {


### PR DESCRIPTION
This patch creates a new type called fwk_optional_id_t which can
be left  into undefined. This allows any non-mandatory configuration
to be left unassigned reducing code-size and improving upgradability.

Change-Id: I28243b6a9394ce7c476f6574c45e6fc55a9fd6c6
Signed-off-by: Leandro Belli <leandro.belli@arm.com>