### PR TITLE
cmake: product/rdv1

### DIFF
--- a/product/rdv1/include/fmw_cmsis.h
+++ b/product/rdv1/include/fmw_cmsis.h
@@ -8,6 +8,8 @@
 #ifndef FMW_CMSIS_H
 #define FMW_CMSIS_H
 
+#include <stdint.h>
+
 #define __CHECK_DEVICE_DEFINES
 #define __CM7_REV              0x0000U
 #define __FPU_PRESENT          0U
@@ -18,6 +20,7 @@
 #define __NVIC_PRIO_BITS       3U
 #define __Vendor_SysTickConfig 0U
 
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 typedef enum IRQn {
     Reset_IRQn = -15,
     NonMaskableInt_IRQn = -14,

--- a/product/rdv1/mcp_romfw/CMakeLists.txt
+++ b/product/rdv1/mcp_romfw/CMakeLists.txt
@@ -1,0 +1,38 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdv1-mcp-bl1)
+
+target_include_directories(
+    rdv1-mcp-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                        "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdv1-mcp-bl1
+    PRIVATE "config_clock.c" "config_bootloader.c"
+            "config_pl011.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdv1-mcp-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(rdv1-mcp-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdv1/mcp_romfw/Firmware.cmake
+++ b/product/rdv1/mcp_romfw/Firmware.cmake
@@ -1,0 +1,31 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "rdv1-mcp-bl1")
+set(SCP_FIRMWARE_TARGET "rdv1-mcp-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_FIRMWARE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+set(SCP_GENERATE_FLAT_BINARY TRUE)
+set(SCP_ARCHITECTURE "armv7-m")
+
+set(SCP_ENABLE_MULTITHREADING FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "bootloader")
+list(APPEND SCP_MODULES "isys-rom")

--- a/product/rdv1/mcp_romfw/Toolchain-ArmClang.cmake
+++ b/product/rdv1/mcp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdv1/mcp_romfw/Toolchain-GNU.cmake
+++ b/product/rdv1/mcp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/rdv1/module/platform_system/CMakeLists.txt
+++ b/product/rdv1/module/platform_system/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_platform_system.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-sds module-clock
+    module-power-domain module-ppu-v1 module-scmi module-system-power)

--- a/product/rdv1/module/platform_system/Module.cmake
+++ b/product/rdv1/module/platform_system/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "platform-system")
+
+set(SCP_MODULE_TARGET "module-platform-system")

--- a/product/rdv1/scp_ramfw/CMakeLists.txt
+++ b/product/rdv1/scp_ramfw/CMakeLists.txt
@@ -1,0 +1,63 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdv1-bl2)
+
+target_include_directories(
+    rdv1-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                        "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdv1-bl2
+    PRIVATE "config_system_power.c"
+            "rtx_config.c"
+            "config_armv7m_mpu.c"
+            "config_power_domain.c"
+            "config_ppu_v1.c"
+            "config_mhu2.c"
+            "config_smt.c"
+            "config_scmi.c"
+            "config_sds.c"
+            "config_timer.c"
+            "config_gtimer.c"
+            "config_cmn650.c"
+            "config_scmi_system_power.c"
+            "config_system_pll.c"
+            "config_pik_clock.c"
+            "config_css_clock.c"
+            "config_clock.c"
+            "config_apcontext.c"
+            "config_scmi_power_domain.c"
+            "../src/config_system_info.c"
+            "../src/config_pl011.c"
+            "../src/config_sid.c")
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(rdv1-bl2 PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(rdv1-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdv1-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(rdv1-bl2
+   PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdv1/scp_ramfw/Firmware.cmake
+++ b/product/rdv1/scp_ramfw/Firmware.cmake
@@ -1,0 +1,55 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "rdv1-bl2")
+set(SCP_FIRMWARE_TARGET "rdv1-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_FIRMWARE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+set(SCP_GENERATE_FLAT_BINARY TRUE)
+set(SCP_ARCHITECTURE "armv7-m")
+
+set(SCP_ENABLE_MULTITHREADING TRUE)
+set(SCP_ENABLE_NOTIFICATIONS TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/platform_system")
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../../../module/cmn650")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "armv7m-mpu")
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "cmn650")
+list(APPEND SCP_MODULES "apcontext")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "mhu2")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "system-pll")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "platform-system")

--- a/product/rdv1/scp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/rdv1/scp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdv1/scp_ramfw/Toolchain-GNU.cmake
+++ b/product/rdv1/scp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/rdv1/scp_romfw/CMakeLists.txt
+++ b/product/rdv1/scp_romfw/CMakeLists.txt
@@ -1,0 +1,41 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdv1-bl1)
+
+target_include_directories(
+    rdv1-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                        "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdv1-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdv1-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(rdv1-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdv1/scp_romfw/Firmware.cmake
+++ b/product/rdv1/scp_romfw/Firmware.cmake
@@ -1,0 +1,34 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "rdv1-bl1")
+set(SCP_FIRMWARE_TARGET "rdv1-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_FIRMWARE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+set(SCP_GENERATE_FLAT_BINARY TRUE)
+set(SCP_ARCHITECTURE "armv7-m")
+
+set(SCP_ENABLE_MULTITHREADING FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "bootloader")
+list(APPEND SCP_MODULES "isys-rom")

--- a/product/rdv1/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/rdv1/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdv1/scp_romfw/Toolchain-GNU.cmake
+++ b/product/rdv1/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")


### PR DESCRIPTION
This change adds CMake build support for rdv1 platform.

Please note that firmware targets do not use libRTX_CM3.a
or RTX_CM3.lib, instead in CMake build, the library
is built using sources.

Change-Id: If5528341e9380a5c0e53b8d11ce905089ddf6bd4
Signed-off-by: Girish Pathak <girish.pathak@arm.com>