### PR TITLE
cmake: product/juno

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,6 +335,9 @@ cmake_dependent_option(
     "${SCP_ENABLE_SCMI_NOTIFICATIONS_INIT}" "DEFINED SCP_ENABLE_SCMI_NOTIFICATIONS_INIT"
     "${SCP_ENABLE_SCMI_NOTIFICATIONS}")
 
+# Include firmware specific build options
+    include("${SCP_FIRMWARE_SOURCE_DIR}/Buildoptions.cmake" OPTIONAL)
+
 #
 # Wrap `add_executable` in a way that allows us to do some extra processing on
 # the firmware target.(e.g. flat binary generation) This is necessary

--- a/product/juno/include/fmw_cmsis.h
+++ b/product/juno/include/fmw_cmsis.h
@@ -8,11 +8,15 @@
 #ifndef FMW_CMSIS_H
 #define FMW_CMSIS_H
 
+#include <stdint.h>
+
 #define __CHECK_DEVICE_DEFINES
 #define __CM3_REV 0x0201
 #define __MPU_PRESENT 1
 #define __NVIC_PRIO_BITS 3
 #define __Vendor_SysTickConfig 0
+
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 
 typedef enum IRQn {
     Reset_IRQn = -15,

--- a/product/juno/module/juno_adc/CMakeLists.txt
+++ b/product/juno/module/juno_adc/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_adc.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-sensor)

--- a/product/juno/module/juno_adc/Module.cmake
+++ b/product/juno/module/juno_adc/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-adc")
+
+set(SCP_MODULE_TARGET "module-juno-adc")

--- a/product/juno/module/juno_cdcel937/CMakeLists.txt
+++ b/product/juno/module/juno_cdcel937/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_cdcel937.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-clock)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-i2c)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-juno-hdlcd)

--- a/product/juno/module/juno_cdcel937/Module.cmake
+++ b/product/juno/module/juno_cdcel937/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-cdcel937")
+
+set(SCP_MODULE_TARGET "module-juno-cdcel937")

--- a/product/juno/module/juno_ddr_phy400/CMakeLists.txt
+++ b/product/juno/module/juno_ddr_phy400/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_ddr_phy400.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-juno-dmc400)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-timer)

--- a/product/juno/module/juno_ddr_phy400/Module.cmake
+++ b/product/juno/module/juno_ddr_phy400/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-ddr-phy400")
+
+set(SCP_MODULE_TARGET "module-juno-ddr-phy400")

--- a/product/juno/module/juno_debug/CMakeLists.txt
+++ b/product/juno/module/juno_debug/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_debug.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-debug)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-power-domain)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-timer)

--- a/product/juno/module/juno_debug/Module.cmake
+++ b/product/juno/module/juno_debug/Module.cmake
@@ -1,0 +1,14 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-debug")
+
+set(SCP_MODULE_TARGET "module-juno-debug")
+
+if(SCP_ENABLE_DEBUG_UNIT)
+    list(APPEND SCP_MODULES "juno-debug")
+endif()

--- a/product/juno/module/juno_dmc400/CMakeLists.txt
+++ b/product/juno/module/juno_dmc400/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_dmc400.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-timer)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-power-domain)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-system-power)

--- a/product/juno/module/juno_dmc400/Module.cmake
+++ b/product/juno/module/juno_dmc400/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-dmc400")
+
+set(SCP_MODULE_TARGET "module-juno-dmc400")

--- a/product/juno/module/juno_hdlcd/CMakeLists.txt
+++ b/product/juno/module/juno_hdlcd/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_hdlcd.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-clock)

--- a/product/juno/module/juno_hdlcd/Module.cmake
+++ b/product/juno/module/juno_hdlcd/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-hdlcd")
+
+set(SCP_MODULE_TARGET "module-juno-hdlcd")

--- a/product/juno/module/juno_ppu/CMakeLists.txt
+++ b/product/juno/module/juno_ppu/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_ppu.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-power-domain)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-system-power)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-timer)

--- a/product/juno/module/juno_ppu/Module.cmake
+++ b/product/juno/module/juno_ppu/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-ppu")
+
+set(SCP_MODULE_TARGET "module-juno-ppu")

