### PR TITLE
scmi: fix psci protocol-count assertions

### DIFF
--- a/module/scmi/src/mod_scmi.c
+++ b/module/scmi/src/mod_scmi.c
@@ -740,7 +740,7 @@ static int scmi_base_protocol_attributes_handler(fwk_id_t service_id,
      */
     if (agent_type == SCMI_AGENT_TYPE_PSCI) {
         fwk_assert(
-            scmi_ctx.protocol_count > scmi_ctx.config->dis_protocol_count_psci);
+            scmi_ctx.protocol_count >= scmi_ctx.config->dis_protocol_count_psci);
         protocol_count =
             scmi_ctx.protocol_count - scmi_ctx.config->dis_protocol_count_psci;
     } else
@@ -908,7 +908,7 @@ static int scmi_base_discover_list_protocols_handler(fwk_id_t service_id,
 
     if (agent_type == SCMI_AGENT_TYPE_PSCI) {
         fwk_assert(
-            scmi_ctx.protocol_count > scmi_ctx.config->dis_protocol_count_psci);
+            scmi_ctx.protocol_count >= scmi_ctx.config->dis_protocol_count_psci);
 
         protocol_count_psci =
             scmi_ctx.protocol_count - scmi_ctx.config->dis_protocol_count_psci;


### PR DESCRIPTION
I got assertion errors when trying to work with mod_scmi with a PSCI agent with `protocol_count=0`.

It turned out the assertion itself has a bug, it does not allow `scmi_ctx.protocol_count` to be equal to `scmi_ctx.config->dis_protocol_count_psci`.

The reason for the assertion is so that the subtraction `scmi_ctx.protocol_count - scmi_ctx.config->dis_protocol_count_psci` would not be negative. But no reason it cannot be 0.

It worked after fixing these 2 assertions.
