### PR TITLE
cli: fix escape buffer overflow check

### DIFF
--- a/debugger/src/cli/cli.c
+++ b/debugger/src/cli/cli.c
@@ -973,7 +973,7 @@ static uint32_t cli_get_command(
         if (flag_escape_sequence == true) {
             /* Prevent escape buffer overflow, Only save first 7 bytes data of
              * escape sequences. */
-            if(escape_index >= 7) {
+            if (escape_index >= 7) {
                 escape[escape_index] = c;
                 escape[escape_index + 1] = 0;
                 escape_index = escape_index + 1;

--- a/debugger/src/cli/cli.c
+++ b/debugger/src/cli/cli.c
@@ -971,9 +971,13 @@ static uint32_t cli_get_command(
 
         /* Dealing with escape sequences. */
         if (flag_escape_sequence == true) {
-            escape[escape_index] = c;
-            escape[escape_index + 1] = 0;
-            escape_index = escape_index + 1;
+            /* Prevent escape buffer overflow, Only save first 7 bytes data of
+             * escape sequences. */
+            if(escape_index >= 7) {
+                escape[escape_index] = c;
+                escape[escape_index + 1] = 0;
+                escape_index = escape_index + 1;
+            }
 
             /* Escape sequences end with a letter. */
             if ((c > 0x40 && c < 0x5B) || (c > 0x60 && c < 0x7B)) {


### PR DESCRIPTION
This commit add escape buffer overflow check when cli receive
escape sequence(cursor position response). escape buffer size
is 8 bytes, the last byte used to store string end symbol '\0'.
So the longest string escape buffer can save is 7 bytes. But in
some console or tool, the cursor position response sequence is
more then 7 bytes, and escap buffer will overflow. This patch
fix it.

Signed-off-by: Zhilong Wubin <zhilong.wb@alibaba-inc.com>