### PR TITLE
gemfile.lock: set rexml from 3.2.4 to 3.2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     chef-utils (16.5.64)
     kramdown (2.3.1)
-      rexml (>= 3.2.5)
+      rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     mdl (0.11.0)
@@ -17,7 +17,7 @@ GEM
       tomlrb
     mixlib-shellout (3.1.6)
       chef-utils
-    rexml (3.2.4)
+    rexml (3.2.5)
     tomlrb (1.3.0)
 
 PLATFORMS


### PR DESCRIPTION
PR #464 updates to Gemfile.lock is wrong for rexml
version change. It updates the value at wrong place.
This updated commit fixes it.

Signed-off-by: Leandro Belli <leandro.belli@arm.com>
Change-Id: I2650db000e0c35467d14d9832f7495a815008864