### PR TITLE
mod_scmi_perf: Fix invalid command return value

### DIFF
--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -1065,7 +1065,7 @@ static int scmi_perf_message_handler(fwk_id_t protocol_id, fwk_id_t service_id,
     fwk_assert(payload != NULL);
 
     if (message_id >= FWK_ARRAY_SIZE(handler_table)) {
-        return_value = SCMI_NOT_SUPPORTED;
+        return_value = SCMI_NOT_FOUND;
         goto error;
     }
 


### PR DESCRIPTION
According to the SCMIv2 spec section 4.1.4, if a command does
not exist then SCMI_NOT_FOUND must be returned. This commit
fixes this behaviour for the SCMI Performance Protocol.

Change-Id: I523ced9acf034ea4828c9b70096780ddc02e0ae5
Signed-off-by: Luca Vizzarro <Luca.Vizzarro@arm.com>