### PR TITLE
Ppu v1 opmode include

### DIFF
--- a/module/ppu_v1/include/mod_ppu_v1.h
+++ b/module/ppu_v1/include/mod_ppu_v1.h
@@ -44,6 +44,30 @@ enum mod_ppu_v1_api_idx {
 };
 
 /*!
+ * \brief PPU_V1 OPERATING MODES
+ */
+enum ppu_v1_opmode {
+    PPU_V1_OPMODE_00,
+    PPU_V1_OPMODE_01,
+    PPU_V1_OPMODE_02,
+    PPU_V1_OPMODE_03,
+    PPU_V1_OPMODE_04,
+    PPU_V1_OPMODE_05,
+    PPU_V1_OPMODE_06,
+    PPU_V1_OPMODE_07,
+    PPU_V1_OPMODE_08,
+    PPU_V1_OPMODE_09,
+    PPU_V1_OPMODE_10,
+    PPU_V1_OPMODE_11,
+    PPU_V1_OPMODE_12,
+    PPU_V1_OPMODE_13,
+    PPU_V1_OPMODE_14,
+    PPU_V1_OPMODE_15,
+    /* No valid operating modes after this line */
+    PPU_V1_OPMODE_COUNT
+};
+
+/*!
  * \brief Power domain PPU descriptor.
  */
 struct mod_ppu_v1 {
@@ -105,6 +129,11 @@ struct mod_ppu_v1_pd_config {
      *  the value of this field is undefined.
      */
     fwk_id_t cluster_id;
+
+    /*!
+     *  Product specific ppu opmode.
+     */
+    enum ppu_v1_opmode opmode;
 
     /*!
      * Flag indicating if this domain should be powered on during element

--- a/module/ppu_v1/src/mod_ppu_v1.c
+++ b/module/ppu_v1/src/mod_ppu_v1.c
@@ -456,6 +456,8 @@ static void cluster_on(struct ppu_v1_pd_ctx *pd_ctx)
                                       PPU_V1_MODE_ON,
                                       PPU_V1_EDGE_SENSITIVITY_MASKED);
 
+    ppu_v1_request_operating_mode(ppu, pd_ctx->config->opmode);
+
     ppu_v1_set_power_mode(ppu, PPU_V1_MODE_ON, pd_ctx->timer_ctx);
     status = pd_ctx->pd_driver_input_api->report_power_state_transition(
         pd_ctx->bound_id, MOD_PD_STATE_ON);

--- a/module/ppu_v1/src/ppu_v1.h
+++ b/module/ppu_v1/src/ppu_v1.h
@@ -12,6 +12,7 @@
  * \cond
  */
 
+#include <mod_ppu_v1.h>
 #include <mod_timer.h>
 
 #include <fwk_macros.h>
@@ -73,27 +74,6 @@ enum ppu_v1_mode {
     PPU_V1_MODE_DBG_RECOV   = 10,
     /* No valid modes after this line */
     PPU_V1_MODE_COUNT
-};
-
-enum ppu_v1_opmode {
-    PPU_V1_OPMODE_00,
-    PPU_V1_OPMODE_01,
-    PPU_V1_OPMODE_02,
-    PPU_V1_OPMODE_03,
-    PPU_V1_OPMODE_04,
-    PPU_V1_OPMODE_05,
-    PPU_V1_OPMODE_06,
-    PPU_V1_OPMODE_07,
-    PPU_V1_OPMODE_08,
-    PPU_V1_OPMODE_09,
-    PPU_V1_OPMODE_10,
-    PPU_V1_OPMODE_11,
-    PPU_V1_OPMODE_12,
-    PPU_V1_OPMODE_13,
-    PPU_V1_OPMODE_14,
-    PPU_V1_OPMODE_15,
-    /* No valid operating modes after this line */
-    PPU_V1_OPMODE_COUNT
 };
 
 enum ppu_v1_op_devactive {

--- a/product/n1sdp/include/n1sdp_scc_reg.h
+++ b/product/n1sdp/include/n1sdp_scc_reg.h
@@ -215,4 +215,6 @@ struct scc_reg {
 #define SCC_SYS_MAN_RESET_CCIX_POS       UINT32_C(11)
 #define SCC_SYS_MAN_RESET_PCIE_POS       UINT32_C(10)
 
+#define SCC_BOOTGPR1_L3_CACHE_ENABLE_MASK UINT32_C(0x1)
+
 #endif /* N1SDP_SCC_REG_H */

--- a/product/n1sdp/scp_ramfw/config_ppu_v1.c
+++ b/product/n1sdp/scp_ramfw/config_ppu_v1.c
@@ -7,7 +7,9 @@
 
 #include "config_power_domain.h"
 #include "n1sdp_core.h"
+#include "n1sdp_scc_reg.h"
 #include "n1sdp_scp_mmap.h"
+#include "n1sdp_scp_pik.h"
 
 #include <mod_cmn600.h>
 #include <mod_power_domain.h>
@@ -135,6 +137,10 @@ static const struct fwk_element *ppu_v1_get_element_table(fwk_id_t module_id)
                                              MOD_CMN600_API_IDX_PPU_OBSERVER);
         pd_config->post_ppu_on_param =
             (void *)&cluster_idx_to_node_id[cluster_idx];
+        pd_config->opmode =
+            (SCC->BOOT_GPR1 & SCC_BOOTGPR1_L3_CACHE_ENABLE_MASK) ?
+            PPU_V1_OPMODE_04 :
+            PPU_V1_OPMODE_00;
     }
 
     memcpy(&element_table[core_count + cluster_count],


### PR DESCRIPTION
This PR contains:

- Assigning opmode from product ppu configs
- Enable L3 cache from BOOTGPR1 reg for N1SDP