### PR TITLE
cmn700: exclude CCG devices when calculating external rnsam count

### DIFF
--- a/module/cmn700/src/mod_cmn700.c
+++ b/module/cmn700/src/mod_cmn700.c
@@ -369,7 +369,8 @@ static void cmn700_configure(void)
 
                 if (!(get_device_type(xp, xp_port) == DEVICE_TYPE_CXRH) &&
                     !(get_device_type(xp, xp_port) == DEVICE_TYPE_CXHA) &&
-                    !(get_device_type(xp, xp_port) == DEVICE_TYPE_CXRA)) {
+                    !(get_device_type(xp, xp_port) == DEVICE_TYPE_CXRA) &&
+                    !(get_device_type(xp, xp_port) == DEVICE_TYPE_CCG)) {
                     fwk_assert(xrnsam_entry < ctx->external_rnsam_count);
 
                     ctx->external_rnsam_table[xrnsam_entry].node_id = node_id;


### PR DESCRIPTION
CMN-700 has new device type CCG which act as CXL gateway in addition to
CXRH, CXHA, CXRA (CCIX Gateway blocks). Exclude CCG device from the
count of devices that contain RNSAM table.

Signed-off-by: Vijayenthiran Subramaniam <vijayenthiran.subramaniam@arm.com>
Change-Id: Ie253dcd40a7215c84a956d5978a7af8ebcc1c297