### PR TITLE
Cmake multi tool v1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,23 @@ project(
     LANGUAGES NONE)
 
 #
+# Configure the default build type to be "Release". We choose to default to a
+# release build as non-developer consumers will generally want a release build,
+# whereas developers who need a debug build are generally familiar with how to
+# enable it in the build system.
+#
+
+if((NOT CMAKE_BUILD_TYPE) AND (NOT CMAKE_CONFIGURATION_TYPES))
+    set(CMAKE_BUILD_TYPE
+        "Release"
+        CACHE STRING "Build type." FORCE)
+
+    set_property(
+        CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel"
+                                                "RelWithDebInfo")
+endif()
+
+#
 # Set up global inclusions and exclusions for source file quality assurance
 # tools. This is intended to filter in external directories (e.g. out-of-tree
 # modules) and filter out third-party directories.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,26 @@ if(SCP_FIRMWARE_SOURCE_DIR)
     endif()
 endif()
 
+#
+# Handle automatic selection of the toolchain. This only occurs if the user has
+# not explicitly provided the path to a toolchain file and the firmware has
+# given us a default preference.
+#
+
+if(SCP_TOOLCHAIN_INIT AND (NOT CMAKE_TOOLCHAIN_FILE))
+    #
+    # Let the firmware decide what its default toolchain should be, but allow
+    # the user to override it.
+    #
+
+    if(NOT SCP_TOOLCHAIN)
+        set(SCP_TOOLCHAIN "${SCP_TOOLCHAIN_INIT}")
+    endif()
+
+    set(CMAKE_TOOLCHAIN_FILE
+        "${SCP_FIRMWARE_SOURCE_DIR}/Toolchain-${SCP_TOOLCHAIN}.cmake")
+endif()
+
 project(
     SCP
     VERSION 2.7.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,14 @@ if((NOT CMAKE_BUILD_TYPE) AND (NOT CMAKE_CONFIGURATION_TYPES))
 endif()
 
 #
+# Set the default C standard to C11 plus any compiler extensions.
+#
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED TRUE)
+set(CMAKE_C_EXTENSIONS TRUE)
+
+#
 # Set up global inclusions and exclusions for source file quality assurance
 # tools. This is intended to filter in external directories (e.g. out-of-tree
 # modules) and filter out third-party directories.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,52 @@ cmake_minimum_required(VERSION 3.18.3)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+#
+# Individual firmware targets are configured based on the 'Firmware.cmake'
+# living in the firmware source directory that the user provides to us, which
+# determines the default set of configuration options we are given, including
+# the toolchain file.
+#
+
+if(SCP_FIRMWARE_SOURCE_DIR)
+    get_filename_component(SCP_FIRMWARE_SOURCE_DIR "${SCP_FIRMWARE_SOURCE_DIR}"
+                           ABSOLUTE BASE_DIR "${CMAKE_SOURCE_DIR}/product")
+
+    include("${SCP_FIRMWARE_SOURCE_DIR}/Firmware.cmake")
+
+    if((NOT SCP_FIRMWARE) OR (NOT SCP_FIRMWARE_TARGET))
+        # cmake-format: off
+        message(FATAL_ERROR
+            "Insufficient firmware metadata provided.\n"
+
+            "Please ensure your 'Firmware.cmake' has set both `SCP_FIRMWARE` "
+            "and `SCP_FIRMWARE_TARGET` to the name of your firmware and the "
+            "firmware's CMake target respectively.")
+        # cmake-format: on
+    endif()
+
+    if(NOT SCP_FIRMWARE_BINARY_DIR)
+        #
+        # Derive the binary directory from the location of the source directory
+        # if it's in-tree.
+        #
+
+        file(RELATIVE_PATH SCP_FIRMWARE_BINARY_DIR "${CMAKE_SOURCE_DIR}"
+             "${SCP_FIRMWARE_SOURCE_DIR}")
+    endif()
+
+    if(SCP_FIRMWARE_BINARY_DIR MATCHES "\\.\\.")
+        # cmake-format: off
+        message(FATAL_ERROR
+            "Invalid firmware binary directory.\n"
+
+            "Please ensure your firmware binary directory is a relative path. "
+            "This path is used as the location within the project binary "
+            "directory that will be used for firmware artifacts.")
+        # cmake-format: on
+    endif()
+endif()
+
 project(
     SCP
     VERSION 2.7.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,15 @@ set(CMAKE_C_STANDARD_REQUIRED TRUE)
 set(CMAKE_C_EXTENSIONS TRUE)
 
 #
+# We use `__declspec` when available, but Clang needs to explicitly enable
+# support for it before we can use them.
+#
+
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    string(APPEND CMAKE_C_FLAGS " -fms-extensions")
+endif()
+
+#
 # Set up global inclusions and exclusions for source file quality assurance
 # tools. This is intended to filter in external directories (e.g. out-of-tree
 # modules) and filter out third-party directories.

--- a/cmake/Toolchain/ArmClang-Baremetal.cmake
+++ b/cmake/Toolchain/ArmClang-Baremetal.cmake
@@ -1,0 +1,19 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include("${CMAKE_CURRENT_LIST_DIR}/ArmClang-Base.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Generic-Baremetal.cmake")
+
+foreach(language IN ITEMS ASM C CXX)
+    string(APPEND CMAKE_${language}_FLAGS_INIT "-ffunction-sections ")
+    string(APPEND CMAKE_${language}_FLAGS_INIT "-fdata-sections ")
+    string(APPEND CMAKE_${language}_FLAGS_INIT "-fshort-enums ")
+
+    string(APPEND CMAKE_${language}_FLAGS_DEBUG_INIT "-Og ")
+endforeach()
+
+string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT "--remove ")

