### PR TITLE
cmake: product/sgm775

### DIFF
--- a/module/clock/src/mod_clock.c
+++ b/module/clock/src/mod_clock.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <clock.h>
+#include "clock.h"
 
 #include <mod_clock.h>
 #include <mod_power_domain.h>

--- a/module/gtimer/src/mod_gtimer.c
+++ b/module/gtimer/src/mod_gtimer.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <gtimer_reg.h>
+#include "gtimer_reg.h"
 
 #include <mod_clock.h>
 #include <mod_gtimer.h>

--- a/module/pl011/src/mod_pl011.c
+++ b/module/pl011/src/mod_pl011.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <pl011.h>
+#include "pl011.h"
 
 #include <mod_pl011.h>
 

--- a/module/ppu_v0/src/mod_ppu_v0.c
+++ b/module/ppu_v0/src/mod_ppu_v0.c
@@ -8,7 +8,7 @@
  *     Power State Management PPU v0 driver.
  */
 
-#include <ppu_v0.h>
+#include "ppu_v0.h"
 
 #include <mod_power_domain.h>
 #include <mod_ppu_v0.h>

--- a/module/ppu_v0/src/ppu_v0.c
+++ b/module/ppu_v0/src/ppu_v0.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <ppu_v0.h>
+#include "ppu_v0.h"
 
 #include <fwk_assert.h>
 #include <fwk_status.h>

--- a/module/ppu_v1/src/mod_ppu_v1.c
+++ b/module/ppu_v1/src/mod_ppu_v1.c
@@ -8,7 +8,7 @@
  *     Power State Management PPU v1 driver.
  */
 
-#include <ppu_v1.h>
+#include "ppu_v1.h"
 
 #include <mod_power_domain.h>
 #include <mod_ppu_v1.h>

--- a/module/ppu_v1/src/ppu_v1.c
+++ b/module/ppu_v1/src/ppu_v1.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <ppu_v1.h>
+#include "ppu_v1.h"
 
 #include <fwk_assert.h>
 #include <fwk_status.h>

--- a/module/sensor/src/mod_sensor.c
+++ b/module/sensor/src/mod_sensor.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <sensor.h>
+#include "sensor.h"
 
 #include <mod_scmi_sensor.h>
 #include <mod_sensor.h>

--- a/module/sid/src/mod_sid.c
+++ b/module/sid/src/mod_sid.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <sid_reg.h>
+#include "sid_reg.h"
 
 #include <mod_pcid.h>
 #include <mod_sid.h>

--- a/product/sgm775/include/fmw_cmsis.h
+++ b/product/sgm775/include/fmw_cmsis.h
@@ -8,11 +8,15 @@
 #ifndef FMW_CMSIS_H
 #define FMW_CMSIS_H
 
+#include <stdint.h>
+
 #define __CHECK_DEVICE_DEFINES
 #define __CM3_REV 0x0201
 #define __MPU_PRESENT 1
 #define __NVIC_PRIO_BITS 3
 #define __Vendor_SysTickConfig 0
+
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 
 typedef enum IRQn {
     Reset_IRQn = -15,

--- a/product/sgm775/module/sgm775_ddr_phy500/CMakeLists.txt
+++ b/product/sgm775/module/sgm775_ddr_phy500/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_sgm775_ddr_phy500.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-sgm775-dmc500)

--- a/product/sgm775/module/sgm775_ddr_phy500/Module.cmake
+++ b/product/sgm775/module/sgm775_ddr_phy500/Module.cmake
@@ -1,0 +1,9 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "sgm775-ddr-phy500")
+set(SCP_MODULE_TARGET "module-sgm775-ddr-phy500")

--- a/product/sgm775/module/sgm775_dmc500/CMakeLists.txt
+++ b/product/sgm775/module/sgm775_dmc500/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_sgm775_dmc500.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PUBLIC module-timer)

--- a/product/sgm775/module/sgm775_dmc500/Module.cmake
+++ b/product/sgm775/module/sgm775_dmc500/Module.cmake
@@ -1,0 +1,9 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "sgm775-dmc500")
+set(SCP_MODULE_TARGET "module-sgm775-dmc500")

--- a/product/sgm775/module/sgm775_system/CMakeLists.txt
+++ b/product/sgm775/module/sgm775_system/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_sgm775_system.c")
+
+target_link_libraries(
+    module-sgm775-system PRIVATE module-power-domain module-scmi module-sds
+                                 module-system-power)

