### PR TITLE
Kramdown & docker fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     chef-utils (16.5.64)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ FROM ubuntu:20.04 as ci
 
 ARG ARM_GNU_RM_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2"
 ARG ARM_COMPILER_6_URL="https://developer.arm.com/-/media/Files/downloads/compiler/DS500-BN-00026-r5p0-16rel1.tgz"
-ARG DOXYGEN_URL="https://deac-ams.dl.sourceforge.net/project/doxygen/rel-1.8.20/doxygen-1.8.20.linux.bin.tar.gz"
+ARG DOXYGEN_URL="https://sourceforge.net/projects/doxygen/files/rel-1.8.20/doxygen-1.8.20.linux.bin.tar.gz"
 ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3-Linux-x86_64.tar.gz"
 ARG AARCH64_GCC_URL="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-elf.tar.xz"
 ARG CPPCHECK_SRC_URL="git://github.com/danmar/cppcheck.git"


### PR DESCRIPTION
This PR brings:
- update kramdown to 2.3.1 to include a security issue fix
- update docker URL