### PR TITLE
product/n1sdp: Enable non-secure CoreSight access in C2C setup

### DIFF
--- a/product/n1sdp/module/n1sdp_system/src/mod_n1sdp_system.c
+++ b/product/n1sdp/module/n1sdp_system/src/mod_n1sdp_system.c
@@ -402,6 +402,12 @@ static int n1sdp_system_init_primary_core(void)
         }
     }
 
+    /* Enable non-secure CoreSight debug access */
+    FWK_LOG_INFO(
+        "[N1SDP SYSTEM] Enabling CoreSight debug non-secure access");
+    *(volatile uint32_t
+          *)(AP_SCP_SRAM_OFFSET + NIC_400_SEC_0_CSAPBM_OFFSET) = 0xFFFFFFFF;
+
     if (n1sdp_get_chipid() == 0x0) {
         struct mod_fip_entry_data entry;
         status = n1sdp_system_ctx.fip_api->get_entry(
@@ -444,12 +450,6 @@ static int n1sdp_system_init_primary_core(void)
         if (status != FWK_SUCCESS) {
             return status;
         }
-
-        /* Enable non-secure CoreSight debug access */
-        FWK_LOG_INFO(
-            "[N1SDP SYSTEM] Enabling CoreSight debug non-secure access");
-        *(volatile uint32_t *)(AP_SCP_SRAM_OFFSET +
-                               NIC_400_SEC_0_CSAPBM_OFFSET) = 0xFFFFFFFF;
 
         mod_pd_restricted_api = n1sdp_system_ctx.mod_pd_restricted_api;
 


### PR DESCRIPTION
This patch enables non-secure AXI access to CoreSight components
in both the primary and secondary boards in C2C setup.

Signed-off-by: Himanshu Sharma <Himanshu.Sharma@arm.com>
Change-Id: I000485fd30f87579b2b0a9b7f3935fe7ead99a7b