--- a/cmake/Toolchain/ArmClang-Base.cmake
+++ b/cmake/Toolchain/ArmClang-Base.cmake
@@ -1,0 +1,53 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(CMAKE_ASM_COMPILER
+    armclang
+    CACHE FILEPATH "Path to the assembler.")
+set(CMAKE_C_COMPILER
+    armclang
+    CACHE FILEPATH "Path to the C compiler.")
+set(CMAKE_CXX_COMPILER
+    armclang
+    CACHE FILEPATH "Path to the C++ compiler.")
+
+foreach(language IN ITEMS ASM C CXX)
+    if(CMAKE_${language}_COMPILER_TARGET)
+        string(APPEND CMAKE_${language}_FLAGS_INIT
+               "--target=${CMAKE_${language}_COMPILER_TARGET} ")
+    endif()
+endforeach()
+
+#
+# Suppress warnings about duplicate input files. This one is CMake's fault -
+# linked libraries are added more than once if they are depended on by multiple
+# targets.
+#
+
+string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT "--diag_suppress L6304W ")
+
+#
+# The Arm Compiler 6 support in CMake, until hopefully, v3.18.3, incorrectly
+# uses the Clang-style -Xlinker linker wrapper flag, even though its linker is
+# configured to locate and use 'armlink' instead of 'armclang'. This is just a
+# bit of a hacky workaround to reset it to nothing whenever the CMake toolchain
+# logic tries to override it.
+#
+# https://gitlab.kitware.com/cmake/cmake/-/issues/21154#note_826110
+#
+
+if(CMAKE_VERSION VERSION_LESS "3.18.3")
+    # cmake-lint: disable=C0111
+
+    macro(scp_reset_linker_wrapper_flag)
+        set(CMAKE_C_LINKER_WRAPPER_FLAG "")
+        set(CMAKE_CXX_LINKER_WRAPPER_FLAG "")
+    endmacro()
+
+    variable_watch(CMAKE_C_LINKER_WRAPPER_FLAG scp_reset_linker_wrapper_flag)
+    variable_watch(CMAKE_CXX_LINKER_WRAPPER_FLAG scp_reset_linker_wrapper_flag)
+endif()

--- a/cmake/Toolchain/GNU-Baremetal.cmake
+++ b/cmake/Toolchain/GNU-Baremetal.cmake
@@ -1,0 +1,23 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include("${CMAKE_CURRENT_LIST_DIR}/GNU-Base.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Generic-Baremetal.cmake")
+
+foreach(language IN ITEMS ASM C CXX)
+    string(APPEND CMAKE_${language}_FLAGS_INIT
+           "-mcpu=${CMAKE_SYSTEM_PROCESSOR} ")
+    string(APPEND CMAKE_${language}_FLAGS_INIT "-mthumb ")
+
+    string(APPEND CMAKE_${language}_FLAGS_INIT "-ffunction-sections ")
+    string(APPEND CMAKE_${language}_FLAGS_INIT "-fdata-sections ")
+    string(APPEND CMAKE_${language}_FLAGS_INIT "-fshort-enums ")
+
+    string(APPEND CMAKE_${language}_FLAGS_DEBUG_INIT "-Og")
+endforeach()
+
+string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--gc-sections ")

--- a/cmake/Toolchain/GNU-Base.cmake
+++ b/cmake/Toolchain/GNU-Base.cmake
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(CMAKE_ASM_COMPILER
+    ${CMAKE_TOOLCHAIN_PREFIX}gcc
+    CACHE FILEPATH "Path to the assembler.")
+set(CMAKE_C_COMPILER
+    ${CMAKE_TOOLCHAIN_PREFIX}gcc
+    CACHE FILEPATH "Path to the C compiler.")
+set(CMAKE_CXX_COMPILER
+    ${CMAKE_TOOLCHAIN_PREFIX}g++
+    CACHE FILEPATH "Path to the C++ compiler.")

--- a/cmake/Toolchain/Generic-Baremetal.cmake
+++ b/cmake/Toolchain/Generic-Baremetal.cmake
@@ -1,0 +1,15 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(CMAKE_SYSTEM_NAME Generic)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)


### PR DESCRIPTION
This change is part of a larger CMake patch set, which will be introduced in the coming weeks. 

This PR adds some misc feature to CMake build system

Notably 
- Sets default build to release
- Adds C standards and C11 plus extensions
- Multi-toolchain support

Note: this is just a partial commit from CMake patch set and only done so that we can verify forthcoming patches on CI.