### PR TITLE
Add disabled PSCI protocols when resource permission feature is disabled

### DIFF
--- a/product/rdn1e1/scp_ramfw/config_scmi.c
+++ b/product/rdn1e1/scp_ramfw/config_scmi.c
@@ -57,6 +57,15 @@ static const struct fwk_element *get_service_table(fwk_id_t module_id)
     return service_table;
 }
 
+#ifndef BUILD_HAS_RESOURCE_PERMISSIONS
+
+/* PSCI agent has no access to perf and sensor protocol */
+static const uint32_t dis_protocol_list_psci[] = {
+    MOD_SCMI_PROTOCOL_ID_SENSOR,
+    MOD_SCMI_PROTOCOL_ID_PERF,
+};
+#endif
+
 static struct mod_scmi_agent agent_table[] = {
     [SCP_SCMI_AGENT_ID_OSPM] = {
         .type = SCMI_AGENT_TYPE_OSPM,
@@ -73,7 +82,8 @@ const struct fwk_module_config config_scmi = {
         &(struct mod_scmi_config){
             .protocol_count_max = 9,
 #ifndef BUILD_HAS_RESOURCE_PERMISSIONS
-#    error "Please configure the disabled protocols for PSCI agents"
+            .dis_protocol_count_psci = FWK_ARRAY_SIZE(dis_protocol_list_psci),
+            .dis_protocol_list_psci = dis_protocol_list_psci,
 #endif
             .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
             .agent_table = agent_table,

--- a/product/sgi575/scp_ramfw/config_scmi.c
+++ b/product/sgi575/scp_ramfw/config_scmi.c
@@ -57,6 +57,15 @@ static const struct fwk_element *get_service_table(fwk_id_t module_id)
     return service_table;
 }
 
+#ifndef BUILD_HAS_RESOURCE_PERMISSIONS
+
+/* PSCI agent has no access to perf and sensor protocols */
+static const uint32_t dis_protocol_list_psci[] = {
+    MOD_SCMI_PROTOCOL_ID_SENSOR,
+    MOD_SCMI_PROTOCOL_ID_PERF,
+};
+#endif
+
 static struct mod_scmi_agent agent_table[] = {
     [SCP_SCMI_AGENT_ID_OSPM] = {
         .type = SCMI_AGENT_TYPE_OSPM,
@@ -72,7 +81,8 @@ const struct fwk_module_config config_scmi = {
     .data = &((struct mod_scmi_config){
         .protocol_count_max = 9,
 #ifndef BUILD_HAS_RESOURCE_PERMISSIONS
-#    error "Please configure the disabled protocols for PSCI agents"
+        .dis_protocol_count_psci = FWK_ARRAY_SIZE(dis_protocol_list_psci),
+        .dis_protocol_list_psci = dis_protocol_list_psci,
 #endif
         .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
         .agent_table = agent_table,

--- a/product/sgm775/scp_ramfw/config_scmi.c
+++ b/product/sgm775/scp_ramfw/config_scmi.c
@@ -67,6 +67,16 @@ static const struct fwk_element *get_service_table(fwk_id_t module_id)
     return service_table;
 }
 
+#ifndef BUILD_HAS_RESOURCE_PERMISSIONS
+
+/* PSCI agent has no access to clock, perf and sensor protocol */
+static const uint32_t dis_protocol_list_psci[] = {
+    MOD_SCMI_PROTOCOL_ID_SENSOR,
+    MOD_SCMI_PROTOCOL_ID_CLOCK,
+    MOD_SCMI_PROTOCOL_ID_PERF,
+};
+#endif
+
 static const struct mod_scmi_agent agent_table[] = {
     [SCMI_AGENT_ID_OSPM] = {
         .type = SCMI_AGENT_TYPE_OSPM,
@@ -82,7 +92,8 @@ struct fwk_module_config config_scmi = {
     .data = &((struct mod_scmi_config){
         .protocol_count_max = 9,
 #ifndef BUILD_HAS_RESOURCE_PERMISSIONS
-#    error "Please configure the disabled protocols for PSCI agents"
+        .dis_protocol_count_psci = FWK_ARRAY_SIZE(dis_protocol_list_psci),
+        .dis_protocol_list_psci = dis_protocol_list_psci,
 #endif
         .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
         .agent_table = agent_table,

--- a/product/sgm776/scp_ramfw/config_scmi.c
+++ b/product/sgm776/scp_ramfw/config_scmi.c
@@ -67,6 +67,16 @@ static const struct fwk_element *get_service_table(fwk_id_t module_id)
     return service_table;
 }
 
+#ifndef BUILD_HAS_RESOURCE_PERMISSIONS
+
+/* PSCI agent has no access to clock, perf and sensor protocol */
+static const uint32_t dis_protocol_list_psci[] = {
+    MOD_SCMI_PROTOCOL_ID_SENSOR,
+    MOD_SCMI_PROTOCOL_ID_CLOCK,
+    MOD_SCMI_PROTOCOL_ID_PERF,
+};
+#endif
+
 static const struct mod_scmi_agent agent_table[] = {
     [SCMI_AGENT_ID_OSPM] = {
         .type = SCMI_AGENT_TYPE_OSPM,
@@ -83,7 +93,8 @@ struct fwk_module_config config_scmi = {
         &(struct mod_scmi_config){
             .protocol_count_max = 9,
 #ifndef BUILD_HAS_RESOURCE_PERMISSIONS
-#    error "Please configure the disabled protocols for PSCI agents"
+            .dis_protocol_count_psci = FWK_ARRAY_SIZE(dis_protocol_list_psci),
+            .dis_protocol_list_psci = dis_protocol_list_psci,
 #endif
             .agent_count = FWK_ARRAY_SIZE(agent_table) - 1,
             .agent_table = agent_table,

--- a/product/tc0/scp_ramfw/config_scmi.c
+++ b/product/tc0/scp_ramfw/config_scmi.c
@@ -72,6 +72,16 @@ static const struct fwk_element *get_service_table(fwk_id_t module_id)
     return service_table;
 }
 
+#ifndef BUILD_HAS_RESOURCE_PERMISSIONS
+
+/* PSCI agent has no access to clock, perf and sensor protocol */
+static const uint32_t dis_protocol_list_psci[] = {
+    MOD_SCMI_PROTOCOL_ID_SENSOR,
+    MOD_SCMI_PROTOCOL_ID_CLOCK,
+    MOD_SCMI_PROTOCOL_ID_PERF,
+};
+#endif
+
 static struct mod_scmi_agent agent_table[] = {
     [SCP_SCMI_AGENT_ID_OSPM] = {
         .type = SCMI_AGENT_TYPE_OSPM,
@@ -88,7 +98,8 @@ const struct fwk_module_config config_scmi = {
     .data = &((struct mod_scmi_config){
         .protocol_count_max = 9,
 #ifndef BUILD_HAS_RESOURCE_PERMISSIONS
-#    error "Please configure the disabled protocols for PSCI agents"
+        .dis_protocol_count_psci = FWK_ARRAY_SIZE(dis_protocol_list_psci),
+        .dis_protocol_list_psci = dis_protocol_list_psci,
 #endif
         .agent_count = FWK_ARRAY_SIZE(agent_table),
         .agent_table = agent_table,


### PR DESCRIPTION
Add disabled protocols configurations for sgm775,sgm776,sgi575,rdn1e1
and tc0 platforms when resource permissions option is disabled.