--- a/product/juno/module/juno_pvt/CMakeLists.txt
+++ b/product/juno/module/juno_pvt/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_pvt.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-power-domain)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-sensor)

--- a/product/juno/module/juno_pvt/Module.cmake
+++ b/product/juno/module/juno_pvt/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-pvt")
+
+set(SCP_MODULE_TARGET "module-juno-pvt")

--- a/product/juno/module/juno_ram/CMakeLists.txt
+++ b/product/juno/module/juno_ram/CMakeLists.txt
@@ -1,0 +1,19 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_ram.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/juno_wdog_ram.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-power-domain)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-system-power)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-timer)

--- a/product/juno/module/juno_ram/Module.cmake
+++ b/product/juno/module/juno_ram/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-ram")
+
+set(SCP_MODULE_TARGET "module-juno-ram")

--- a/product/juno/module/juno_reset_domain/CMakeLists.txt
+++ b/product/juno/module/juno_reset_domain/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_reset_domain.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-reset-domain)

--- a/product/juno/module/juno_reset_domain/Module.cmake
+++ b/product/juno/module/juno_reset_domain/Module.cmake
@@ -1,0 +1,14 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-reset-domain")
+
+set(SCP_MODULE_TARGET "module-juno-reset-domain")
+
+if(SCP_ENABLE_SCMI_RESET)
+    list(APPEND SCP_MODULES "juno-reset-domain")
+endif()

--- a/product/juno/module/juno_rom/CMakeLists.txt
+++ b/product/juno/module/juno_rom/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/juno_wdog_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/juno_debug_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_rom.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-juno-ppu)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-power-domain)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-bootloader)

--- a/product/juno/module/juno_rom/Module.cmake
+++ b/product/juno/module/juno_rom/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-rom")
+
+set(SCP_MODULE_TARGET "module-juno-rom")

--- a/product/juno/module/juno_soc_clock/CMakeLists.txt
+++ b/product/juno/module/juno_soc_clock/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_soc_clock.c")

--- a/product/juno/module/juno_soc_clock/Module.cmake
+++ b/product/juno/module/juno_soc_clock/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-soc-clock")
+
+set(SCP_MODULE_TARGET "module-juno-soc-clock")

--- a/product/juno/module/juno_soc_clock_ram/CMakeLists.txt
+++ b/product/juno/module/juno_soc_clock_ram/CMakeLists.txt
@@ -1,0 +1,19 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_soc_clock_ram.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/juno_soc_clock_ram_pll.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-clock)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-power-domain)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-timer)

--- a/product/juno/module/juno_soc_clock_ram/Module.cmake
+++ b/product/juno/module/juno_soc_clock_ram/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-soc-clock-ram")
+
+set(SCP_MODULE_TARGET "module-juno-soc-clock-ram")

--- a/product/juno/module/juno_system/CMakeLists.txt
+++ b/product/juno/module/juno_system/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_system.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-sds)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-psu)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-juno-xrp7724)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-power-domain)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-scmi)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-system-power)

--- a/product/juno/module/juno_system/Module.cmake
+++ b/product/juno/module/juno_system/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-system")
+
+set(SCP_MODULE_TARGET "module-juno-system")

--- a/product/juno/module/juno_thermal/CMakeLists.txt
+++ b/product/juno/module/juno_thermal/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_thermal.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-power-domain)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-sensor)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-system-power)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-timer)

--- a/product/juno/module/juno_thermal/Module.cmake
+++ b/product/juno/module/juno_thermal/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-thermal")
+
+set(SCP_MODULE_TARGET "module-juno-thermal")

--- a/product/juno/module/juno_xrp7724/CMakeLists.txt
+++ b/product/juno/module/juno_xrp7724/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_juno_xrp7724.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-i2c)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-psu)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-sensor)
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-timer)

--- a/product/juno/module/juno_xrp7724/Module.cmake
+++ b/product/juno/module/juno_xrp7724/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "juno-xrp7724")
+
+set(SCP_MODULE_TARGET "module-juno-xrp7724")

