### PR TITLE
Cmake arm platforms v1

### DIFF
--- a/product/morello/include/fmw_cmsis_mcp.h
+++ b/product/morello/include/fmw_cmsis_mcp.h
@@ -8,6 +8,8 @@
 #ifndef FMW_CMSIS_MCP_H
 #define FMW_CMSIS_MCP_H
 
+#include <stdint.h>
+
 #define __CHECK_DEVICE_DEFINES
 #define __CM7_REV 0x0000U
 #define __FPU_PRESENT 0U
@@ -19,6 +21,8 @@
 #define __Vendor_SysTickConfig 0U
 
 #define MCP_WDOG_IRQ FWK_INTERRUPT_NMI /* MCP Watchdog (SP805) */
+
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 
 typedef enum IRQn {
     Reset_IRQn = -15,

--- a/product/morello/include/fmw_cmsis_scp.h
+++ b/product/morello/include/fmw_cmsis_scp.h
@@ -8,6 +8,8 @@
 #ifndef FMW_CMSIS_SCP_H
 #define FMW_CMSIS_SCP_H
 
+#include <stdint.h>
+
 #define __CHECK_DEVICE_DEFINES
 #define __CM7_REV 0x0000U
 #define __FPU_PRESENT 0U
@@ -19,6 +21,8 @@
 #define __Vendor_SysTickConfig 0U
 
 #define SCP_WDOG_IRQ FWK_INTERRUPT_NMI /* SCP Watchdog (SP805) */
+
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 
 typedef enum IRQn {
     Reset_IRQn = -15,

--- a/product/morello/mcp_ramfw_fvp/CMakeLists.txt
+++ b/product/morello/mcp_ramfw_fvp/CMakeLists.txt
@@ -1,0 +1,51 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(morello-fvp-mcp-bl2)
+
+target_include_directories(
+    morello-fvp-mcp-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                               "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    morello-fvp-mcp-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_armv7m_mpu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_agent.c")
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(morello-fvp-mcp-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(morello-fvp-mcp-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(morello-fvp-mcp-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    morello-fvp-mcp-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/morello/mcp_ramfw_fvp/Firmware.cmake
+++ b/product/morello/mcp_ramfw_fvp/Firmware.cmake
@@ -1,0 +1,40 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "morello-fvp-mcp-bl2")
+set(SCP_FIRMWARE_TARGET "morello-fvp-mcp-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_FIRMWARE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+set(SCP_ENABLE_MULTITHREADING_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/morello_mcp_system")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/morello_smt")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/morello_mhu")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/scmi_agent")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "armv7m-mpu")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "morello-smt")
+list(APPEND SCP_MODULES "morello-mhu")
+list(APPEND SCP_MODULES "scmi-agent")
+list(APPEND SCP_MODULES "morello-mcp-system")

--- a/product/morello/mcp_ramfw_fvp/Toolchain-ArmClang.cmake
+++ b/product/morello/mcp_ramfw_fvp/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/morello/mcp_ramfw_fvp/Toolchain-GNU.cmake
+++ b/product/morello/mcp_ramfw_fvp/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/morello/mcp_romfw/CMakeLists.txt
+++ b/product/morello/mcp_romfw/CMakeLists.txt
@@ -1,0 +1,40 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(morello-mcp-bl1)
+
+target_include_directories(
+    morello-mcp-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                           "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    morello-mcp-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_morello_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(morello-mcp-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    morello-mcp-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/morello/mcp_romfw/Firmware.cmake
+++ b/product/morello/mcp_romfw/Firmware.cmake
@@ -1,0 +1,36 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "morello-mcp-bl1")
+
+set(SCP_FIRMWARE_TARGET "morello-mcp-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/morello_rom")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_SOURCE_DIR}/module/fip")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "fip")
+list(APPEND SCP_MODULES "morello-rom")
+list(APPEND SCP_MODULES "clock")

--- a/product/morello/mcp_romfw/Toolchain-ArmClang.cmake
+++ b/product/morello/mcp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/morello/mcp_romfw/Toolchain-GNU.cmake
+++ b/product/morello/mcp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/morello/module/cmn_skeena/CMakeLists.txt
+++ b/product/morello/module/cmn_skeena/CMakeLists.txt
@@ -1,0 +1,22 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(
+    ${SCP_MODULE_TARGET}
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_cmn_skeena.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/cmn_skeena.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/cmn_skeena_ccix.c")
+
+target_link_libraries(
+    ${SCP_MODULE_TARGET} PRIVATE module-timer module-clock module-ppu-v1
+                                 module-system-info)

--- a/product/morello/module/cmn_skeena/Module.cmake
+++ b/product/morello/module/cmn_skeena/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "cmn-skeena")
+
+set(SCP_MODULE_TARGET "module-cmn-skeena")

--- a/product/morello/module/dmc_bing/CMakeLists.txt
+++ b/product/morello/module/dmc_bing/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_dmc_bing.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-clock)

--- a/product/morello/module/dmc_bing/Module.cmake
+++ b/product/morello/module/dmc_bing/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "dmc-bing")
+
+set(SCP_MODULE_TARGET "module-dmc-bing")

--- a/product/morello/module/morello_mcp_system/CMakeLists.txt
+++ b/product/morello/module/morello_mcp_system/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET} PRIVATE "src/mod_morello_mcp_system.c")
+
+target_link_libraries(
+    ${SCP_MODULE_TARGET} PRIVATE module-clock module-pik-clock
+                                 module-power-domain module-scmi-agent)

--- a/product/morello/module/morello_mcp_system/Module.cmake
+++ b/product/morello/module/morello_mcp_system/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "morello-mcp-system")
+
+set(SCP_MODULE_TARGET "module-morello-mcp-system")

--- a/product/morello/module/morello_mhu/CMakeLists.txt
+++ b/product/morello/module/morello_mhu/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_include_directories(
+    ${SCP_MODULE_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include/internal")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_mhu.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-morello-smt)

--- a/product/morello/module/morello_mhu/Module.cmake
+++ b/product/morello/module/morello_mhu/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "morello-mhu")
+
+set(SCP_MODULE_TARGET "module-morello-mhu")

--- a/product/morello/module/morello_pll/CMakeLists.txt
+++ b/product/morello/module/morello_pll/CMakeLists.txt
@@ -1,0 +1,19 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_include_directories(
+    ${SCP_MODULE_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include/internal")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_morello_pll.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-clock
+                                                   module-power-domain)

--- a/product/morello/module/morello_pll/Module.cmake
+++ b/product/morello/module/morello_pll/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "morello-pll")
+
+set(SCP_MODULE_TARGET "module-morello-pll")

--- a/product/morello/module/morello_rom/CMakeLists.txt
+++ b/product/morello/module/morello_rom/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_morello_rom.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-fip)

