### PR TITLE
[RFC] framework thread context in OP-TEE threads

### DIFF
--- a/framework/include/fwk_thread.h
+++ b/framework/include/fwk_thread.h
@@ -138,6 +138,15 @@ int fwk_thread_is_delayed_response_list_empty(fwk_id_t id, bool *is_empty);
  * \return Status code representing the result of the operation.
  */
 int fwk_thread_get_first_delayed_response(fwk_id_t id, struct fwk_event *event);
+
+#ifdef BUILD_OPTEE
+/*!
+ * \brief Set a thread context for processing incoming message.
+ *
+ * \param[in] id Identifier of the module/element that has a message to process.
+ */
+void fwk_set_thread_ctx(fwk_id_t id);
+#endif
 /*!
  * \}
  */

--- a/framework/include/internal/fwk_single_thread.h
+++ b/framework/include/internal/fwk_single_thread.h
@@ -73,4 +73,40 @@ struct __fwk_thread_ctx {
  */
 struct __fwk_thread_ctx *__fwk_thread_get_ctx(void);
 
+// Added OP-TEE
+/*!
+ * \brief Put an event in a module or element thread queue and wait for it to
+ *      be processed.
+ *
+ * \details This framework API function can only be called from a module or
+ *      element's thread. The calling thread is suspended until the event
+ *      has been completely processed. As a consequence, this function cannot
+ *      be called during the pre-runtime phases.
+ *
+ *      The identifier of the event's source is filled in by the framework
+ *      with the identifier of the entity calling the function. Thus there is
+ *      no need for the caller to fill this event's field in.
+ *
+ *      The event identifier and target identifier are validated and must
+ *      belong to the same module.
+ *
+ *      Warning: As this API could have serious adverse effects on system
+ *               performance and throughput, this API has been deprecated
+ *               and should not be used in single-threaded mode.
+ *
+ * \param event Event to put into the queue for processing. Must not be \c NULL.
+ * \param[out] resp_event The response event. Must not be \c NULL.
+ *
+ * \retval FWK_SUCCESS The event was successfully processed.
+ * \retval FWK_E_STATE The execution is not started.
+ * \retval FWK_E_PARAM One or more of the parameters were invalid.
+ * \retval FWK_E_PARAM One or more fields in the \p event parameter were
+ *      invalid.
+ * \retval FWK_E_ACCESS The API is called from an ISR, called from the common
+ *      thread, or the event targets the calling thread.
+ */
+int fwk_thread_put_event_and_wait(struct fwk_event *event,
+    struct fwk_event *resp_event)
+    __attribute__((deprecated));
+
 #endif /* FWK_INTERNAL_SINGLE_THREAD_H */

--- a/framework/include/internal/fwk_thread.h
+++ b/framework/include/internal/fwk_thread.h
@@ -22,7 +22,12 @@
  * \retval ::FWK_SUCCESS The thread framework component was initialized.
  * \retval ::FWK_E_NOMEM Insufficient memory available for event queues.
  */
+#ifdef BUILD_OPTEE
+/* Hack: thread as per context: add the device ID as argument */
+int __fwk_thread_init(size_t event_count, fwk_id_t id);
+#else
 int __fwk_thread_init(size_t event_count);
+#endif
 
 /*
  * \brief Begin waiting for and processing events raised by modules and

--- a/framework/include/internal/fwk_thread.h
+++ b/framework/include/internal/fwk_thread.h
@@ -32,6 +32,16 @@ int __fwk_thread_init(size_t event_count);
  */
 noreturn void __fwk_thread_run(void);
 
+#ifdef BUILD_OPTEE
+/* Hack: Added by OP-TEE to process messages but not endlessly */
+/*
+ * \brief Processing events already raised by modules and interrupt handlers.
+ *
+ * \return The function does not return.
+ */
+void __fwk_run_event(void);
+#endif
+
 /*
  * \brief Get the event being currently processed.
  *

--- a/framework/src/fwk_module.c
+++ b/framework/src/fwk_module.c
@@ -426,7 +426,11 @@ int fwk_module_start(void)
 
     FWK_LOG_CRIT("[FWK] Module initialization complete!");
 
+#ifdef BUILD_OPTEE
+    __fwk_run_event();
+#else
     __fwk_thread_run();
+#endif
 
     return FWK_SUCCESS;
 }

--- a/framework/src/fwk_thread.c
+++ b/framework/src/fwk_thread.c
@@ -289,6 +289,24 @@ struct __fwk_thread_ctx *__fwk_thread_get_ctx(void)
     return &ctx;
 }
 
+void __fwk_run_event(void)
+{
+    for (;;) {
+        while (!fwk_list_is_empty(ctx.event_queue))
+            process_next_event();
+
+        if (fwk_list_is_empty(ctx.isr_event_queue)) {
+            fwk_log_unbuffer();
+            return;
+	}
+
+       if (process_isr())
+            continue;
+
+        fwk_log_unbuffer();
+    }
+}
+
 const struct fwk_event *__fwk_thread_get_current_event(void)
 {
     return ctx.current_event;

--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -645,6 +645,7 @@ static int create_event_request(
         return FWK_E_BUSY;
 
     struct fwk_event event = {
+        .source_id = service_id,
         .target_id = fwk_module_id_scmi_clock,
     };
 

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -617,6 +617,7 @@ static int scmi_perf_limits_get_handler(fwk_id_t service_id,
 
     /* The get_limits request is processed within the event being generated */
     struct fwk_event event = {
+        .source_id = service_id,
         .target_id = fwk_module_id_scmi_perf,
         .id = scmi_perf_get_limits,
     };
@@ -735,6 +736,7 @@ static int scmi_perf_level_get_handler(fwk_id_t service_id,
 
     /* The get_level request is processed within the event being generated */
     struct fwk_event event = {
+        .source_id = service_id,
         .target_id = fwk_module_id_scmi_perf,
         .id = scmi_perf_get_level,
     };

--- a/module/scmi_sensor/src/mod_scmi_sensor.c
+++ b/module/scmi_sensor/src/mod_scmi_sensor.c
@@ -533,6 +533,7 @@ static int scmi_sensor_reading_get_handler(fwk_id_t service_id,
 
     /* The get_value request is processed within the event being generated */
     struct fwk_event event = {
+        .source_id = service_id,
         .target_id = fwk_module_id_scmi_sensor,
         .id = mod_scmi_sensor_event_id_get_request,
     };


### PR DESCRIPTION
This RFC shows how we currently bind an OP-TEE thread context with an SCMI thread context. This is used to allow unrelated SCMI services to nicely operate each on their own OP-TEE thread context. Actually this architecture is still being discussed internally.
This P-R is not really a RFC, rather a way to share code and show how we did.