### PR TITLE
cmake: product/synquacer

### DIFF
--- a/product/synquacer/include/fmw_cmsis.h
+++ b/product/synquacer/include/fmw_cmsis.h
@@ -8,11 +8,15 @@
 #ifndef FMW_CMSIS_H
 #define FMW_CMSIS_H
 
+#include <stdint.h>
+
 #define __CHECK_DEVICE_DEFINES
 #define __CM3_REV 0x0201
 #define __MPU_PRESENT 1
 #define __NVIC_PRIO_BITS 3
 #define __Vendor_SysTickConfig 0
+
+extern uint32_t SystemCoreClock;
 
 typedef enum IRQn {
     Reset_IRQn = -15,

--- a/product/synquacer/module/ccn512/CMakeLists.txt
+++ b/product/synquacer/module/ccn512/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_ccn512.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-ppu-v0-synquacer
+                                                   module-synquacer-memc)

--- a/product/synquacer/module/ccn512/Module.cmake
+++ b/product/synquacer/module/ccn512/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "ccn512")
+
+set(SCP_MODULE_TARGET "module-ccn512")

--- a/product/synquacer/module/f_i2c/CMakeLists.txt
+++ b/product/synquacer/module/f_i2c/CMakeLists.txt
@@ -1,0 +1,22 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_f_i2c.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/i2c_api.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/i2c_reg_access.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/i2c_depend.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/i2c_driver.c")
+
+target_link_libraries(
+    ${SCP_MODULE_TARGET} PRIVATE module-ppu-v0-synquacer
+                                 module-synquacer-system module-power-domain)

--- a/product/synquacer/module/f_i2c/Module.cmake
+++ b/product/synquacer/module/f_i2c/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "f-i2c")
+
+set(SCP_MODULE_TARGET "module-f-i2c")

--- a/product/synquacer/module/f_uart3/CMakeLists.txt
+++ b/product/synquacer/module/f_uart3/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_f_uart3.c")

--- a/product/synquacer/module/f_uart3/Module.cmake
+++ b/product/synquacer/module/f_uart3/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "f-uart3")
+
+set(SCP_MODULE_TARGET "module-f-uart3")

--- a/product/synquacer/module/hsspi/CMakeLists.txt
+++ b/product/synquacer/module/hsspi/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(
+    ${SCP_MODULE_TARGET}
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+           "${CMAKE_SOURCE_DIR}/contrib/cmsis/git/CMSIS/RTOS2/Include"
+           "${CMAKE_SOURCE_DIR}/contrib/cmsis/git/CMSIS/RTOS2/RTX/Include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/hsspi_api.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/hsspi_driver.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_hsspi.c")
+
+target_link_libraries(
+    ${SCP_MODULE_TARGET} PRIVATE module-ppu-v0-synquacer
+                                 module-synquacer-system module-power-domain)

--- a/product/synquacer/module/hsspi/Module.cmake
+++ b/product/synquacer/module/hsspi/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "hsspi")
+
+set(SCP_MODULE_TARGET "module-hsspi")

--- a/product/synquacer/module/ppu_v0_synquacer/CMakeLists.txt
+++ b/product/synquacer/module/ppu_v0_synquacer/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_ppu_v0.c"
+                                 "${CMAKE_CURRENT_SOURCE_DIR}/src/ppu_v0.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-power-domain
+                                                   module-system-power)

--- a/product/synquacer/module/ppu_v0_synquacer/Module.cmake
+++ b/product/synquacer/module/ppu_v0_synquacer/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "ppu-v0-synquacer")
+
+set(SCP_MODULE_TARGET "module-ppu-v0-synquacer")

--- a/product/synquacer/module/scmi_vendor_ext/CMakeLists.txt
+++ b/product/synquacer/module/scmi_vendor_ext/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(
+    ${SCP_MODULE_TARGET}
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+           "${CMAKE_SOURCE_DIR}/contrib/cmsis/git/CMSIS/RTOS2/Include"
+           "${CMAKE_SOURCE_DIR}/contrib/cmsis/git/CMSIS/RTOS2/RTX/Include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_scmi_vendor_ext.c")
+
+target_link_libraries(
+    ${SCP_MODULE_TARGET}
+    PRIVATE module-synquacer-memc module-ppu-v0-synquacer
+            module-synquacer-system module-power-domain module-scmi)

--- a/product/synquacer/module/scmi_vendor_ext/Module.cmake
+++ b/product/synquacer/module/scmi_vendor_ext/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "scmi-vendor-ext")
+
+set(SCP_MODULE_TARGET "module-scmi-vendor-ext")

--- a/product/synquacer/module/synquacer_memc/CMakeLists.txt
+++ b/product/synquacer/module/synquacer_memc/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(
+    ${SCP_MODULE_TARGET}
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+           "${CMAKE_SOURCE_DIR}/contrib/cmsis/git/CMSIS/RTOS2/Include"
+           "${CMAKE_SOURCE_DIR}/contrib/cmsis/git/CMSIS/RTOS2/RTX/Include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/ddr_init.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/synquacer_ddr.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_synquacer_memc.c")
+
+target_link_libraries(
+    ${SCP_MODULE_TARGET}
+    PRIVATE module-ppu-v0-synquacer module-synquacer-system module-power-domain
+            module-scmi module-f-i2c)

--- a/product/synquacer/module/synquacer_memc/Module.cmake
+++ b/product/synquacer/module/synquacer_memc/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "synquacer-memc")
+
+set(SCP_MODULE_TARGET "module-synquacer-memc")

--- a/product/synquacer/module/synquacer_pik_clock/CMakeLists.txt
+++ b/product/synquacer/module/synquacer_pik_clock/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_synquacer_pik_clock.c")
+
+target_link_libraries(
+    ${SCP_MODULE_TARGET} PRIVATE module-clock module-power-domain
+                                 module-ppu-v0-synquacer)

