### PR TITLE
Cmake core v1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ project(
     DESCRIPTION "Arm SCP/MCP Software"
     HOMEPAGE_URL
         "https://developer.arm.com/tools-and-software/open-source-software/firmware/scp-firmware"
-    LANGUAGES NONE)
+    LANGUAGES C ASM)
 
 #
 # Configure the default build type to be "Release". We choose to default to a
@@ -120,10 +120,70 @@ if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
 endif()
 
 #
-# Pull in the CMSIS package.
+# If the firmware developer has given us initial values for these configuration
+# options, we can expose them to the user.
 #
 
-add_subdirectory("contrib/cmsis" EXCLUDE_FROM_ALL)
+include(CMakeDependentOption)
+
+# Common build options
+cmake_dependent_option(
+    SCP_ENABLE_MULTITHREADING "Enable the multithreading subsystem?"
+    "${SCP_ENABLE_MULTITHREADING_INIT}"
+    "DEFINED SCP_ENABLE_MULTITHREADING_INIT" "${SCP_ENABLE_MULTITHREADING}")
+
+cmake_dependent_option(
+    SCP_ENABLE_NOTIFICATIONS "Enable the notification subsystem?"
+    "${SCP_ENABLE_NOTIFICATIONS_INIT}" "DEFINED SCP_ENABLE_NOTIFICATIONS_INIT"
+    "${SCP_ENABLE_NOTIFICATIONS}")
+
+if(SCP_FIRMWARE)
+    #
+    # Pull in the CMSIS package.
+    #
+
+    add_subdirectory("contrib/cmsis" EXCLUDE_FROM_ALL)
+
+    #
+    # Load in the firmware. We do this now so that the firmware list files can
+    # make adjustments to any modules it wishes to load in, configure the
+    # architecture library, etc.
+    #
+
+    add_subdirectory("${SCP_FIRMWARE_SOURCE_DIR}" "${SCP_FIRMWARE_BINARY_DIR}"
+                     EXCLUDE_FROM_ALL)
+
+    #
+    # Make the firmware target a part of the 'all' pseudo-target and give it a
+    # fixed output binary name so that different toolchains don't generate
+    # different names (which is desirable especially for higher-level build
+    # systems).
+    #
+
+    set_target_properties(
+        ${SCP_FIRMWARE_TARGET} PROPERTIES EXCLUDE_FROM_ALL FALSE
+                                          OUTPUT_NAME "${SCP_FIRMWARE_TARGET}"
+                                          RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
+    #
+    # Load in the architecture support library.
+    #
+
+    add_subdirectory("arch" EXCLUDE_FROM_ALL)
+
+    #
+    # Load in the modules specified, plus any that need to be included to
+    # support other modules.
+    #
+
+    add_subdirectory("module" EXCLUDE_FROM_ALL)
+
+    #
+    # Load in the framework. This should be the last of the targets we need.
+    #
+
+    add_subdirectory("framework" EXCLUDE_FROM_ALL)
+endif()
 
 #
 # Set up global inclusions and exclusions for source file quality assurance

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,12 @@ if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
 endif()
 
 #
+# Pull in the CMSIS package.
+#
+
+add_subdirectory("contrib/cmsis" EXCLUDE_FROM_ALL)
+
+#
 # Set up global inclusions and exclusions for source file quality assurance
 # tools. This is intended to filter in external directories (e.g. out-of-tree
 # modules) and filter out third-party directories.

--- a/arch/CMakeLists.txt
+++ b/arch/CMakeLists.txt
@@ -1,0 +1,118 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_ARCHITECTURE_ "${SCP_ARCHITECTURE}")
+
+foreach(path IN LISTS SCP_ARCHITECTURE_PATHS)
+    unset(SCP_ARCHITECTURE)
+
+    include("${path}/Architecture.cmake" OPTIONAL
+            RESULT_VARIABLE SCP_ARCHITECTURE_LIST_FILE)
+
+    if(NOT SCP_ARCHITECTURE_LIST_FILE)
+        # cmake-format: off
+        message(WARNING
+            "No architecture list file found!\n"
+
+            "${path}/Architecture.cmake\n"
+
+            "This architecture path was provided as part of a firmware "
+            "initial-cache file ('Firmware.cmake'), but its "
+            "'Architecture.cmake' file could not be located.")
+        # cmake-format: on
+
+        continue()
+    elseif(NOT DEFINED SCP_ARCHITECTURE)
+        # cmake-format: off
+        message(WARNING
+            "No name given by architecture metadata file!\n"
+
+            "${path}/Architecture.cmake\n"
+
+            "This architecture metadata file has not yielded an architecture "
+            "name and as such cannot be identified. please ensure that you have "
+            "set `SCP_ARCHITECTURE` in your 'Architecture.cmake' file.")
+        # cmake-format: on
+
+        continue()
+    elseif(NOT DEFINED SCP_ARCHITECTURE_TARGET)
+        # cmake-format: off
+        message(WARNING
+            "No target given by architecture: ${SCP_ARCHITECTURE}\n"
+
+            "This architecture has not yielded a target name, and as such "
+            "cannot be used as a dependency for any other targets. "
+            "please ensure that you have set `SCP_ARCHITECTURE_TARGET` in your "
+            "'Architecture.cmake' file.")
+        # cmake-format: on
+
+        continue()
+    endif()
+
+    #
+    # Append this architecture to the list of valid architectures, and make sure
+    # we track its target and source directory.
+    #
+
+    list(APPEND SCP_VALID_ARCHITECTURES "${SCP_ARCHITECTURE}")
+    list(APPEND SCP_VALID_ARCHITECTURE_TARGETS "${SCP_ARCHITECTURE_TARGET}")
+    list(APPEND SCP_VALID_ARCHITECTURE_SOURCE_DIRS "${path}")
+endforeach()
+
+set(SCP_ARCHITECTURE "${SCP_ARCHITECTURE_}")
+
+if(NOT "${SCP_ARCHITECTURE}" IN_LIST SCP_VALID_ARCHITECTURES)
+    # cmake-format: off
+    message(FATAL_ERROR
+        "No architecture found: ${SCP_ARCHITECTURE}\n"
+
+        "The architecture requested by the firmware you are trying to build "
+        "has not been found. This is probably because the firmware "
+        "initial-cache file you provided has requested a custom architecture "
+        "without providing its path.")
+    # cmake-format: on
+endif()
+
+#
+# Load in the architecture support library target.
+#
+
+list(FIND SCP_VALID_ARCHITECTURES "${SCP_ARCHITECTURE}" SCP_ARCHITECTURE_IDX)
+list(GET SCP_VALID_ARCHITECTURE_TARGETS ${SCP_ARCHITECTURE_IDX}
+     SCP_ARCHITECTURE_TARGET)
+list(GET SCP_VALID_ARCHITECTURE_SOURCE_DIRS ${SCP_ARCHITECTURE_IDX}
+     SCP_ARCHITECTURE_SOURCE_DIR)
+
+set(SCP_ARCHITECTURE_BINARY_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/${SCP_ARCHITECTURE}")
+
+add_subdirectory("${SCP_ARCHITECTURE_SOURCE_DIR}"
+                 "${SCP_ARCHITECTURE_BINARY_DIR}" EXCLUDE_FROM_ALL)
+
+#
+# Ensure the firmware links to the architecture library, and that the
+# architecture library links to the framework. It's the firmware dependency on
+# the architecture library that officially causes the the program entrypoint to
+# be linked.
+#
+
+target_link_libraries(${SCP_FIRMWARE_TARGET} PRIVATE ${SCP_ARCHITECTURE_TARGET})
+target_link_libraries(${SCP_ARCHITECTURE_TARGET} PRIVATE framework)
+
+target_include_directories(
+    ${SCP_ARCHITECTURE_TARGET}
+    PRIVATE
+        $<TARGET_PROPERTY:${SCP_FIRMWARE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
+
+target_compile_definitions(
+    ${SCP_ARCHITECTURE_TARGET}
+    PRIVATE
+        $<TARGET_PROPERTY:${SCP_FIRMWARE_TARGET},INTERFACE_COMPILE_DEFINITIONS>)
+
+set(SCP_ARCHITECTURE_TARGET
+    "${SCP_ARCHITECTURE_TARGET}"
+    PARENT_SCOPE)

--- a/contrib/cmsis/CMakeLists.txt
+++ b/contrib/cmsis/CMakeLists.txt
@@ -1,0 +1,22 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+cmake_minimum_required(VERSION 3.18.3)
+
+project(
+    CMSIS
+    VERSION 5.2.0
+    DESCRIPTION "Cortex Microcontroller Software Interface Standard (CMSIS)"
+    HOMEPAGE_URL "https://developer.arm.com/tools-and-software/embedded/cmsis"
+    LANGUAGES C)
+
+add_library(rtos2 INTERFACE)
+
+target_include_directories(
+    rtos2 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/Include")
+
+add_library(cmsis::rtos2 ALIAS rtos2)

--- a/contrib/cmsis/CMakeLists.txt
+++ b/contrib/cmsis/CMakeLists.txt
@@ -13,6 +13,20 @@ project(
     DESCRIPTION "Cortex Microcontroller Software Interface Standard (CMSIS)"
     HOMEPAGE_URL "https://developer.arm.com/tools-and-software/embedded/cmsis"
     LANGUAGES C)
+#
+# Define CMSIS-Core (M).
+#
+
+add_library(core-m INTERFACE)
+
+target_include_directories(
+    core-m INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/Core/Include")
+
+add_library(cmsis::core-m ALIAS core-m)
+
+#
+# Define CMSIS-RTOS2.
+#
 
 add_library(rtos2 INTERFACE)
 

--- a/contrib/cmsis/CMakeLists.txt
+++ b/contrib/cmsis/CMakeLists.txt
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+# cmake-lint: disable=C0301
+
 cmake_minimum_required(VERSION 3.18.3)
 
 project(
@@ -12,7 +14,8 @@ project(
     VERSION 5.2.0
     DESCRIPTION "Cortex Microcontroller Software Interface Standard (CMSIS)"
     HOMEPAGE_URL "https://developer.arm.com/tools-and-software/embedded/cmsis"
-    LANGUAGES C)
+    LANGUAGES C ASM)
+
 #
 # Define CMSIS-Core (M).
 #
@@ -34,3 +37,47 @@ target_include_directories(
     rtos2 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/Include")
 
 add_library(cmsis::rtos2 ALIAS rtos2)
+
+#
+# Define and build CMSIS-RTOS2 RTX.
+#
+
+add_library(rtos2-rtx INTERFACE)
+
+target_include_directories(
+    rtos2-rtx
+    INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include"
+              "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Include"
+              "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source")
+
+# cmake-lint: disable=E1122
+target_sources(
+    rtos2-rtx
+    INTERFACE
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_delay.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_evflags.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_evr.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_kernel.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_memory.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_mempool.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_msgqueue.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_mutex.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_semaphore.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_system.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_thread.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/rtx_timer.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/Source/os_systick.c")
+
+target_compile_definitions(rtos2-rtx INTERFACE RTX_NO_MULTITHREAD_CLIB)
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m[37]")
+    target_sources(
+        rtos2-rtx
+        INTERFACE
+            "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/RTX/Source/GCC/irq_cm3.S"
+    )
+endif()
+
+target_link_libraries(rtos2-rtx INTERFACE core-m rtos2)
+
+add_library(cmsis::rtos2-rtx ALIAS rtos2-rtx)

--- a/contrib/cmsis/include/RTE_Components.h
+++ b/contrib/cmsis/include/RTE_Components.h
@@ -1,0 +1,13 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2017-2021, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef RTE_COMPONENTS_H
+#define RTE_COMPONENTS_H
+
+#define CMSIS_device_header <fmw_cmsis.h>
+
+#endif /* RTE_COMPONENTS_H */

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,0 +1,186 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+#
+# Set up the framework target.
+#
+# This stage does the basic framework target configuration, including adding any
+# default source files, setting up include directories and adding any
+# preprocessor definitions.
+#
+
+add_library(framework)
+
+target_include_directories(framework
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    framework
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/assert.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_arch.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_dlist.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_id.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_interrupt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_io.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_log.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_mm.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_module.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_ring.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_slist.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_status.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_thread_delayed_resp.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_time.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/stdlib.c")
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(framework
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_multi_thread.c")
+
+    target_compile_definitions(framework PUBLIC "BUILD_HAS_MULTITHREADING")
+
+    target_link_libraries(framework PRIVATE cmsis::rtos2)
+else()
+    target_sources(framework
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_thread.c")
+endif()
+
+if(SCP_ENABLE_NOTIFICATIONS)
+    target_sources(framework
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_notification.c")
+
+    target_compile_definitions(framework PUBLIC "BUILD_HAS_NOTIFICATION")
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(framework PUBLIC BUILD_MODE_DEBUG)
+endif()
+
+#
+# Handle the framework logging filter level.
+#
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(SCP_LOG_LEVEL_DEFAULT "INFO")
+else()
+    set(SCP_LOG_LEVEL_DEFAULT "WARN")
+endif()
+
+set(SCP_LOG_LEVEL
+    "${SCP_LOG_LEVEL_DEFAULT}"
+    CACHE STRING "Minimum logging level.")
+
+set_property(CACHE SCP_LOG_LEVEL PROPERTY STRINGS "TRACE" "INFO" "WARN" "ERROR"
+                                                  "CRIT")
+
+target_compile_definitions(framework
+                           PUBLIC FWK_LOG_LEVEL=FWK_LOG_LEVEL_${SCP_LOG_LEVEL})
+
+#
+# Generate `<fwk_module_idx.h>` and `<fwk_module_list.c>` based on the list of
+# modules we have been given. While we're at it, we add these modules as
+# dependencies of the framework.
+#
+
+list(LENGTH SCP_MODULES SCP_MODULE_IDX_MAX)
+
+# cmake-lint: disable=E1120
+
+foreach(idx RANGE ${SCP_MODULE_IDX_MAX})
+    if(idx EQUAL SCP_MODULE_IDX_MAX)
+        string(APPEND SCP_MODULE_IDX_GEN "    FWK_MODULE_IDX_COUNT = ${idx},\n")
+
+        break()
+    endif()
+
+    list(GET SCP_MODULES ${idx} SCP_MODULE)
+
+    string(MAKE_C_IDENTIFIER ${SCP_MODULE} SCP_MODULE)
+    string(TOUPPER ${SCP_MODULE} SCP_MODULE_UPPER)
+
+    # cmake-format: off
+
+    string(APPEND SCP_MODULE_IDX_GEN "    FWK_MODULE_IDX_${SCP_MODULE_UPPER} = ${idx},\n")
+    string(APPEND SCP_MODULE_ID_INIT_GEN "#define FWK_MODULE_ID_${SCP_MODULE_UPPER}_INIT FWK_ID_MODULE_INIT(FWK_MODULE_IDX_${SCP_MODULE_UPPER})\n")
+    string(APPEND SCP_MODULE_ID_GEN "#define FWK_MODULE_ID_${SCP_MODULE_UPPER} FWK_ID_MODULE(FWK_MODULE_IDX_${SCP_MODULE_UPPER})\n")
+    string(APPEND SCP_MODULE_ID_CONST_GEN "static const fwk_id_t fwk_module_id_${SCP_MODULE} = FWK_MODULE_ID_${SCP_MODULE_UPPER}_INIT;\n")
+
+    string(APPEND SCP_MODULE_EXTERN_GEN "extern const struct fwk_module module_${SCP_MODULE};\n")
+    string(APPEND SCP_MODULE_EXTERN_CONFIG_GEN "extern const struct fwk_module_config config_${SCP_MODULE};\n")
+    string(APPEND SCP_MODULE_GEN "    &module_${SCP_MODULE},\n")
+    string(APPEND SCP_MODULE_CONFIG_GEN "    &config_${SCP_MODULE},\n")
+
+    # cmake-format: on
+
+    #
+    # Create the `BUILD_HAS_MOD_<X>` definition.
+    #
+
+    target_compile_definitions(framework
+                               PUBLIC "BUILD_HAS_MOD_${SCP_MODULE_UPPER}=1")
+endforeach()
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/fwk_module_idx.h.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/include/fwk_module_idx.h")
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_module_list.c.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/src/fwk_module_list.c")
+
+target_include_directories(framework
+                           PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/include")
+
+target_sources(framework
+               PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/src/fwk_module_list.c")
+
+#
+# Build framework version string
+#
+# The framework version string uses Git to describe the current commit or tag.
+# If Git errors out, or if the project is not part of a Git repository, the
+# version defaults to `vX.Y.Z-<unknown>`.
+#
+
+find_package(Git)
+
+if(GIT_FOUND)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" describe --tags --dirty --always
+        WORKING_DIRECTORY "${SCP_SOURCE_DIR}"
+        OUTPUT_VARIABLE SCP_DESCRIBE
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+if(NOT SCP_DESCRIBE)
+    set(SCP_DESCRIBE "v${SCP_VERSION}-<unknown>")
+endif()
+
+target_compile_definitions(
+    framework
+    PUBLIC "BUILD_VERSION_DESCRIBE_STRING=\"${SCP_DESCRIBE}\""
+           "BUILD_VERSION_MAJOR=${SCP_VERSION_MAJOR}"
+           "BUILD_VERSION_MINOR=${SCP_VERSION_MINOR}"
+           "BUILD_VERSION_PATCH=${SCP_VERSION_PATCH}")
+
+#
+# Pull in any include directories explicitly exposed by the firmware. We need
+# these for certain `<fmw_<x>.h>` header files.
+#
+
+target_include_directories(
+    framework
+    PRIVATE
+        $<TARGET_PROPERTY:${SCP_FIRMWARE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>)
+
+#
+# Make sure the framework links privately to all of the modules, as it depends
+# on some of the symbols that they export (namely `module_<x>`).
+#
+
+foreach(target IN LISTS SCP_MODULE_TARGETS)
+    target_link_libraries(framework PRIVATE ${target})
+endforeach()

--- a/framework/include/fwk_module_idx.h.in
+++ b/framework/include/fwk_module_idx.h.in
@@ -1,0 +1,23 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FWK_MODULE_IDX_H
+#define FWK_MODULE_IDX_H
+
+#include <fwk_id.h>
+
+@SCP_MODULE_ID_INIT_GEN@
+
+@SCP_MODULE_ID_GEN@
+
+enum fwk_module_idx {
+@SCP_MODULE_IDX_GEN@
+};
+
+@SCP_MODULE_ID_CONST_GEN@
+
+#endif /* FWK_MODULE_IDX_H */

--- a/framework/src/fwk_module_list.c.in
+++ b/framework/src/fwk_module_list.c.in
@@ -1,0 +1,23 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+
+#include <stddef.h>
+
+@SCP_MODULE_EXTERN_GEN@
+
+const struct fwk_module *module_table[FWK_MODULE_IDX_COUNT] = {
+@SCP_MODULE_GEN@
+};
+
+@SCP_MODULE_EXTERN_CONFIG_GEN@
+
+const struct fwk_module_config *module_config_table[FWK_MODULE_IDX_COUNT] = {
+@SCP_MODULE_CONFIG_GEN@
+};

--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -1,0 +1,249 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+#
+# Handle the module libraries.
+#
+# The list of modules and any additional module paths are given by the firmware
+# initial-cache file through `SCP_MODULES` and `SCP_MODULE_PATHS`. Here we
+# iterate through each of the module paths we've been given and load a
+# 'Module.cmake' file from within, which describes the module.
+#
+
+foreach(source_dir IN LISTS SCP_MODULE_PATHS)
+    unset(SCP_MODULE)
+
+    include("${source_dir}/Module.cmake" OPTIONAL
+            RESULT_VARIABLE SCP_MODULE_LIST_FILE)
+
+    if(NOT SCP_MODULE_LIST_FILE)
+        # cmake-format: off
+
+        message(FATAL_ERROR
+            "No module list file found!\n"
+
+            "${source_dir}/Module.cmake\n"
+
+            "This module path was provided as part of a firmware initial-cache "
+            "file ('Firmware.cmake'), but its 'Module.cmake' file could not be "
+            "located.")
+
+        # cmake-format: on
+    elseif(NOT DEFINED SCP_MODULE)
+        # cmake-format: off
+
+        message(FATAL_ERROR
+            "No module name given for module!\n"
+
+            "${source_dir}/Module.cmake\n"
+
+            "This module metadata file has not yielded a module name and as "
+            "such cannot be identified. "
+            "please ensure that you have set `SCP_MODULE` in your "
+            "'Module.cmake' file.")
+
+        # cmake-format: on
+    endif()
+
+    #
+    # Append this module to the list of valid modules and track its source
+    # directory.
+    #
+
+    list(APPEND SCP_VALID_MODULES "${SCP_MODULE}")
+    list(APPEND SCP_VALID_MODULE_TARGETS "${SCP_MODULE_TARGET}")
+    list(APPEND SCP_VALID_MODULE_SOURCE_DIRS "${source_dir}")
+endforeach()
+
+#
+# Load in each module, one by one.
+#
+# We've stored a list of modules that we've located inside `SCP_VALID_MODULES`.
+# Now, we need to run through the list of modules that the firmware requested
+# and ensure that we found it. If we did, load it into the build system. If we
+# didn't, exit and let the user know.
+#
+
+set(SCP_MISSING_MODULES "${SCP_MODULES}")
+list(REMOVE_ITEM SCP_MISSING_MODULES ${SCP_VALID_MODULES})
+
+foreach(module IN LISTS SCP_MISSING_MODULES)
+    # cmake-format: off
+    message(WARNING
+        "Module requested, but not found: ${module}\n"
+
+        "The firmware requested this module, but we were unable to locate it. "
+        "If you are the firmware developer, please ensure that you have added "
+        "the module path to `SCP_MODULE_PATHS` in your 'Firmware.cmake' file.")
+    # cmake-format: on
+endforeach()
+
+if(SCP_MISSING_MODULES)
+    message(FATAL_ERROR "Missing modules were requested!")
+endif()
+
+#
+# Wrap the standard target creation/manipulation facilities so that we can
+# control the underlying target type and its sources when the module creates its
+# target.
+#
+
+include(CMakeParseArguments)
+
+# cmake-lint: disable=C0103,C0111
+
+macro(add_library target)
+    set(args "${ARGN}")
+
+    set(is_module FALSE)
+
+    if("SCP_MODULE" IN_LIST args)
+        if(SCP_MODULE_HEADER_ONLY)
+            #
+            # If this module is being loaded in as a header-only module, then we
+            # silently replace any `add_library` calls using the `SCP_MODULE`
+            # type with `INTERFACE`.
+            #
+
+            string(REPLACE "SCP_MODULE" "INTERFACE" args "${args}")
+        else()
+            string(REPLACE "SCP_MODULE" "" args "${args}")
+        endif()
+
+        set(is_module TRUE)
+    endif()
+
+    _add_library(${target} ${args})
+
+    if(is_module)
+        set_target_properties("${target}" PROPERTIES _SCP_IS_MODULE TRUE)
+    endif()
+endmacro()
+
+# cmake-lint: disable=C0103,C0111
+
+function(scp_generate_builtin_module_wrapper builtin)
+    function(${builtin} target)
+        set(args "${ARGN}")
+
+        get_target_property(is_module "${target}" _SCP_IS_MODULE)
+        get_target_property(type "${target}" TYPE)
+        get_target_property(is_imported "${target}" IMPORTED)
+
+        set(is_interface FALSE)
+
+        if(type STREQUAL "INTERFACE_LIBRARY")
+            set(is_interface TRUE)
+        endif()
+
+        if(is_imported)
+            set(is_interface TRUE)
+        endif()
+
+        if(is_module AND is_interface)
+            #
+            # If this module is being pulled in as an interface library target,
+            # we need to strip any `PRIVATE` arguments and convert any `PUBLIC`
+            # ones to `INTERFACE`.
+            #
+
+            cmake_parse_arguments("scp_${CMAKE_CURRENT_FUNCTION}" "" ""
+                                  "PRIVATE" ${ARGN})
+
+            set(args "${scp_${CMAKE_CURRENT_FUNCTION}_UNPARSED_ARGUMENTS}")
+            string(REPLACE "PUBLIC" "INTERFACE" args "${args}")
+        endif()
+
+        if(args)
+            cmake_language(CALL _${CMAKE_CURRENT_FUNCTION} ${target} ${args})
+        endif()
+    endfunction()
+endfunction()
+
+scp_generate_builtin_module_wrapper(target_include_directories)
+scp_generate_builtin_module_wrapper(target_sources)
+scp_generate_builtin_module_wrapper(target_link_libraries)
+scp_generate_builtin_module_wrapper(target_link_options)
+
+#
+# Load in all the modules we have access to.
+#
+
+# cmake-lint: disable=C0103
+
+foreach(SCP_MODULE IN LISTS SCP_VALID_MODULES)
+    #
+    # We have the module, so grab its target and the source directory, both of
+    # which were specified by its 'Module.cmake' file.
+    #
+
+    list(FIND SCP_VALID_MODULES "${SCP_MODULE}" SCP_MODULE_IDX)
+    list(GET SCP_VALID_MODULE_TARGETS ${SCP_MODULE_IDX} SCP_MODULE_TARGET)
+    list(GET SCP_VALID_MODULE_SOURCE_DIRS ${SCP_MODULE_IDX}
+         SCP_MODULE_SOURCE_DIR)
+
+    #
+    # Pull the module in, creating the target. Modules that we do not intend on
+    # linking to are created as interface targets, so that other modules can use
+    # their headers if they so wish.
+    #
+
+    if(SCP_MODULE IN_LIST SCP_MODULES)
+        set(SCP_MODULE_HEADER_ONLY FALSE)
+        set(SCP_MODULE_PUBLIC "PUBLIC")
+    else()
+        set(SCP_MODULE_HEADER_ONLY TRUE)
+        set(SCP_MODULE_PUBLIC "INTERFACE")
+    endif()
+
+    add_subdirectory(
+        "${SCP_MODULE_SOURCE_DIR}"
+        "${CMAKE_CURRENT_BINARY_DIR}/modules/${SCP_MODULE}" EXCLUDE_FROM_ALL)
+
+    #
+    # Link the firmware to the module, and the module to the framework.
+    #
+
+    target_link_libraries(${SCP_FIRMWARE_TARGET} PRIVATE ${SCP_MODULE_TARGET})
+    target_link_libraries(${SCP_MODULE_TARGET} ${SCP_MODULE_PUBLIC} framework)
+
+    #
+    # Handle any modules that we actually intend on linking to.
+    #
+
+    if(SCP_MODULE IN_LIST SCP_MODULES)
+        #
+        # Expose any firmware interface headers to the module.
+        #
+
+        target_include_directories(
+            ${SCP_MODULE_TARGET}
+            PRIVATE
+                $<TARGET_PROPERTY:${SCP_FIRMWARE_TARGET},INTERFACE_INCLUDE_DIRECTORIES>
+        )
+
+        #
+        # Make sure this module is linked.
+        #
+
+        list(APPEND SCP_MODULE_TARGETS "${SCP_MODULE_TARGET}")
+    endif()
+endforeach()
+
+#
+# Export the updated module list and their targets so they can be used from the
+# root variable scope downwards.
+#
+
+set(SCP_MODULES
+    "${SCP_MODULES}"
+    PARENT_SCOPE)
+set(SCP_MODULE_TARGETS
+    "${SCP_MODULE_TARGETS}"
+    PARENT_SCOPE)


### PR DESCRIPTION
This PR adds core CMake build support for the SCP firmware. However, note that this PR doesn't enable the building of any of the firmware targets.  Subsequent patches will be added in the coming weeks which will first support the building of the modules of the SCP firmware and later the actual firmware targets which will then finally enable the building of the platform-specific firmware binaries.  Also intended is a document that would explain how to build SCP firmware using CMake.


