### PR TITLE
scp: Fix Mandatory MISRA C:2012 defects

### DIFF
--- a/framework/src/fwk_id.c
+++ b/framework/src/fwk_id.c
@@ -151,7 +151,7 @@ static void fwk_id_format(
 
 struct __fwk_id_fmt __fwk_id_str(fwk_id_t id)
 {
-    struct __fwk_id_fmt fmt;
+    struct __fwk_id_fmt fmt = { { 0 } };
 
     fwk_id_format(fmt.str, sizeof(fmt.str), id, false);
 
@@ -160,7 +160,7 @@ struct __fwk_id_fmt __fwk_id_str(fwk_id_t id)
 
 struct fwk_id_verbose_fmt fwk_id_verbose_str(fwk_id_t id)
 {
-    struct fwk_id_verbose_fmt fmt;
+    struct fwk_id_verbose_fmt fmt = { { 0 } };
 
     fwk_id_format(fmt.str, sizeof(fmt.str), id, true);
 

--- a/module/dvfs/src/mod_dvfs.c
+++ b/module/dvfs/src/mod_dvfs.c
@@ -683,7 +683,7 @@ static void dvfs_complete_respond(
     int status;
     struct fwk_event read_req_event;
     struct mod_dvfs_params_response *resp_params;
-    bool return_opp;
+    bool return_opp = false;
 
     if ((ctx->state == DVFS_DOMAIN_GET_OPP) && (req_status == FWK_SUCCESS))
         return_opp = true;

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -333,7 +333,7 @@ static int scmi_perf_domain_attributes_handler(fwk_id_t service_id,
     int status;
     unsigned int agent_id;
     const struct scmi_perf_domain_attributes_a2p *parameters;
-    uint32_t permissions;
+    uint32_t permissions = 0;
     fwk_id_t domain_id;
     struct mod_dvfs_opp opp;
     struct scmi_perf_domain_attributes_p2a return_values = {


### PR DESCRIPTION
In this patch all MISRA C:2012 mandatory defects are fixed.
In particular rule 9.1. As this is the mandatory rule affected.

Change-Id: I969906065d0dd28196d578f971adab24123c1cfb
Signed-off-by: Ahmed Gadallah <ahmed.gadallah@arm.com>