### PR TITLE
product/morello: Fix comparison within assert

### DIFF
--- a/product/morello/module/morello_pll/src/mod_morello_pll.c
+++ b/product/morello/module/morello_pll/src/mod_morello_pll.c
@@ -70,7 +70,7 @@ static int pll_set_rate(
     size_t i;
 
     fwk_assert(ctx != NULL);
-    fwk_assert(rate <= (UINT16_MAX * FWK_MHZ));
+    fwk_assert(rate <= ((uint64_t)UINT16_MAX * FWK_MHZ));
 
     config = ctx->config;
 


### PR DESCRIPTION
In mod_morello_pll.c, there is an assert call to check the incoming
rate which is uint64_t with UINT16_MAX*FWK_MHZ. However the resulting
value is not stored in correct data type which causes calculation to
fail. This commit fixes this calculation.

Note, this is visible only in the debug build since assert calls are
enabled only in debug builds.

Change-Id: I682882bf52c68e099d8d9959915fa26744ae845f
Signed-off-by: Girish Pathak <girish.pathak@arm.com>