--- a/product/synquacer/module/synquacer_pik_clock/Module.cmake
+++ b/product/synquacer/module/synquacer_pik_clock/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "synquacer-pik-clock")
+
+set(SCP_MODULE_TARGET "module-synquacer-pik-clock")

--- a/product/synquacer/module/synquacer_rom/CMakeLists.txt
+++ b/product/synquacer/module/synquacer_rom/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_synquacer_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/synquacer_init.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-ppu-v0-synquacer)

--- a/product/synquacer/module/synquacer_rom/Module.cmake
+++ b/product/synquacer/module/synquacer_rom/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "synquacer-rom")
+
+set(SCP_MODULE_TARGET "module-synquacer-rom")

--- a/product/synquacer/module/synquacer_system/CMakeLists.txt
+++ b/product/synquacer/module/synquacer_system/CMakeLists.txt
@@ -1,0 +1,35 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(
+    ${SCP_MODULE_TARGET}
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+           "${CMAKE_SOURCE_DIR}/contrib/cmsis/git/CMSIS/RTOS2/Include"
+           "${CMAKE_SOURCE_DIR}/contrib/cmsis/git/CMSIS/RTOS2/RTX/Include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/nic400.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/mmu500.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_synquacer_system.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/synquacer_main.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/thermal_sensor.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/transaction_sw.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/synquacer_pd_manage.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/sysoc.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/load_secure_fw.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/boot_ctl.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/smmu_config.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/sysdef_option.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/gpio.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/pmu_driver.c")
+
+target_link_libraries(
+    ${SCP_MODULE_TARGET}
+    PRIVATE module-ppu-v0-synquacer module-power-domain module-system-power
+            module-f-i2c module-hsspi module-synquacer-memc)

--- a/product/synquacer/module/synquacer_system/Module.cmake
+++ b/product/synquacer/module/synquacer_system/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "synquacer-system")
+
+set(SCP_MODULE_TARGET "module-synquacer-system")

--- a/product/synquacer/scp_ramfw/CMakeLists.txt
+++ b/product/synquacer/scp_ramfw/CMakeLists.txt
@@ -1,0 +1,65 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(synquacer-bl2)
+
+# cmake-lint: disable=E1122
+
+target_include_directories(
+    synquacer-bl2
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+           "${CMAKE_CURRENT_SOURCE_DIR}"
+           "${CMAKE_SOURCE_DIR}/contrib/cmsis/git/CMSIS/RTOS2/RTX/Include1")
+
+target_sources(
+    synquacer-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_armv7m_mpu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ccn512.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_f_i2c.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_hsspi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_f_uart3.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v0_synquacer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_apcore.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_synquacer_memc.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c")
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(synquacer-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(synquacer-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(synquacer-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    synquacer-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/synquacer/scp_ramfw/Firmware.cmake
+++ b/product/synquacer/scp_ramfw/Firmware.cmake
@@ -1,0 +1,69 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "synquacer-bl2")
+
+set(SCP_FIRMWARE_TARGET "synquacer-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/scmi_vendor_ext")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/synquacer_memc")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/f_i2c")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/f_uart3")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/hsspi")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/ccn512")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/ppu_v0_synquacer")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/synquacer_system")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "armv7m-mpu")
+list(APPEND SCP_MODULES "f-uart3")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "ppu-v0-synquacer")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "synquacer-system")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "ccn512")
+list(APPEND SCP_MODULES "f-i2c")
+list(APPEND SCP_MODULES "hsspi")
+list(APPEND SCP_MODULES "synquacer-memc")
+list(APPEND SCP_MODULES "mhu")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "scmi-apcore")
+list(APPEND SCP_MODULES "scmi-vendor-ext")
+
+add_compile_definitions(PUBLIC HAS_RTOS PCIE_FILTER_BUS0_TYPE0_CONFIG
+                        ENABLE_OPTEE SET_PCIE_NON_SECURE)

--- a/product/synquacer/scp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/synquacer/scp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/synquacer/scp_ramfw/Toolchain-GNU.cmake
+++ b/product/synquacer/scp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/synquacer/scp_romfw/CMakeLists.txt
+++ b/product/synquacer/scp_romfw/CMakeLists.txt
@@ -1,0 +1,44 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(synquacer-bl1)
+
+target_include_directories(
+    synquacer-bl1
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+           "${CMAKE_CURRENT_SOURCE_DIR}"
+           "${CMAKE_SOURCE_DIR}/contrib/cmsis/git/CMSIS/Core/Include")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    synquacer-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_armv7m_mpu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_synquacer_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_synquacer_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(synquacer-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    synquacer-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/synquacer/scp_romfw/Firmware.cmake
+++ b/product/synquacer/scp_romfw/Firmware.cmake
@@ -1,0 +1,46 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "synquacer-bl1")
+
+set(SCP_FIRMWARE_TARGET "synquacer-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/synquacer_pik_clock")
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/ppu_v0_synquacer")
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/synquacer_rom")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "armv7m-mpu")
+list(APPEND SCP_MODULES "synquacer-rom")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "synquacer-pik-clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")

--- a/product/synquacer/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/synquacer/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/synquacer/scp_romfw/Toolchain-GNU.cmake
+++ b/product/synquacer/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")


### PR DESCRIPTION
This change adds CMake build support for product/synquacer

Please note that firmware targets do not use libRTX_CM3.a
or RTX_CM3.lib, instead in CMake build, the library
is built using sources.

Change-Id: I886dd947c8d84d4ffb4d0a0f4c84defd4224d48b
Signed-off-by: Girish Pathak <girish.pathak@arm.com>