### PR TITLE
apremap: fix 2 GiB range check

### DIFF
--- a/module/apremap/src/mod_apremap.c
+++ b/module/apremap/src/mod_apremap.c
@@ -107,7 +107,7 @@ static inline bool is_addr_second_1gb_block(uint64_t addr)
  */
 static inline bool is_addr_above_2gb(uint64_t addr)
 {
-    return ((addr >= (1 * FWK_GIB)) && (addr < (2 * FWK_GIB)));
+    return (addr >= (2 * FWK_GIB));
 }
 
 /*


### PR DESCRIPTION
The function that checks whether the address is above 2 GiB incorrectly
checks if the address is between 1 GiB and 2 GiB. Fix this.

Signed-off-by: Vijayenthiran Subramaniam <vijayenthiran.subramaniam@arm.com>
Change-Id: I2d2a7a785a8d098a507a650f1b0db2cc2842f56c