### PR TITLE
Makefile: fix fwk_module_list.o location

### DIFF
--- a/tools/build_system/rules.mk
+++ b/tools/build_system/rules.mk
@@ -308,7 +308,8 @@ OBJECTS := $(addprefix $(OBJ_DIR)/, \
            $(patsubst %.S,%.o, \
            $(patsubst %.s,%.o, \
            $(patsubst %.c,%.o, \
-           $(SOURCES)))))
+           $(patsubst $(BUILD_FIRMWARE_DIR)%,%, \
+           $(SOURCES))))))
 
 #
 # Module code generation
@@ -336,6 +337,10 @@ $(LIB): $(OBJECTS) | $$(@D)/
 	$(AR) $(ARFLAGS) $@ $(OBJECTS)
 
 $(OBJ_DIR)/%.o: %.c $(EXTRA_DEP) | $$(@D)/
+	$(call show-action,CC,$<)
+	$(CC) -c $(CFLAGS) $(DEP_CFLAGS)  $< -o $@
+
+$(OBJ_DIR)/%.o: $(BUILD_FIRMWARE_DIR)%.c $(EXTRA_DEP) | $$(@D)/
 	$(call show-action,CC,$<)
 	$(CC) -c $(CFLAGS) $(DEP_CFLAGS)  $< -o $@
 


### PR DESCRIPTION
Placed fwk_module_list.o file in the correct directory:
<Absolute path to SCP-firmware>/build/product/<product_name>/fw/release/obj/

instead of the extended and dulplicated path

<Absolute path to SCP-firmware>/build/product/<product name>/fw/release/obj/<Absolute path to SCP-firmware>/build/product/<product_name/fw/

Signed-off-by: Vincent Guittot <vincent.guittot@linaro.org>