--- a/product/juno/scp_ramfw/Buildoptions.cmake
+++ b/product/juno/scp_ramfw/Buildoptions.cmake
@@ -1,0 +1,19 @@
+cmake_dependent_option(
+    SCP_ENABLE_SCMI_RESET "Enable the scmi reset?"
+    "${SCP_ENABLE_SCMI_RESET_INIT}" "DEFINED SCP_ENABLE_SCMI_RESET_INIT"
+    "${SCP_ENABLE_SCMI_RESET}")
+
+cmake_dependent_option(
+    SCP_ENABLE_FAST_CHANNELS "Enable the SCMI Fast channels?"
+    "${SCP_ENABLE_FAST_CHANNELS_INIT}" "DEFINED SCP_ENABLE_FAST_CHANNELS_INIT"
+    "${SCP_ENABLE_FAST_CHANNELS}")
+
+cmake_dependent_option(
+    SCP_ENABLE_DEBUG_UNIT "Enable the debug support?"
+    "${SCP_ENABLE_DEBUG_UNIT_INIT}" "DEFINED SCP_ENABLE_DEBUG_UNIT_INIT"
+    "${SCP_ENABLE_DEBUG_UNIT}")
+
+cmake_dependent_option(
+    SCP_ENABLE_STATISTICS "Enable the performance statistics?"
+    "${SCP_ENABLE_STATISTICS_INIT}" "DEFINED SCP_ENABLE_STATISTICS_INIT"
+    "${SCP_ENABLE_STATISTICS}")

--- a/product/juno/scp_ramfw/CMakeLists.txt
+++ b/product/juno/scp_ramfw/CMakeLists.txt
@@ -1,0 +1,101 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(juno-bl2)
+
+target_include_directories(
+    juno-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                    "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    juno-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_soc_clock_ram.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dvfs.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_cdcel937.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_hdlcd.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_ddr_phy400.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_dmc400.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_ram.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_ppu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_perf.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_i2c.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_adc.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_xrp7724.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sensor.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_reg_sensor.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mock_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_pvt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_thermal.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mock_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/juno_utils.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/juno_id.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/juno_scmi_clock.c")
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(juno-bl2 PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(juno-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+if(SCP_ENABLE_DEBUG_UNIT)
+    target_sources(
+        juno-bl2 PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_debug.c"
+                         "${CMAKE_CURRENT_SOURCE_DIR}/config_debug.c")
+endif()
+
+if(SCP_ENABLE_SCMI_RESET)
+    target_sources(
+        juno-bl2
+        PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_reset_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_reset_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_reset_domain.c")
+endif()
+
+if(SCP_ENABLE_STATISTICS)
+    target_sources(juno-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_stats.c")
+endif()
+
+if(${SCP_ENABLE_RESOURCE_PERMISSIONS})
+    target_sources(
+        juno-bl2 PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_resource_perms.c")
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(juno-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    juno-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/juno/scp_ramfw/Firmware.cmake
+++ b/product/juno/scp_ramfw/Firmware.cmake
@@ -1,0 +1,103 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "juno-bl2")
+set(SCP_FIRMWARE_TARGET "juno-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_FIRMWARE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_SCMI_NOTIFICATIONS_INIT FALSE)
+
+set(SCP_ENABLE_FAST_CHANNELS_INIT FALSE)
+
+set(SCP_ENABLE_RESOURCE_PERMISSIONS_INIT FALSE)
+
+set(SCP_ENABLE_DEBUG_UNIT_INIT FALSE)
+
+set(SCP_ENABLE_SCMI_RESET_INIT FALSE)
+
+set(SCP_ENABLE_STATISTICS_INIT FALSE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_reset_domain")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_cdcel937")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/juno_rom")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/juno_ppu")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_soc_clock_ram")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/juno_adc")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_soc_clock")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_thermal")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/juno_ram")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/juno_pvt")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_ddr_phy400")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_dmc400")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_debug")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_system")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_xrp7724")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_hdlcd")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "juno-soc-clock-ram")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "juno-cdcel937")
+list(APPEND SCP_MODULES "juno-hdlcd")
+list(APPEND SCP_MODULES "dvfs")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "juno-ddr-phy400")
+list(APPEND SCP_MODULES "juno-dmc400")
+list(APPEND SCP_MODULES "juno-ram")
+list(APPEND SCP_MODULES "juno-ppu")
+list(APPEND SCP_MODULES "juno-system")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "mhu")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "scmi-clock")
+list(APPEND SCP_MODULES "scmi-perf")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "sensor")
+list(APPEND SCP_MODULES "scmi-sensor")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "i2c")
+list(APPEND SCP_MODULES "dw-apb-i2c")
+list(APPEND SCP_MODULES "juno-adc")
+list(APPEND SCP_MODULES "juno-xrp7724")
+list(APPEND SCP_MODULES "reg-sensor")
+list(APPEND SCP_MODULES "psu")
+list(APPEND SCP_MODULES "mock-psu")
+list(APPEND SCP_MODULES "juno-pvt")
+list(APPEND SCP_MODULES "juno-thermal")
+list(APPEND SCP_MODULES "mock-clock")

