### PR TITLE
Cmake rdn2 v1

### DIFF
--- a/doc/cmake_readme.md
+++ b/doc/cmake_readme.md
@@ -87,11 +87,12 @@ options available.
 > $ make -f Makefile.cmake help
 > ```
 
-**NOTE**
-CMake build support is getting added gradually. That is at present only sgm775,
-juno and rdv1 are supported.
-
 **LIMITATIONS**
+
+- CMake build of rdn2 platform is not working. It requires further
+  investigation.
+- CMake build of platform synquacer is not tested.
+- CMake build of platform rcar is not tested.
 - ArmClang toolchain is supported but not all platforms are working.
 
 **NOTE**: Read below documentation for advanced use of development environment

--- a/module/apremap/CMakeLists.txt
+++ b/module/apremap/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_apremap.c")

--- a/module/apremap/Module.cmake
+++ b/module/apremap/Module.cmake
@@ -1,0 +1,9 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "apremap")
+set(SCP_MODULE_TARGET "module-apremap")

--- a/module/cmn700/CMakeLists.txt
+++ b/module/cmn700/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                           PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+target_sources(
+    ${SCP_MODULE_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_cmn700.c"
+                                 "${CMAKE_CURRENT_SOURCE_DIR}/src/cmn700.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-clock module-timer module-sds module-system-info)

--- a/module/cmn700/Module.cmake
+++ b/module/cmn700/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "cmn700")
+
+set(SCP_MODULE_TARGET "module-cmn700")

--- a/product/rdn2/include/fmw_cmsis.h
+++ b/product/rdn2/include/fmw_cmsis.h
@@ -8,6 +8,8 @@
 #ifndef FMW_CMSIS_H
 #define FMW_CMSIS_H
 
+#include <stdint.h>
+
 #define __CHECK_DEVICE_DEFINES
 #define __CM7_REV              0x0000U
 #define __FPU_PRESENT          0U
@@ -17,6 +19,8 @@
 #define __DTCM_PRESENT         0U
 #define __NVIC_PRIO_BITS       3U
 #define __Vendor_SysTickConfig 0U
+
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)*/
 
 typedef enum IRQn {
     Reset_IRQn = -15,

--- a/product/rdn2/mcp_romfw/CMakeLists.txt
+++ b/product/rdn2/mcp_romfw/CMakeLists.txt
@@ -1,0 +1,40 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdn2-mcp-bl1)
+
+target_include_directories(
+    rdn2-mcp-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                    "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdn2-mcp-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdn2-mcp-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(rdn2-mcp-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdn2/mcp_romfw/Firmware.cmake
+++ b/product/rdn2/mcp_romfw/Firmware.cmake
@@ -1,0 +1,35 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "rdn2-mcp-bl1")
+
+set(SCP_FIRMWARE_TARGET "rdn2-mcp-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "bootloader")
+list(APPEND SCP_MODULES "isys-rom")

--- a/product/rdn2/mcp_romfw/Toolchain-ArmClang.cmake
+++ b/product/rdn2/mcp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdn2/mcp_romfw/Toolchain-GNU.cmake
+++ b/product/rdn2/mcp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/rdn2/module/platform_system/CMakeLists.txt
+++ b/product/rdn2/module/platform_system/CMakeLists.txt
@@ -1,0 +1,17 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_platform_system.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-sds module-clock module-power-domain module-ppu-v1
+            module-scmi module-system-power module-apremap)

--- a/product/rdn2/module/platform_system/Module.cmake
+++ b/product/rdn2/module/platform_system/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "platform-system")
+
+set(SCP_MODULE_TARGET "module-platform-system")

--- a/product/rdn2/scp_ramfw/CMakeLists.txt
+++ b/product/rdn2/scp_ramfw/CMakeLists.txt
@@ -1,0 +1,64 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdn2-bl2)
+
+target_include_directories(
+    rdn2-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                    "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdn2-bl2
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_armv7m_mpu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_ppu_v1.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu2.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_smt.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_sds.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_gtimer.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_system_power.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_cmn700.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_system_pll.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_apcontext.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_apremap.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c")
+
+if(SCP_ENABLE_MULTITHREADING)
+    target_sources(rdn2-bl2 PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/rtx_config.c")
+    target_link_libraries(rdn2-bl2 PRIVATE cmsis::rtos2-rtx)
+endif()
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdn2-bl2 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(rdn2-bl2
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdn2/scp_ramfw/Firmware.cmake
+++ b/product/rdn2/scp_ramfw/Firmware.cmake
@@ -1,0 +1,62 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "rdn2-bl2")
+
+set(SCP_FIRMWARE_TARGET "rdn2-bl2")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT TRUE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_CURRENT_LIST_DIR}/../module/platform_system")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_SOURCE_DIR}/module/cmn700")
+list(PREPEND SCP_MODULE_PATHS
+     "${CMAKE_SOURCE_DIR}/module/apremap")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "armv7m-mpu")
+list(APPEND SCP_MODULES "apremap")
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "pik-clock")
+list(APPEND SCP_MODULES "css-clock")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "gtimer")
+list(APPEND SCP_MODULES "timer")
+list(APPEND SCP_MODULES "cmn700")
+list(APPEND SCP_MODULES "apcontext")
+list(APPEND SCP_MODULES "ppu-v1")
+list(APPEND SCP_MODULES "system-power")
+list(APPEND SCP_MODULES "mhu2")
+list(APPEND SCP_MODULES "smt")
+list(APPEND SCP_MODULES "scmi")
+list(APPEND SCP_MODULES "sds")
+list(APPEND SCP_MODULES "system-pll")
+list(APPEND SCP_MODULES "power-domain")
+list(APPEND SCP_MODULES "scmi-power-domain")
+list(APPEND SCP_MODULES "scmi-system-power")
+list(APPEND SCP_MODULES "platform-system")

--- a/product/rdn2/scp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/rdn2/scp_ramfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdn2/scp_ramfw/Toolchain-GNU.cmake
+++ b/product/rdn2/scp_ramfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/product/rdn2/scp_romfw/CMakeLists.txt
+++ b/product/rdn2/scp_romfw/CMakeLists.txt
@@ -1,0 +1,41 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Create the firmware target.
+#
+
+add_executable(rdn2-bl1)
+
+target_include_directories(
+    rdn2-bl1 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+                    "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# cmake-lint: disable=E1122
+
+target_sources(
+    rdn2-bl1
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_bootloader.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_pl011.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c")
+
+#
+# Some of our firmware includes require CMSIS.
+#
+
+target_link_libraries(rdn2-bl1 PUBLIC cmsis::core-m)
+
+#
+# We explicitly add the CMSIS include directories to our interfaceinclude
+# directories. Each module target adds these include directories totheir own,
+# allowing them to include any firmware includes we expose.
+#
+
+target_include_directories(rdn2-bl1
+    PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdn2/scp_romfw/Firmware.cmake
+++ b/product/rdn2/scp_romfw/Firmware.cmake
@@ -1,0 +1,38 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+#
+# Configure the build system.
+#
+
+set(SCP_FIRMWARE "rdn2-bl1")
+
+set(SCP_FIRMWARE_TARGET "rdn2-bl1")
+
+set(SCP_TOOLCHAIN_INIT "GNU")
+
+set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
+
+set(SCP_ENABLE_MULTITHREADING_INIT FALSE)
+
+set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
+
+set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_ARCHITECTURE "armv7-m")
+
+# The order of the modules in the following list is the order in which the
+# modules are initialized, bound, started during the pre-runtime phase.
+# any change in the order will cause firmware initialization errors.
+
+list(APPEND SCP_MODULES "sid")
+list(APPEND SCP_MODULES "system-info")
+list(APPEND SCP_MODULES "pcid")
+list(APPEND SCP_MODULES "pl011")
+list(APPEND SCP_MODULES "clock")
+list(APPEND SCP_MODULES "bootloader")
+list(APPEND SCP_MODULES "isys-rom")

--- a/product/rdn2/scp_romfw/Toolchain-ArmClang.cmake
+++ b/product/rdn2/scp_romfw/Toolchain-ArmClang.cmake
@@ -1,0 +1,20 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+# cmake-lint: disable=C0301
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/ArmClang-Baremetal.cmake"
+)

--- a/product/rdn2/scp_romfw/Toolchain-GNU.cmake
+++ b/product/rdn2/scp_romfw/Toolchain-GNU.cmake
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+set(CMAKE_TOOLCHAIN_PREFIX "arm-none-eabi-")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/GNU-Baremetal.cmake")

--- a/tools/ci_cmake.py
+++ b/tools/ci_cmake.py
@@ -90,7 +90,9 @@ def main():
 
     banner("Test building host product")
 
-    products = ['host', 'juno', 'rdv1', 'sgm775']
+    products = ['host', 'juno', 'morello', 'n1sdp', 'rdv1', 'rdv1mc',
+                'rdn1e1', 'sgi575', 'sgm775', 'sgm776', 'tc0',
+                'rdn2']
 
     build_types = ['debug', 'release']
     toolchains = ['GNU', 'ArmClang']


### PR DESCRIPTION
This PR is the last in the ongoing PR series for CMake.

It includes.
- Support for building rdn2 platform.
- And update tool ci_cmake.py to build all platforms.