--- a/product/morello/module/morello_rom/Module.cmake
+++ b/product/morello/module/morello_rom/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "morello-rom")
+
+set(SCP_MODULE_TARGET "module-morello-rom")

--- a/product/morello/module/morello_smt/CMakeLists.txt
+++ b/product/morello/module/morello_smt/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_smt.c")

--- a/product/morello/module/morello_smt/Module.cmake
+++ b/product/morello/module/morello_smt/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "morello-smt")
+
+set(SCP_MODULE_TARGET "module-morello-smt")

--- a/product/morello/module/morello_system/CMakeLists.txt
+++ b/product/morello/module/morello_system/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_morello_system.c")
+
+target_link_libraries(
+    ${SCP_MODULE_TARGET}
+    PRIVATE module-sds
+            module-clock
+            module-fip
+            module-power-domain
+            module-ppu-v1
+            module-scmi
+            module-system-power)

--- a/product/morello/module/morello_system/Module.cmake
+++ b/product/morello/module/morello_system/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "morello-system")
+
+set(SCP_MODULE_TARGET "module-morello-system")

--- a/product/morello/module/scmi_agent/CMakeLists.txt
+++ b/product/morello/module/scmi_agent/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_scmi_agent.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-morello-smt)

--- a/product/morello/module/scmi_agent/Module.cmake
+++ b/product/morello/module/scmi_agent/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "scmi-agent")
+
+set(SCP_MODULE_TARGET "module-scmi-agent")

--- a/product/morello/module/scmi_management/CMakeLists.txt
+++ b/product/morello/module/scmi_management/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(
+    ${SCP_MODULE_TARGET}
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    PUBLIC "${CMAKE_SOURCE_DIR}/module/scmi/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_scmi_management.c")

--- a/product/morello/module/scmi_management/Module.cmake
+++ b/product/morello/module/scmi_management/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "scmi-management")
+
+set(SCP_MODULE_TARGET "module-scmi-management")

--- a/product/morello/scp_ramfw_fvp/CMakeLists.txt
+++ b/product/morello/scp_ramfw_fvp/CMakeLists.txt
@@ -1,0 +1,73 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(morello-fvp-bl2)
+
+target_include_directories(
+    morello-fvp-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                               "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    morello-fvp-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_armv7m_mpu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ssc.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_info.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v0.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dmc_bing.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_cmn_skeena.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_management.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_morello_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mock_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dvfs.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_perf.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_apcontext.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_resource_perms.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/morello_core.c")
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(morello-fvp-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(morello-fvp-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(morello-fvp-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    morello-fvp-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/morello/scp_ramfw_fvp/Firmware.cmake
+++ b/product/morello/scp_ramfw_fvp/Firmware.cmake
@@ -1,0 +1,74 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "morello-fvp-bl2")
+
+set(SCP_FIRMWARE_TARGET "morello-fvp-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+set(SCP_ENABLE_MULTITHREADING_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../../../module/fip")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/morello_pll")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/morello_system")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/dmc_bing")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/scmi_management")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/cmn_skeena")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "cmn-skeena")
+list(APPEND SCP_MODULES "apcontext")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "ppu-v0")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "morello-pll")
+list(APPEND SCP_MODULES "dmc-bing")
+list(APPEND SCP_MODULES "mhu")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "scmi-management")
+list(APPEND SCP_MODULES "fip")
+list(APPEND SCP_MODULES "ssc")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "psu")
+list(APPEND SCP_MODULES "mock-psu")
+list(APPEND SCP_MODULES "dvfs")
+list(APPEND SCP_MODULES "scmi-perf")
+list(APPEND SCP_MODULES "morello-system")
+list(APPEND SCP_MODULES "resource-perms")

--- a/product/morello/scp_ramfw_fvp/Toolchain-ArmClang.cmake
+++ b/product/morello/scp_ramfw_fvp/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/morello/scp_ramfw_fvp/Toolchain-GNU.cmake
+++ b/product/morello/scp_ramfw_fvp/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/morello/scp_romfw/CMakeLists.txt
+++ b/product/morello/scp_romfw/CMakeLists.txt
@@ -1,0 +1,40 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(morello-bl1)
+
+target_include_directories(
+    morello-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                           "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    morello-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_morello_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(morello-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    morello-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/morello/scp_romfw/Firmware.cmake
+++ b/product/morello/scp_romfw/Firmware.cmake
@@ -1,0 +1,36 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "morello-bl1")
+
+set(SCP_FIRMWARE_TARGET "morello-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/morello_rom")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_SOURCE_DIR}/module/fip")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "fip")
+list(APPEND SCP_MODULES "morello-rom")
+list(APPEND SCP_MODULES "clock")

--- a/product/morello/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/morello/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/morello/scp_romfw/Toolchain-GNU.cmake
+++ b/product/morello/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/n1sdp/include/fmw_cmsis_mcp.h
+++ b/product/n1sdp/include/fmw_cmsis_mcp.h
@@ -8,6 +8,8 @@
 #ifndef FMW_CMSIS_MCP_H
 #define FMW_CMSIS_MCP_H
 
+#include <stdint.h>
+
 #define __CHECK_DEVICE_DEFINES
 #define __CM7_REV 0x0000U
 #define __FPU_PRESENT 0U
