### PR TITLE
Minor fix in cpu.mk of bug causing an intended error message to not be displayed

### DIFF
--- a/tools/build_system/cpu.mk
+++ b/tools/build_system/cpu.mk
@@ -58,7 +58,7 @@ else ifeq ($(BS_FIRMWARE_CPU),host)
     BS_ARCH_VENDOR := none
     BS_ARCH_ARCH := host
 else
-    $(erro "$(BS_FIRMWARE_CPU) is not a supported CPU. Aborting...")
+    $(error "$(BS_FIRMWARE_CPU) is not a supported CPU. Aborting...")
 endif
 
 endif


### PR DESCRIPTION
When building without setting `BS_FIRMWARE_CPU` to a valid option I was not getting the intended error message because of a typo in the error line in `cpu.mk` - it should be `$(error ...)` and not `$(erro ...)`