### PR TITLE
Fix default value for AR

### DIFF
--- a/tools/build_system/rules.mk
+++ b/tools/build_system/rules.mk
@@ -67,7 +67,7 @@ else ifeq ($(BS_TOOLCHAIN),LLVM)
     # therefore we are enforcing the use of it manually.
     export LD := $(shell $(CC) --print-prog-name=ld.lld)
 else
-    export AR := $(shell $(CC) --print-prog-name gcc-ar)
+    export AR := $(shell $(CC) --print-prog-name ar)
     export OBJCOPY := $(shell $(CC) --print-prog-name objcopy)
     export SIZE := $(shell $(CC) --print-prog-name size)
 endif


### PR DESCRIPTION
arm-none-eabi-gcc --print-prog-name gcc-ar just prints gcc-ar, whereas
ar prints <prefix>/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ar

Signed-off-by: Jagadeesh Ujja <jagadeesh.ujja@arm.com>
Change-Id: I511fc2d307e2a8cd5e223013f9dfcc391e3969e0