@@ -18,6 +20,7 @@
 #define __NVIC_PRIO_BITS 3U
 #define __Vendor_SysTickConfig 0U
 
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 typedef enum IRQn {
     Reset_IRQn = -15,
     NonMaskableInt_IRQn = -14,

--- a/product/n1sdp/include/fmw_cmsis_scp.h
+++ b/product/n1sdp/include/fmw_cmsis_scp.h
@@ -8,6 +8,7 @@
 #ifndef FMW_CMSIS_SCP_H
 #define FMW_CMSIS_SCP_H
 
+#include <stdint.h>
 
 #define __CHECK_DEVICE_DEFINES
 #define __CM7_REV 0x0000U
@@ -18,6 +19,8 @@
 #define __DTCM_PRESENT 0U
 #define __NVIC_PRIO_BITS 3U
 #define __Vendor_SysTickConfig 0U
+
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 
 typedef enum IRQn {
     Reset_IRQn = -15,

--- a/product/n1sdp/mcp_ramfw/CMakeLists.txt
+++ b/product/n1sdp/mcp_ramfw/CMakeLists.txt
@@ -1,0 +1,50 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(n1sdp-mcp-bl2)
+
+target_include_directories(
+    n1sdp-mcp-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                     "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    n1sdp-mcp-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_armv7m_mpu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_agent.c")
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(n1sdp-mcp-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(n1sdp-mcp-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(n1sdp-mcp-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(n1sdp-mcp-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/n1sdp/mcp_ramfw/Firmware.cmake
+++ b/product/n1sdp/mcp_ramfw/Firmware.cmake
@@ -1,0 +1,47 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "n1sdp-mcp-bl2")
+
+set(SCP_FIRMWARE_TARGET "n1sdp-mcp-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+set(SCP_FIRMWARE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_smt")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_mhu")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/scmi_agent")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_mcp_system")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "armv7m-mpu")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "n1sdp-mhu")
+list(APPEND SCP_MODULES "n1sdp-smt")
+list(APPEND SCP_MODULES "scmi-agent")
+list(APPEND SCP_MODULES "n1sdp-mcp-system")

--- a/product/n1sdp/mcp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/n1sdp/mcp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/n1sdp/mcp_ramfw/Toolchain-GNU.cmake
+++ b/product/n1sdp/mcp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/n1sdp/mcp_romfw/CMakeLists.txt
+++ b/product/n1sdp/mcp_romfw/CMakeLists.txt
@@ -1,0 +1,39 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(n1sdp-mcp-bl1)
+
+target_include_directories(
+    n1sdp-mcp-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                     "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    n1sdp-mcp-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_n1sdp_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(n1sdp-mcp-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(n1sdp-mcp-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/n1sdp/mcp_romfw/Firmware.cmake
+++ b/product/n1sdp/mcp_romfw/Firmware.cmake
@@ -1,0 +1,38 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "n1sdp-mpc-bl1")
+
+set(SCP_FIRMWARE_TARGET "n1sdp-mcp-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_FIRMWARE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_rom")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_SOURCE_DIR}/module/fip")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "fip")
+list(APPEND SCP_MODULES "n1sdp-rom")
+list(APPEND SCP_MODULES "clock")

--- a/product/n1sdp/mcp_romfw/Toolchain-ArmClang.cmake
+++ b/product/n1sdp/mcp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/n1sdp/mcp_romfw/Toolchain-GNU.cmake
+++ b/product/n1sdp/mcp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/n1sdp/module/n1sdp_c2c/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_c2c/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_c2c_i2c.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-power-domain module-n1sdp-scp2pcc module-clock module-cmn600
+            module-n1sdp-dmc620 module-n1sdp-i2c module-n1sdp-pcie
+            module-n1sdp-timer-sync module-timer)

--- a/product/n1sdp/module/n1sdp_c2c/Module.cmake
+++ b/product/n1sdp/module/n1sdp_c2c/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-c2c")
+
+set(SCP_MODULE_TARGET "module-n1sdp-c2c")

--- a/product/n1sdp/module/n1sdp_ddr_phy/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_ddr_phy/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                           PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/ddr_phy_values_1333.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/ddr_phy_values_800.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_ddr_phy.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/ddr_phy_values_1200.c"
+)
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-n1sdp-dmc620)

--- a/product/n1sdp/module/n1sdp_ddr_phy/Module.cmake
+++ b/product/n1sdp/module/n1sdp_ddr_phy/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-ddr-phy")
+
+set(SCP_MODULE_TARGET "module-n1sdp-ddr-phy")

--- a/product/n1sdp/module/n1sdp_dmc620/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_dmc620/CMakeLists.txt
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_dmc620.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/dimm_spd.c"
+)
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-n1sdp-i2c module-clock module-timer)

--- a/product/n1sdp/module/n1sdp_dmc620/Module.cmake
+++ b/product/n1sdp/module/n1sdp_dmc620/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-dmc620")
+
+set(SCP_MODULE_TARGET "module-n1sdp-dmc620")

--- a/product/n1sdp/module/n1sdp_dmc620/src/dimm_spd.c
+++ b/product/n1sdp/module/n1sdp_dmc620/src/dimm_spd.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <dimm_spd.h>
+#include "dimm_spd.h"
 
 #include <mod_n1sdp_dmc620.h>
 #include <mod_n1sdp_i2c.h>

--- a/product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c
+++ b/product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c
@@ -8,10 +8,9 @@
  *     N1SDP DMC-620 driver
  */
 
+#include "dimm_spd.h"
 #include "n1sdp_pik_system.h"
 #include "n1sdp_scp_pik.h"
-
-#include <dimm_spd.h>
 
 #include <mod_clock.h>
 #include <mod_n1sdp_dmc620.h>

--- a/product/n1sdp/module/n1sdp_i2c/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_i2c/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_i2c.c")

--- a/product/n1sdp/module/n1sdp_i2c/Module.cmake
+++ b/product/n1sdp/module/n1sdp_i2c/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-i2c")
+
+set(SCP_MODULE_TARGET "module-n1sdp-i2c")

--- a/product/n1sdp/module/n1sdp_mcp_system/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_mcp_system/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_mcp_system.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-clock module-pik-clock module-power-domain module-scmi-agent)

--- a/product/n1sdp/module/n1sdp_mcp_system/Module.cmake
+++ b/product/n1sdp/module/n1sdp_mcp_system/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-mcp-system")
+
+set(SCP_MODULE_TARGET "module-n1sdp-mcp-system")

--- a/product/n1sdp/module/n1sdp_mhu/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_mhu/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_mhu.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-n1sdp-smt)

--- a/product/n1sdp/module/n1sdp_mhu/Module.cmake
+++ b/product/n1sdp/module/n1sdp_mhu/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-mhu")
+
+set(SCP_MODULE_TARGET "module-n1sdp-mhu")

--- a/product/n1sdp/module/n1sdp_pcie/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_pcie/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/pcie_enumeration.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/n1sdp_pcie.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_pcie.c"
+)
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-timer module-clock module-n1sdp-c2c module-power-domain)

--- a/product/n1sdp/module/n1sdp_pcie/Module.cmake
+++ b/product/n1sdp/module/n1sdp_pcie/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-pcie")
+
+set(SCP_MODULE_TARGET "module-n1sdp-pcie")

--- a/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
+++ b/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
@@ -7,10 +7,9 @@
 
 #include "config_clock.h"
 #include "n1sdp_core.h"
