### PR TITLE
scmi_clock: Fix return code when resource is in stopped state

### DIFF
--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -526,6 +526,11 @@ FWK_WEAK int mod_scmi_clock_config_set_policy(
         break;
 
     case MOD_CLOCK_STATE_STOPPED:
+        /* The agent has already requested to set state to STOPPED */
+        if (clock_state == MOD_CLOCK_STATE_STOPPED) {
+            status = FWK_SUCCESS;
+            break;
+        }
         /* error to try and stop a stopped clock */
         if (clock_count[clock_dev_id] == 0) {
             scmi_clock_ctx.scmi_api->get_agent_id(service_id, &agent_id);
@@ -537,10 +542,6 @@ FWK_WEAK int mod_scmi_clock_config_set_policy(
                 *state);
             return FWK_E_STATE;
         }
-
-        /* The agent has already requested to set state to STOPPED */
-        if (clock_state == MOD_CLOCK_STATE_STOPPED)
-            return FWK_E_STATE;
 
         /* set the clock state for this agent to STOPPED */
         if (policy_commit == MOD_SCMI_CLOCK_POST_MESSAGE_HANDLER) {


### PR DESCRIPTION
The SCP firmware returned an error when an agent tries to set any
resource to its current state. This takes care of the behavior
when Uboot turns OFF  a resource and the kernel tries to again
enable it at boot (both are same agents on same mailbox channel).

Change-Id: Icfbddfb75eeb6247e9bd2bbe66434d8dbf988f13
Signed-off-by: Leandro Belli <leandro.belli@arm.com>