### PR TITLE
fwk/fwk_log.c: fix erroneous check preventing log drain from working

### DIFF
--- a/framework/src/fwk_log.c
+++ b/framework/src/fwk_log.c
@@ -55,7 +55,7 @@ int fwk_log_init(void)
         fwk_log_stream = fwk_io_stdout;
     else if (!fwk_id_is_equal(FMW_LOG_DRAIN_ID, FWK_ID_NONE)) {
         status = fwk_io_open(&stream, FMW_LOG_DRAIN_ID, FWK_IO_MODE_WRITE);
-        if (!fwk_expect(status == FWK_SUCCESS))
+        if (fwk_expect(status == FWK_SUCCESS))
             fwk_log_stream = &stream;
     }
 


### PR DESCRIPTION
The condition that ensures `fwk_log_stream` is only set if `fwk_io_open` succeeds
is wrong - it only set `fwk_log_stream` if `fwk_io_open` failed.
