### PR TITLE
module/cmn_booker: amend CFGM base address calculation

### DIFF
--- a/module/cmn_booker/include/mod_cmn_booker.h
+++ b/module/cmn_booker/include/mod_cmn_booker.h
@@ -127,6 +127,13 @@ struct mod_cmn_booker_config {
      *      to a CAL port, node id of HN-F will be a odd number).
      */
     bool hnf_cal_mode;
+
+    /*! \
+     * \brief Number of device ports per XP
+     * \details The calculation for CFGM base address depends on the number of
+     *      ports per cross point
+     */
+    unsigned int ports_per_xp;
 };
 
 /*!

--- a/module/cmn_booker/src/cmn_booker.h
+++ b/module/cmn_booker/src/cmn_booker.h
@@ -22,6 +22,8 @@
 #define MAX_RNI_COUNT 32
 #define MAX_RNF_COUNT 64
 
+#define MAX_PORTS_COUNT 6
+
 /* Maximum System Cache Group regions supported by CMN-BOOKER */
 #define MAX_SCG_COUNT 4
 
@@ -417,12 +419,16 @@ unsigned int get_node_pos_y(void *node_base);
  * \param base CMN BOOKER peripheral base address
  * \param hnd_node_id HN-D node identifier containing the global configuration
  * \param mesh_size_x Size of the mesh along the x-axis
- * \param mesh_size_y Size of the mesh along the x-axis
+ * \param mesh_size_y Size of the mesh along the y-axis
+ * \param mesh_size_y Device ports per XP
  *
  * \return Pointer to the root node descriptor
  */
-struct cmn_booker_cfgm_reg *get_root_node(uintptr_t base,
-    unsigned int hnd_node_id, unsigned int mesh_size_x,
-    unsigned int mesh_size_y);
+struct cmn_booker_cfgm_reg *get_root_node(
+    uintptr_t base,
+    unsigned int hnd_node_id,
+    unsigned int mesh_size_x,
+    unsigned int mesh_size_y,
+    unsigned int ports_per_xp);
 
 #endif /* CMN_BOOKER_H */

--- a/module/cmn_booker/src/mod_cmn_booker.c
+++ b/module/cmn_booker/src/mod_cmn_booker.c
@@ -535,8 +535,14 @@ static int cmn_booker_init(fwk_id_t module_id, unsigned int element_count,
     if (config->snf_count > CMN_BOOKER_HNF_CACHE_GROUP_ENTRIES_MAX)
         return FWK_E_DATA;
 
-    ctx->root = get_root_node(config->base, config->hnd_node_id,
-        config->mesh_size_x, config->mesh_size_y);
+    fwk_assert(config->ports_per_xp < MAX_PORTS_COUNT);
+
+    ctx->root = get_root_node(
+        config->base,
+        config->hnd_node_id,
+        config->mesh_size_x,
+        config->mesh_size_y,
+        config->ports_per_xp);
 
     ctx->config = config;
 

--- a/product/tc0/scp_romfw/config_cmn_booker.c
+++ b/product/tc0/scp_romfw/config_cmn_booker.c
@@ -116,5 +116,6 @@ const struct fwk_module_config config_cmn_booker = {
         .clock_id =
             FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_INTERCONNECT),
         .hnf_cal_mode = false,
+        .ports_per_xp = 4,
     }),
 };


### PR DESCRIPTION
The CFGM base address calculation depends on the number of ports
per XP (cross-point).

Signed-off-by: Usama Arif <usama.arif@arm.com>
Change-Id: Iabb9e76b86ee80b345857deb86e9acd4cec5988c