+#include "n1sdp_pcie.h"
 #include "n1sdp_scc_reg.h"
 #include "n1sdp_scp_pik.h"
-
-#include <n1sdp_pcie.h>
 
 #include <internal/pcie_ctrl_apb_reg.h>
 

--- a/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.c
+++ b/product/n1sdp/module/n1sdp_pcie/src/n1sdp_pcie.c
@@ -5,10 +5,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "n1sdp_pcie.h"
 #include "n1sdp_scc_reg.h"
 #include "n1sdp_scp_pik.h"
-
-#include <n1sdp_pcie.h>
 
 #include <internal/pcie_ctrl_apb_reg.h>
 

--- a/product/n1sdp/module/n1sdp_pcie/src/pcie_enumeration.c
+++ b/product/n1sdp/module/n1sdp_pcie/src/pcie_enumeration.c
@@ -14,9 +14,8 @@
  * fault when reading the configuration space.
  */
 
+#include "n1sdp_pcie.h"
 #include "n1sdp_scp_mmap.h"
-
-#include <n1sdp_pcie.h>
 
 #include <mod_n1sdp_pcie.h>
 

--- a/product/n1sdp/module/n1sdp_pll/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_pll/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_pll.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-clock module-power-domain)

--- a/product/n1sdp/module/n1sdp_pll/Module.cmake
+++ b/product/n1sdp/module/n1sdp_pll/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-pll")
+
+set(SCP_MODULE_TARGET "module-n1sdp-pll")

--- a/product/n1sdp/module/n1sdp_remote_pd/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_remote_pd/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_remote_pd.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-power-domain module-n1sdp-c2c)

--- a/product/n1sdp/module/n1sdp_remote_pd/Module.cmake
+++ b/product/n1sdp/module/n1sdp_remote_pd/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-remote-pd")
+
+set(SCP_MODULE_TARGET "module-n1sdp-remote-pd")

--- a/product/n1sdp/module/n1sdp_rom/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_rom/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_rom.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-fip)

--- a/product/n1sdp/module/n1sdp_rom/Module.cmake
+++ b/product/n1sdp/module/n1sdp_rom/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-rom")
+
+set(SCP_MODULE_TARGET "module-n1sdp-rom")

--- a/product/n1sdp/module/n1sdp_scp2pcc/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_scp2pcc/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_scp2pcc.c")

--- a/product/n1sdp/module/n1sdp_scp2pcc/Module.cmake
+++ b/product/n1sdp/module/n1sdp_scp2pcc/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-scp2pcc")
+
+set(SCP_MODULE_TARGET "module-n1sdp-scp2pcc")

--- a/product/n1sdp/module/n1sdp_sensor/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_sensor/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+add_library(n1sdp_sensor_driver STATIC IMPORTED GLOBAL)
+
+set_target_properties(
+    n1sdp_sensor_driver
+    PROPERTIES
+        IMPORTED_LOCATION
+            "${CMAKE_CURRENT_SOURCE_DIR}/lib/mod_n1sdp_sensor_driver.a")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_sensor.c")
+
+target_include_directories(
+    ${SCP_MODULE_TARGET}
+    PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+target_link_libraries(
+    ${SCP_MODULE_TARGET} PRIVATE module-timer module-power-domain module-sensor
+                                 module-n1sdp-scp2pcc n1sdp_sensor_driver)

--- a/product/n1sdp/module/n1sdp_sensor/Module.cmake
+++ b/product/n1sdp/module/n1sdp_sensor/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-sensor")
+
+set(SCP_MODULE_TARGET "module-n1sdp-sensor")

--- a/product/n1sdp/module/n1sdp_smt/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_smt/CMakeLists.txt
@@ -1,0 +1,13 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_smt.c")

--- a/product/n1sdp/module/n1sdp_smt/Module.cmake
+++ b/product/n1sdp/module/n1sdp_smt/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-smt")
+
+set(SCP_MODULE_TARGET "module-n1sdp-smt")

--- a/product/n1sdp/module/n1sdp_system/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_system/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_system.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-sds module-n1sdp-scp2pcc module-clock module-fip
+            module-n1sdp-c2c module-power-domain module-n1sdp-dmc620
+            module-ppu-v1 module-scmi module-system-power)

--- a/product/n1sdp/module/n1sdp_system/Module.cmake
+++ b/product/n1sdp/module/n1sdp_system/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-system")
+
+set(SCP_MODULE_TARGET "module-n1sdp-system")

--- a/product/n1sdp/module/n1sdp_timer_sync/CMakeLists.txt
+++ b/product/n1sdp/module/n1sdp_timer_sync/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_n1sdp_timer_sync.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-n1sdp-system module-timer module-scmi)

--- a/product/n1sdp/module/n1sdp_timer_sync/Module.cmake
+++ b/product/n1sdp/module/n1sdp_timer_sync/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "n1sdp-timer-sync")
+
+set(SCP_MODULE_TARGET "module-n1sdp-timer-sync")

--- a/product/n1sdp/module/scmi_agent/CMakeLists.txt
+++ b/product/n1sdp/module/scmi_agent/CMakeLists.txt
@@ -1,0 +1,15 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_scmi_agent.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-n1sdp-smt)

--- a/product/n1sdp/module/scmi_agent/Module.cmake
+++ b/product/n1sdp/module/scmi_agent/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "scmi-agent")
+
+set(SCP_MODULE_TARGET "module-scmi-agent")

--- a/product/n1sdp/module/scmi_ccix_config/CMakeLists.txt
+++ b/product/n1sdp/module/scmi_ccix_config/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_scmi_ccix_config.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-cmn600 module-n1sdp-pcie module-scmi)

--- a/product/n1sdp/module/scmi_ccix_config/Module.cmake
+++ b/product/n1sdp/module/scmi_ccix_config/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "scmi-ccix-config")
+
+set(SCP_MODULE_TARGET "module-scmi-ccix-config")

--- a/product/n1sdp/module/scmi_management/CMakeLists.txt
+++ b/product/n1sdp/module/scmi_management/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_scmi_management.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-n1sdp-system module-scmi)

--- a/product/n1sdp/module/scmi_management/Module.cmake
+++ b/product/n1sdp/module/scmi_management/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "scmi-management")
+
+set(SCP_MODULE_TARGET "module-scmi-management")

