### PR TITLE
scmi_clock: Fix return code when resource is in requested state

### DIFF
--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -499,8 +499,10 @@ FWK_WEAK int mod_scmi_clock_config_set_policy(
     switch (*state) {
     case MOD_CLOCK_STATE_RUNNING:
         /* The agent has already requested to set state to RUNNING */
-        if (clock_state == MOD_CLOCK_STATE_RUNNING)
-            return FWK_E_STATE;
+        if (clock_state == MOD_CLOCK_STATE_RUNNING) {
+            status = FWK_SUCCESS;
+            break;
+        }
 
         /* set the clock state for this agent to RUNNING */
         if (policy_commit == MOD_SCMI_CLOCK_POST_MESSAGE_HANDLER) {


### PR DESCRIPTION
The SCP firmware returned an error when an agent tries to set any
resource to its current state. This takes care of the behavior
when Uboot turns ON a resource and the kernel tries to again
enable it at boot (both are same agents on same mailbox channel).

Change-Id: Ib1f094ef008d36d9979f5b69a72440ca77c1813a
Signed-off-by: Leandro Belli <leandro.belli@arm.com>