--- a/product/juno/scp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/juno/scp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/juno/scp_ramfw/Toolchain-GNU.cmake
+++ b/product/juno/scp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/juno/scp_romfw/CMakeLists.txt
+++ b/product/juno/scp_romfw/CMakeLists.txt
@@ -1,0 +1,46 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(juno-bl1)
+
+target_include_directories(
+    juno-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                    "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    juno-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_ppu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_soc_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/juno_utils.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/juno_id.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(juno-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    juno-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/juno/scp_romfw/Firmware.cmake
+++ b/product/juno/scp_romfw/Firmware.cmake
@@ -1,0 +1,39 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "juno-bl1")
+set(SCP_FIRMWARE_TARGET "juno-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_FIRMWARE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+set(SCP_GENERATE_FLAT_BINARY TRUE)
+set(SCP_ARCHITECTURE "armv7-m")
+
+set(SCP_ENABLE_MULTITHREADING FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/juno_rom")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/juno_ppu")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_soc_clock")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "juno-ppu")
+list(APPEND SCP_MODULES "juno-rom")
+list(APPEND SCP_MODULES "juno-soc-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "bootloader")

--- a/product/juno/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/juno/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/juno/scp_romfw/Toolchain-GNU.cmake
+++ b/product/juno/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/juno/scp_romfw_bypass/CMakeLists.txt
+++ b/product/juno/scp_romfw_bypass/CMakeLists.txt
@@ -1,0 +1,47 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(juno-bl1-bypass)
+
+target_compile_definitions(juno-bl1-bypass PUBLIC -DSCP_ROM_BYPASS=1)
+
+target_include_directories(
+    juno-bl1-bypass PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                           "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    juno-bl1-bypass
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_ppu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_juno_soc_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/juno_pll_workaround.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/juno_utils.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/juno_id.c")
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+target_include_directories(
+    juno-bl1-bypass
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    target_link_options(juno-bl1-bypass
+        PUBLIC "LINKER:--wrap=arch_exception_reset")
+endif()

--- a/product/juno/scp_romfw_bypass/Firmware.cmake
+++ b/product/juno/scp_romfw_bypass/Firmware.cmake
@@ -1,0 +1,40 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "juno-bl1-bypass")
+set(SCP_FIRMWARE_TARGET "juno-bl1-bypass")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_FIRMWARE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+
+set(SCP_GENERATE_FLAT_BINARY TRUE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+set(SCP_ENABLE_MULTITHREADING FALSE)
+set(SCP_ENABLE_NOTIFICATIONS TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/juno_rom")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/juno_ppu")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/juno_soc_clock")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "juno-ppu")
+list(APPEND SCP_MODULES "juno-rom")
+list(APPEND SCP_MODULES "juno-soc-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "bootloader")

--- a/product/juno/scp_romfw_bypass/Toolchain-ArmClang.cmake
+++ b/product/juno/scp_romfw_bypass/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/juno/scp_romfw_bypass/Toolchain-GNU.cmake
+++ b/product/juno/scp_romfw_bypass/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")


### PR DESCRIPTION
This change adds CMake build system support for product/juno

Please note that firmware targets do not use libRTX_CM3.a
or RTX_CM3.lib, instead in CMake build, the library
is built using sources.

Change-Id: Iefcad29d75fc240237295295f224278254cdc9fd
Signed-off-by: Girish Pathak <girish.pathak@arm.com>