--- a/product/n1sdp/scp_ramfw/CMakeLists.txt
+++ b/product/n1sdp/scp_ramfw/CMakeLists.txt
@@ -1,0 +1,78 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(n1sdp-bl2)
+
+target_include_directories(
+    n1sdp-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                          "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    n1sdp-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/n1sdp_core.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_armv7m_mpu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ssc.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_info.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v0.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_n1sdp_i2c.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_n1sdp_dmc620.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_n1sdp_ddr_phy.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_cmn600.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_n1sdp_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_n1sdp_pcie.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_n1sdp_scp2pcc.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sensor.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_apcontext.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_n1sdp_c2c_i2c.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_n1sdp_remote_pd.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_n1sdp_timer_sync.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c")
+
+if(SCP_ENABLE_DEBUGGER)
+    target_sources(n1sdp-bl2 PRIVATE "config_debugger_cli.c")
+endif()
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(n1sdp-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(n1sdp-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(n1sdp-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(n1sdp-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/n1sdp/scp_ramfw/Firmware.cmake
+++ b/product/n1sdp/scp_ramfw/Firmware.cmake
@@ -1,0 +1,98 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "n1sdp-bl2")
+
+set(SCP_FIRMWARE_TARGET "n1sdp-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_SOURCE_DIR}/module/fip")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_pcie")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_remote_pd")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_ddr_phy")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_scp2pcc")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_system")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_dmc620")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/scmi_ccix_config")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_sensor")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_c2c")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_i2c")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_timer_sync")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/scmi_management")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_pll")
+
+
+list(APPEND SCP_MODULES "armv7m-mpu")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "cmn600")
+list(APPEND SCP_MODULES "apcontext")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "ppu-v0")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "n1sdp-pll")
+list(APPEND SCP_MODULES "n1sdp-i2c")
+list(APPEND SCP_MODULES "n1sdp-dmc620")
+list(APPEND SCP_MODULES "n1sdp-ddr-phy")
+list(APPEND SCP_MODULES "mhu")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "n1sdp-scp2pcc")
+list(APPEND SCP_MODULES "n1sdp-sensor")
+list(APPEND SCP_MODULES "sensor")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "scmi-sensor")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "scmi-management")
+list(APPEND SCP_MODULES "scmi-ccix-config")
+list(APPEND SCP_MODULES "fip")
+list(APPEND SCP_MODULES "n1sdp-timer-sync")
+list(APPEND SCP_MODULES "n1sdp-c2c")
+list(APPEND SCP_MODULES "n1sdp-remote-pd")
+list(APPEND SCP_MODULES "n1sdp-pcie")
+list(APPEND SCP_MODULES "ssc")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "n1sdp-system")
+
+if(SCP_ENABLE_DEBUGGER)
+    list(APPEND SCP_MODULES,"debugger-cli")
+endif()

--- a/product/n1sdp/scp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/n1sdp/scp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/n1sdp/scp_ramfw/Toolchain-GNU.cmake
+++ b/product/n1sdp/scp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/n1sdp/scp_romfw/CMakeLists.txt
+++ b/product/n1sdp/scp_romfw/CMakeLists.txt
@@ -1,0 +1,39 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(n1sdp-bl1)
+
+target_include_directories(
+    n1sdp-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                     "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    n1sdp-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_n1sdp_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(n1sdp-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(n1sdp-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/n1sdp/scp_romfw/Firmware.cmake
+++ b/product/n1sdp/scp_romfw/Firmware.cmake
@@ -1,0 +1,36 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "n1sdp-bl1")
+
+set(SCP_FIRMWARE_TARGET "n1sdp-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_SOURCE_DIR}/module/fip")
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/n1sdp_rom")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "fip")
+list(APPEND SCP_MODULES "n1sdp-rom")
+list(APPEND SCP_MODULES "clock")

--- a/product/n1sdp/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/n1sdp/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/n1sdp/scp_romfw/Toolchain-GNU.cmake
+++ b/product/n1sdp/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/rdn1e1/include/fmw_cmsis_scp.h
+++ b/product/rdn1e1/include/fmw_cmsis_scp.h
@@ -8,6 +8,7 @@
 #ifndef FMW_CMSIS_SCP_H
 #define FMW_CMSIS_SCP_H
 
+#include <stdint.h>
 
 #define __CHECK_DEVICE_DEFINES
 #define __CM7_REV 0x0000U
@@ -18,6 +19,8 @@
 #define __DTCM_PRESENT 0U
 #define __NVIC_PRIO_BITS 3U
 #define __Vendor_SysTickConfig 0U
+
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 
 typedef enum IRQn {
     Reset_IRQn = -15,

--- a/product/rdn1e1/mcp_romfw/CMakeLists.txt
+++ b/product/rdn1e1/mcp_romfw/CMakeLists.txt
@@ -1,0 +1,38 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdn1e1-mcp-bl1)
+
+target_include_directories(
+    rdn1e1-mcp-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                          "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdn1e1-mcp-bl1 PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+                           "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdn1e1-mcp-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    rdn1e1-mcp-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdn1e1/mcp_romfw/Firmware.cmake
+++ b/product/rdn1e1/mcp_romfw/Firmware.cmake
@@ -1,0 +1,33 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "rdn1e1-mcp-bl1")
+
+set(SCP_FIRMWARE_TARGET "rdn1e1-mcp-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "clock")

--- a/product/rdn1e1/mcp_romfw/Toolchain-ArmClang.cmake
+++ b/product/rdn1e1/mcp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdn1e1/mcp_romfw/Toolchain-GNU.cmake
+++ b/product/rdn1e1/mcp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/rdn1e1/module/rdn1e1_system/CMakeLists.txt
+++ b/product/rdn1e1/module/rdn1e1_system/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_rdn1e1_system.c")
+
+target_link_libraries(
+    ${SCP_MODULE_TARGET}
+    PRIVATE module-sds module-clock module-cmn600 module-power-domain
+    PRIVATE module-ppu-v1 module-scmi module-system-info module-system-power)

--- a/product/rdn1e1/module/rdn1e1_system/Module.cmake
+++ b/product/rdn1e1/module/rdn1e1_system/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "rdn1e1-system")
+
+set(SCP_MODULE_TARGET "module-rdn1e1-system")

