### PR TITLE
fwk: Add new function to retrieve sub-element id

### DIFF
--- a/framework/include/fwk_id.h
+++ b/framework/include/fwk_id.h
@@ -561,6 +561,23 @@ fwk_id_t fwk_id_build_element_id(fwk_id_t id, unsigned int element_idx)
     FWK_CONST FWK_LEAF FWK_NOTHROW;
 
 /*!
+ * \brief Retrieve the identifier of a sub-element for a given element
+ *      identifier and sub-element index.
+ *
+ * \details The given identifier must be an element identifier and the
+ *      function will be used to build an sub-element identifier for a
+ *      sub-element with the given index that is owned by that element.
+ *
+ * \param id Identifier.
+ * \param sub_element_idx Sub-element index.
+ *
+ * \return Sub-element identifier associated with the sub-element index for the
+ *      element.
+ */
+fwk_id_t fwk_id_build_sub_element_id(fwk_id_t id, unsigned int sub_element_idx)
+    FWK_CONST FWK_LEAF FWK_NOTHROW;
+
+/*!
  * \brief Retrieve the identifier of an API for a given identifier and
  *      API index.
  *

--- a/framework/src/fwk_id.c
+++ b/framework/src/fwk_id.c
@@ -222,6 +222,14 @@ fwk_id_t fwk_id_build_element_id(fwk_id_t id, unsigned int element_idx)
     return FWK_ID_ELEMENT(id.common.module_idx, element_idx);
 }
 
+fwk_id_t fwk_id_build_sub_element_id(fwk_id_t id, unsigned int sub_element_idx)
+{
+    fwk_assert(id.common.type == __FWK_ID_TYPE_ELEMENT);
+
+    return FWK_ID_SUB_ELEMENT(
+        id.common.module_idx, id.element.element_idx, sub_element_idx);
+}
+
 fwk_id_t fwk_id_build_api_id(fwk_id_t id, unsigned int api_idx)
 {
     fwk_assert(id.common.type != __FWK_ID_TYPE_INVALID);

--- a/framework/test/test_fwk_id_build.c
+++ b/framework/test/test_fwk_id_build.c
@@ -116,6 +116,14 @@ static void test_element_from_element_and_index(void)
     assert(fwk_id_is_equal(element_id, FWK_ID_ELEMENT(42, 58)));
 }
 
+static void test_sub_element_from_element_and_index(void)
+{
+    fwk_id_t element_id = FWK_ID_ELEMENT_INIT(42, 64);
+    fwk_id_t sub_element_id = fwk_id_build_sub_element_id(element_id, 58);
+
+    assert(fwk_id_is_equal(sub_element_id, FWK_ID_SUB_ELEMENT(42, 64, 58)));
+}
+
 static const struct fwk_test_case_desc test_case_table[] = {
     FWK_TEST_CASE(test_overlapping_fields),
     FWK_TEST_CASE(test_build_module),
@@ -127,6 +135,7 @@ static const struct fwk_test_case_desc test_case_table[] = {
     FWK_TEST_CASE(test_module_from_element),
     FWK_TEST_CASE(test_element_from_module_and_index),
     FWK_TEST_CASE(test_element_from_element_and_index),
+    FWK_TEST_CASE(test_sub_element_from_element_and_index),
 };
 
 struct fwk_test_suite_desc test_suite = {


### PR DESCRIPTION
It is required to convert from sub-element index to identifier.
This patch adds the required new function.

Signed-off-by: Tarek El-Sherbiny <tarek.el-sherbiny@arm.com>
Change-Id: I55f2702668ef97f7a6964adb924c3cedaae1e1e1