### PR TITLE
fwk: only use __access__(none) with GCC 11

### DIFF
--- a/framework/include/fwk_attributes.h
+++ b/framework/include/fwk_attributes.h
@@ -499,7 +499,7 @@
  * \see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
  */
 
-#if FWK_HAS_GNU_ATTRIBUTE(__access__)
+#if FWK_HAS_GNU_ATTRIBUTE(__access__) && __GNUC__ >= 11
 #    define FWK_UNTOUCHED(REF_POS) __attribute__((__access__(none, REF_POS)))
 #else
 #    define FWK_UNTOUCHED(REF_POS)


### PR DESCRIPTION
GCC 10 onwards supports read_only, write_only and read_write attributes to
__access__ and only GCC 11 (which is unreleased at this point in time) also
supports none.

To fix the build on GCC 10, only use none with GCC 11.

Change-Id: I65a258fb2fc93874fe0b6fe5e695a6df030ce3a1
Signed-off-by: Ross Burton <ross.burton@arm.com>