--- a/product/rdn1e1/scp_ramfw/CMakeLists.txt
+++ b/product/rdn1e1/scp_ramfw/CMakeLists.txt
@@ -1,0 +1,74 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdn1e1-bl2)
+
+target_include_directories(
+    rdn1e1-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                          "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdn1e1-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_armv7m_mpu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v0.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dmc620.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ddr_phy500.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu2.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sensor.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_cmn600.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mock_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dvfs.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_perf.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_apcore.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_apcontext.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_resource_perms.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c")
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(rdn1e1-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(rdn1e1-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdn1e1-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    rdn1e1-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdn1e1/scp_ramfw/Firmware.cmake
+++ b/product/rdn1e1/scp_ramfw/Firmware.cmake
@@ -1,0 +1,70 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "rdn1e1-bl2")
+
+set(SCP_FIRMWARE_TARGET "rdn1e1-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+set(SCP_ENABLE_RESOURCE_PERMISSIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/rdn1e1_system")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "armv7m-mpu")
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "cmn600")
+list(APPEND SCP_MODULES "apcontext")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "ppu-v0")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "dmc620")
+list(APPEND SCP_MODULES "ddr-phy500")
+list(APPEND SCP_MODULES "mhu2")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "system-pll")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "sensor")
+list(APPEND SCP_MODULES "reg-sensor")
+list(APPEND SCP_MODULES "scmi-sensor")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "scmi-apcore")
+list(APPEND SCP_MODULES "mock-psu")
+list(APPEND SCP_MODULES "psu")
+list(APPEND SCP_MODULES "dvfs")
+list(APPEND SCP_MODULES "scmi-perf")
+list(APPEND SCP_MODULES "rdn1e1-system")

--- a/product/rdn1e1/scp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/rdn1e1/scp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdn1e1/scp_ramfw/Toolchain-GNU.cmake
+++ b/product/rdn1e1/scp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/rdn1e1/scp_romfw/CMakeLists.txt
+++ b/product/rdn1e1/scp_romfw/CMakeLists.txt
@@ -1,0 +1,42 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdn1e1-bl1)
+
+target_include_directories(
+    rdn1e1-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                      "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdn1e1-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_gtimer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdn1e1-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(rdn1e1-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdn1e1/scp_romfw/Firmware.cmake
+++ b/product/rdn1e1/scp_romfw/Firmware.cmake
@@ -1,0 +1,39 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "rdn1e1-bl1")
+
+set(SCP_FIRMWARE_TARGET "rdn1e1-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "bootloader")
+list(APPEND SCP_MODULES "isys-rom")

--- a/product/rdn1e1/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/rdn1e1/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdn1e1/scp_romfw/Toolchain-GNU.cmake
+++ b/product/rdn1e1/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/rdv1mc/include/fmw_cmsis.h
+++ b/product/rdv1mc/include/fmw_cmsis.h
@@ -8,6 +8,8 @@
 #ifndef FMW_CMSIS_H
 #define FMW_CMSIS_H
 
+#include <stdint.h>
+
 #define __CHECK_DEVICE_DEFINES
 #define __CM7_REV              0x0000U
 #define __FPU_PRESENT          0U
@@ -17,6 +19,8 @@
 #define __DTCM_PRESENT         0U
 #define __NVIC_PRIO_BITS       3U
 #define __Vendor_SysTickConfig 0U
+
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 
 typedef enum IRQn {
     Reset_IRQn = -15,

--- a/product/rdv1mc/mcp_romfw/CMakeLists.txt
+++ b/product/rdv1mc/mcp_romfw/CMakeLists.txt
@@ -1,0 +1,40 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdv1mc-mcp-bl1)
+
+target_include_directories(
+    rdv1mc-mcp-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                           "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdv1mc-mcp-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdv1mc-mcp-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    rdv1mc-mcp-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdv1mc/mcp_romfw/Firmware.cmake
+++ b/product/rdv1mc/mcp_romfw/Firmware.cmake
@@ -1,0 +1,33 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "rdv1mc-mcp-bl1")
+
+set(SCP_FIRMWARE_TARGET "rdv1mc-mcp-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "bootloader")
+list(APPEND SCP_MODULES "isys-rom")

--- a/product/rdv1mc/mcp_romfw/Toolchain-ArmClang.cmake
+++ b/product/rdv1mc/mcp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdv1mc/mcp_romfw/Toolchain-GNU.cmake
+++ b/product/rdv1mc/mcp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/rdv1mc/module/platform_system/CMakeLists.txt
+++ b/product/rdv1mc/module/platform_system/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(
+    ${SCP_MODULE_TARGET}
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_platform_system.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-sds module-clock module-power-domain module-ppu-v1
+            module-scmi module-system-info module-system-power)

--- a/product/rdv1mc/module/platform_system/Module.cmake
+++ b/product/rdv1mc/module/platform_system/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "platform-system")
+
+set(SCP_MODULE_TARGET "module-platform-system")

--- a/product/rdv1mc/scp_ramfw/CMakeLists.txt
+++ b/product/rdv1mc/scp_ramfw/CMakeLists.txt
@@ -1,0 +1,65 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdv1mc-bl2)
+
+target_include_directories(
+    rdv1mc-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                           "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdv1mc-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_armv7m_mpu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu2.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_gtimer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_cmn650.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_apcontext.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c")
+
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(rdv1mc-bl2 PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(rdv1mc-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdv1mc-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    rdv1mc-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdv1mc/scp_ramfw/Firmware.cmake
+++ b/product/rdv1mc/scp_ramfw/Firmware.cmake
@@ -1,0 +1,60 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "rdv1mc-bl2")
+
+set(SCP_FIRMWARE_TARGET "rdv1mc-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/platform_system")
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_SOURCE_DIR}/module/cmn650")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "armv7m-mpu")
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "cmn650")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "mhu2")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "system-pll")
+list(APPEND SCP_MODULES "apcontext")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "platform-system")