--- a/product/sgm775/module/sgm775_system/Module.cmake
+++ b/product/sgm775/module/sgm775_system/Module.cmake
@@ -1,0 +1,9 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "sgm775-system")
+set(SCP_MODULE_TARGET "module-sgm775-system")

--- a/product/sgm775/scp_ramfw/CMakeLists.txt
+++ b/product/sgm775/scp_ramfw/CMakeLists.txt
@@ -1,0 +1,85 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(sgm775-bl2)
+
+target_include_directories(
+    sgm775-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                      "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    sgm775-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_debugger_cli.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dvfs.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mock_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v0.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_resource_perms.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_apcore.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_perf.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sensor.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sgm775_ddr_phy500.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sgm775_dmc500.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../src/sgm775_core.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c")
+
+if(SCP_ENABLE_DEBUGGER)
+    target_sources(sgm775-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_debugger_cli.c")
+endif()
+
+if(SCP_ENABLE_RESOURCE_PERMISSIONS)
+    target_sources(
+        sgm775-bl2
+        PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_resource_perms.c")
+endif()
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(sgm775-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+
+    target_link_libraries(sgm775-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(sgm775-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interface include
+# directories. Each module target adds these include directories to their own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    sgm775-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/sgm775/scp_ramfw/Firmware.cmake
+++ b/product/sgm775/scp_ramfw/Firmware.cmake
@@ -1,0 +1,67 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "sgm775-bl2")
+set(SCP_FIRMWARE_TARGET "sgm775-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY TRUE)
+
+set(SCP_ENABLE_DEBUGGER_INIT FALSE)
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+set(SCP_ENABLE_RESOURCE_PERMISSIONS_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/sgm775_ddr_phy500")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/sgm775_dmc500")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/sgm775_system")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "sgm775-ddr-phy500")
+list(APPEND SCP_MODULES "sgm775-dmc500")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "system-pll")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "ppu-v0")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "sgm775-system")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "reg-sensor")
+list(APPEND SCP_MODULES "sensor")
+list(APPEND SCP_MODULES "dvfs")
+list(APPEND SCP_MODULES "psu")
+list(APPEND SCP_MODULES "mock-psu")
+list(APPEND SCP_MODULES "mhu")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "scmi-clock")
+list(APPEND SCP_MODULES "scmi-perf")
+list(APPEND SCP_MODULES "scmi-sensor")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "scmi-apcore")
+list(APPEND SCP_MODULES "sds")

--- a/product/sgm775/scp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/sgm775/scp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,21 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/sgm775/scp_ramfw/Toolchain-GNU.cmake
+++ b/product/sgm775/scp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/sgm775/scp_romfw/CMakeLists.txt
+++ b/product/sgm775/scp_romfw/CMakeLists.txt
@@ -1,0 +1,51 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(sgm775-bl1)
+
+target_include_directories(
+    sgm775-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                      "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    sgm775-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_msys_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v0.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../src/sgm775_core.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(sgm775-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interface include
+# directories. Each module target adds these include directories to their own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    sgm775-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/sgm775/scp_romfw/Firmware.cmake
+++ b/product/sgm775/scp_romfw/Firmware.cmake
@@ -1,0 +1,41 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "sgm775-bl1")
+set(SCP_FIRMWARE_TARGET "sgm775-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY TRUE)
+
+set(SCP_ENABLE_DEBUGGER FALSE)
+set(SCP_ENABLE_MULTITHREADING FALSE)
+set(SCP_ENABLE_NOTIFICATIONS TRUE)
+set(SCP_ENABLE_RESOURCE_PERMISSIONS FALSE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "ppu-v0")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "msys-rom")
+list(APPEND SCP_MODULES "bootloader")
+list(APPEND SCP_MODULES "system-pll")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "sds")

--- a/product/sgm775/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/sgm775/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,21 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/sgm775/scp_romfw/Toolchain-GNU.cmake
+++ b/product/sgm775/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")


### PR DESCRIPTION
This change adds CMake build support for product/sgm775

Please note that firmware targets do not use libRTX_CM3.a
or RTX_CM3.lib, instead in CMake build, the library
is built using sources.

Change-Id: If5568e88d27689430013b701e0203bc579127ce7
Signed-off-by: Chris Kay <chris.kay@arm.com>
Signed-off-by: Joel Goddard <joel.goddard@arm.com>
Signed-off-by: Girish Pathak <girish.pathak@arm.com>