### PR TITLE
gemfile.lock: set rexml to use version 3.2.5 or later

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     chef-utils (16.5.64)
     kramdown (2.3.1)
-      rexml
+      rexml (>= 3.2.5)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     mdl (0.11.0)


### PR DESCRIPTION
Bumps rexml from 3.2.4 to 3.2.5 as suggested by github.

Signed-off-by: Leandro Belli <leandro.belli@arm.com>
Change-Id: Ibf982a3b2d07011b1d1f0926b6e9dbf33fec0f64