--- a/product/rdv1mc/scp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/rdv1mc/scp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdv1mc/scp_ramfw/Toolchain-GNU.cmake
+++ b/product/rdv1mc/scp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/rdv1mc/scp_romfw/CMakeLists.txt
+++ b/product/rdv1mc/scp_romfw/CMakeLists.txt
@@ -1,0 +1,47 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdv1mc-bl1)
+
+target_include_directories(
+    rdv1mc-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                           "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdv1mc-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c")
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(rdv1mc-bl1 PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(rdv1mc-bl1 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdv1mc-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    rdv1mc-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdv1mc/scp_romfw/Firmware.cmake
+++ b/product/rdv1mc/scp_romfw/Firmware.cmake
@@ -1,0 +1,38 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "rdv1mc-bl1")
+
+set(SCP_FIRMWARE_TARGET "rdv1mc-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "bootloader")
+list(APPEND SCP_MODULES "isys-rom")

--- a/product/rdv1mc/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/rdv1mc/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdv1mc/scp_romfw/Toolchain-GNU.cmake
+++ b/product/rdv1mc/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/sgi575/mcp_romfw/CMakeLists.txt
+++ b/product/sgi575/mcp_romfw/CMakeLists.txt
@@ -1,0 +1,38 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(sgi575-mcp-bl1)
+
+target_include_directories(
+    sgi575-mcp-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                          "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    sgi575-mcp-bl1 PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+                           "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(sgi575-mcp-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interface include
+# directories. Each module target adds these include directories to their own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    sgi575-mcp-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/sgi575/mcp_romfw/Firmware.cmake
+++ b/product/sgi575/mcp_romfw/Firmware.cmake
@@ -1,0 +1,29 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "sgi575-mcp-bl1")
+set(SCP_FIRMWARE_TARGET "sgi575-mcp-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_DEBUGGER_INIT FALSE)
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+set(SCP_ENABLE_RESOURCE_PERMISSIONS_INIT FALSE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "clock")

--- a/product/sgi575/mcp_romfw/Toolchain-ArmClang.cmake
+++ b/product/sgi575/mcp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,21 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/sgi575/mcp_romfw/Toolchain-GNU.cmake
+++ b/product/sgi575/mcp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/sgi575/module/sgi575_system/CMakeLists.txt
+++ b/product/sgi575/module/sgi575_system/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_sgi575_system.c")
+
+target_link_libraries(
+    module-sgi575-system PRIVATE module-clock module-power-domain module-ppu-v1
+                                 module-scmi module-sds module-system-power)

--- a/product/sgi575/module/sgi575_system/Module.cmake
+++ b/product/sgi575/module/sgi575_system/Module.cmake
@@ -1,0 +1,9 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "sgi575-system")
+set(SCP_MODULE_TARGET "module-sgi575-system")

--- a/product/sgi575/scp_ramfw/CMakeLists.txt
+++ b/product/sgi575/scp_ramfw/CMakeLists.txt
@@ -1,0 +1,78 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(sgi575-bl2)
+
+target_include_directories(
+    sgi575-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                      "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    sgi575-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_armv7m_mpu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_cmn600.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dmc620.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ddr_phy500.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v0.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sensor.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mock_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dvfs.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_perf.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_apcore.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ssc.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_info.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_apcontext.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c")
+
+if(SCP_ENABLE_RESOURCE_PERMISSIONS)
+    target_sources(
+        sgi575-bl2
+        PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_resource_perms.c")
+endif()
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(sgi575-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(sgi575-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(sgi575-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interface include
+# directories. Each module target adds these include directories to their own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    sgi575-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/sgi575/scp_ramfw/Firmware.cmake
+++ b/product/sgi575/scp_ramfw/Firmware.cmake
@@ -1,0 +1,63 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "sgi575-bl2")
+set(SCP_FIRMWARE_TARGET "sgi575-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT TRUE)
+set(SCP_ENABLE_RESOURCE_PERMISSIONS_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/sgi575_system")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "armv7m-mpu")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "cmn600")
+list(APPEND SCP_MODULES "apcontext")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "dmc620")
+list(APPEND SCP_MODULES "ddr-phy500")
+list(APPEND SCP_MODULES "ppu-v0")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "sgi575-system")
+list(APPEND SCP_MODULES "mhu")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "system-pll")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "sensor")
+list(APPEND SCP_MODULES "reg-sensor")
+list(APPEND SCP_MODULES "scmi-sensor")
+list(APPEND SCP_MODULES "mock-psu")
+list(APPEND SCP_MODULES "psu")
+list(APPEND SCP_MODULES "dvfs")
+list(APPEND SCP_MODULES "scmi-perf")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "ssc")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "scmi-apcore")

--- a/product/sgi575/scp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/sgi575/scp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,21 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/sgi575/scp_ramfw/Toolchain-GNU.cmake
+++ b/product/sgi575/scp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/sgi575/scp_ramfw/fmw_cmsis.h
+++ b/product/sgi575/scp_ramfw/fmw_cmsis.h
@@ -10,4 +10,6 @@
 
 #include <fmw_cmsis_scp.h>
 
+extern uint32_t SystemCoreClock;
+
 #endif /* FMW_CMSIS_H */

--- a/product/sgi575/scp_romfw/CMakeLists.txt
+++ b/product/sgi575/scp_romfw/CMakeLists.txt
@@ -1,0 +1,41 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(sgi575-bl1)
+
+target_include_directories(
+    sgi575-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                      "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    sgi575-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_gtimer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(sgi575-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interface include
+# directories. Each module target adds these include directories to their own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    sgi575-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/sgi575/scp_romfw/Firmware.cmake
+++ b/product/sgi575/scp_romfw/Firmware.cmake
@@ -1,0 +1,32 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "sgi575-bl1")
+set(SCP_FIRMWARE_TARGET "sgi575-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_DEBUGGER_INIT FALSE)
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+set(SCP_ENABLE_RESOURCE_PERMISSIONS_INIT FALSE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "bootloader")
+list(APPEND SCP_MODULES "isys-rom")

--- a/product/sgi575/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/sgi575/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,21 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/sgi575/scp_romfw/Toolchain-GNU.cmake
+++ b/product/sgi575/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/sgm776/include/fmw_cmsis.h
+++ b/product/sgm776/include/fmw_cmsis.h
@@ -8,12 +8,15 @@
 #ifndef FMW_CMSIS_H
 #define FMW_CMSIS_H
 
+#include <stdint.h>
+
 #define __CHECK_DEVICE_DEFINES
 #define __CM3_REV 0x0201
 #define __MPU_PRESENT 1
 #define __NVIC_PRIO_BITS 3
 #define __Vendor_SysTickConfig 0
 
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 typedef enum IRQn {
     Reset_IRQn = -15,
     NonMaskableInt_IRQn = -14,

--- a/product/sgm776/module/sgm776_system/CMakeLists.txt
+++ b/product/sgm776/module/sgm776_system/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_sgm776_system.c")
+
+target_link_libraries(module-sgm776-system PRIVATE module-power-domain
+                                                   module-system-power)

--- a/product/sgm776/module/sgm776_system/Module.cmake
+++ b/product/sgm776/module/sgm776_system/Module.cmake
@@ -1,0 +1,9 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "sgm776-system")
+set(SCP_MODULE_TARGET "module-sgm776-system")

--- a/product/sgm776/scp_ramfw/CMakeLists.txt
+++ b/product/sgm776/scp_ramfw/CMakeLists.txt
@@ -1,0 +1,77 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(sgm776-bl2)
+
+target_include_directories(
+    sgm776-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                      "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    sgm776-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ddr_phy500.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dmc500.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sensor.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_perf.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_apcore.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mock_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dvfs.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain"
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../src/sgm776_core.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c")
+
+if(SCP_ENABLE_RESOURCE_PERMISSIONS)
+    target_sources(
+        sgm776-bl2
+        PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_resource_perms.c")
+endif()
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(sgm776-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+
+    target_link_libraries(sgm776-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(sgm776-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interface include
+# directories. Each module target adds these include directories to their own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    sgm776-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/sgm776/scp_ramfw/Firmware.cmake
+++ b/product/sgm776/scp_ramfw/Firmware.cmake
@@ -1,0 +1,61 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "sgm776-bl2")
+set(SCP_FIRMWARE_TARGET "sgm776-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+set(SCP_ENABLE_RESOURCE_PERMISSIONS_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/sgm776_system")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "ddr-phy500")
+list(APPEND SCP_MODULES "dmc500")
+list(APPEND SCP_MODULES "reg-sensor")
+list(APPEND SCP_MODULES "sensor")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "sgm776-system")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "psu")
+list(APPEND SCP_MODULES "mock-psu")
+list(APPEND SCP_MODULES "mhu2")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "system-pll")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "dvfs")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "scmi-clock")
+list(APPEND SCP_MODULES "scmi-perf")
+list(APPEND SCP_MODULES "scmi-sensor")
+list(APPEND SCP_MODULES "scmi-apcore")
+list(APPEND SCP_MODULES "sds")

--- a/product/sgm776/scp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/sgm776/scp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,21 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/sgm776/scp_ramfw/Toolchain-GNU.cmake
+++ b/product/sgm776/scp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/sgm776/scp_romfw/CMakeLists.txt
+++ b/product/sgm776/scp_romfw/CMakeLists.txt
@@ -1,0 +1,50 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(sgm776-bl1)
+
+target_include_directories(
+    sgm776-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                      "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    sgm776-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_msys_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../src/sgm776_core.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(sgm776-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interface include
+# directories. Each module target adds these include directories to their own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(
+    sgm776-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/sgm776/scp_romfw/Firmware.cmake
+++ b/product/sgm776/scp_romfw/Firmware.cmake
@@ -1,0 +1,40 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_FIRMWARE "sgm776-bl1")
+set(SCP_FIRMWARE_TARGET "sgm776-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+set(SCP_ENABLE_RESOURCE_PERMISSIONS_INIT FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "msys-rom")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "bootloader")
+list(APPEND SCP_MODULES "system-pll")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "clock")

--- a/product/sgm776/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/sgm776/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,21 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/sgm776/scp_romfw/Toolchain-GNU.cmake
+++ b/product/sgm776/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/tc0/include/fmw_cmsis.h
+++ b/product/tc0/include/fmw_cmsis.h
@@ -8,6 +8,8 @@
 #ifndef FMW_CMSIS_H
 #define FMW_CMSIS_H
 
+#include <stdint.h>
+
 #define __CHECK_DEVICE_DEFINES
 #define __CM3_REV 0x0201
 #define __FPU_PRESENT 0U
@@ -17,6 +19,8 @@
 #define __DTCM_PRESENT 0U
 #define __NVIC_PRIO_BITS 3U
 #define __Vendor_SysTickConfig 0U
+
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 
 typedef enum IRQn {
     Reset_IRQn = -15,

--- a/product/tc0/module/tc0_system/CMakeLists.txt
+++ b/product/tc0/module/tc0_system/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_tc0_system.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-clock module-sds module-power-domain module-ppu-v1
+            module-scmi module-system-power)

--- a/product/tc0/module/tc0_system/Module.cmake
+++ b/product/tc0/module/tc0_system/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "tc0-system")
+
+set(SCP_MODULE_TARGET "module-tc0-system")

