### PR TITLE
cli: fix to revert escape buffer overflow check

### DIFF
--- a/debugger/src/cli/cli.c
+++ b/debugger/src/cli/cli.c
@@ -971,13 +971,9 @@ static uint32_t cli_get_command(
 
         /* Dealing with escape sequences. */
         if (flag_escape_sequence == true) {
-            /* Prevent escape buffer overflow, Only save first 7 bytes data of
-             * escape sequences. */
-            if (escape_index >= 7) {
-                escape[escape_index] = c;
-                escape[escape_index + 1] = 0;
-                escape_index = escape_index + 1;
-            }
+            escape[escape_index] = c;
+            escape[escape_index + 1] = 0;
+            escape_index = escape_index + 1;
 
             /* Escape sequences end with a letter. */
             if ((c > 0x40 && c < 0x5B) || (c > 0x60 && c < 0x7B)) {


### PR DESCRIPTION
Reverted a change that was causing the cli debugger to hang after a
character was entered.

Fixes 21acbdd473d87c23622bb65cb0ae4e27222e0b86 (cli: fix escape buffer overflow check)

Signed-off-by: Katherine Vincent <katherine.vincent@arm.com>
Change-Id: Ie6f54cb84ef7c0110ba93c8a1cc56679ec35a590