--- a/product/tc0/scp_ramfw/CMakeLists.txt
+++ b/product/tc0/scp_ramfw/CMakeLists.txt
@@ -1,0 +1,69 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(tc0-bl2)
+
+target_include_directories(
+    tc0-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                   "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    tc0-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_armv7m_mpu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu2.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_perf.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_gtimer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dvfs.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mock_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c")
+
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(tc0-bl2 PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(tc0-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+if(SCP_ENABLE_RESOURCE_PERMISSIONS)
+    target_sources(tc0-bl2 PRIVATE "config_resource_perms.c")
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(tc0-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(tc0-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/tc0/scp_ramfw/Firmware.cmake
+++ b/product/tc0/scp_ramfw/Firmware.cmake
@@ -1,0 +1,62 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "tc0-bl2")
+
+set(SCP_FIRMWARE_TARGET "tc0-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_RESOURCE_PERMISSIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/tc0_system")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "armv7m-mpu")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "mhu2")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "system-pll")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "dvfs")
+list(APPEND SCP_MODULES "scmi-clock")
+list(APPEND SCP_MODULES "scmi-perf")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "mock-psu")
+list(APPEND SCP_MODULES "psu")
+list(APPEND SCP_MODULES "tc0-system")
+
+if(SCP_ENABLE_RESOURCE_PERMISSIONS)
+    list(APPEND SCP_MODULES,"resource-perms")
+endif()

--- a/product/tc0/scp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/tc0/scp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/tc0/scp_ramfw/Toolchain-GNU.cmake
+++ b/product/tc0/scp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/tc0/scp_romfw/CMakeLists.txt
+++ b/product/tc0/scp_romfw/CMakeLists.txt
@@ -1,0 +1,48 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(tc0-bl1)
+
+target_include_directories(
+    tc0-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                   "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    tc0-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_cmn_booker.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_gtimer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_msys_rom.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(tc0-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(tc0-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/tc0/scp_romfw/Firmware.cmake
+++ b/product/tc0/scp_romfw/Firmware.cmake
@@ -1,0 +1,45 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "tc0-bl1")
+
+set(SCP_FIRMWARE_TARGET "tc0-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS "${CMAKE_SOURCE_DIR}/module/cmn_booker")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "msys-rom")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "bootloader")
+list(APPEND SCP_MODULES "system-pll")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "cmn-booker")

--- a/product/tc0/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/tc0/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/tc0/scp_romfw/Toolchain-GNU.cmake
+++ b/product/tc0/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m3")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")


### PR DESCRIPTION
This PR is a part of the ongoing CMake build patch series. 

This PR includes CMake build support for the following ARM Platforms.

morello
n1sdp
rdv1mc
rdn1e1
sgm776
sgi575
tc0