### PR TITLE
MISRAC Fixes rules 15.6 and 10.1

### DIFF
--- a/doc/code_rules.md
+++ b/doc/code_rules.md
@@ -50,6 +50,18 @@ Certain checks have been manually suppressed. Checks are generally only
 disabled if they have been triaged as false positives. The list of suppressed
 checks can be found [here](../tools/cppcheck_suppress_list.txt).
 
+MISRAC-2012
+-----------
+The SCP-firmware is gradually achieving compliance with MISRAC-2012. To date,
+the mandatory rules have been resolved.
+
+In order to provide a reference, Juno platform is taken as a first platform to
+provide compliance. At the same time, a MISRAC-2012 checker will run upon PR
+submission.
+
+Please note that new patches will have to be compliant with the current status
+of compliance.
+
 C Standard Library
 ------------------
 When developing a module, only the following headers of the C standard library

--- a/module/bootloader/src/mod_bootloader.c
+++ b/module/bootloader/src/mod_bootloader.c
@@ -71,14 +71,18 @@ static int load_image(void)
 
     bool sds = false;
 
-    if (module_ctx.module_config == NULL)
+    if (module_ctx.module_config == NULL) {
         return FWK_E_PARAM;
-    if (module_ctx.module_config->source_base == 0)
+    }
+    if (module_ctx.module_config->source_base == 0) {
         return FWK_E_PARAM;
-    if (module_ctx.module_config->destination_base == 0)
+    }
+    if (module_ctx.module_config->destination_base == 0) {
         return FWK_E_PARAM;
-    if (module_ctx.module_config->source_size == 0)
+    }
+    if (module_ctx.module_config->source_size == 0) {
         return FWK_E_PARAM;
+    }
 
 #ifdef BUILD_HAS_MOD_SDS
     sds = module_ctx.module_config->sds_struct_id != 0;
@@ -97,10 +101,13 @@ static int load_image(void)
                 &image_flags,
                 sizeof(image_flags));
 
-            if (status != FWK_SUCCESS)
+            if (status != FWK_SUCCESS) {
                 return status;
-            if ((image_flags & (uint32_t)IMAGE_FLAGS_VALID_MASK) != (uint32_t)0)
+            }
+            if ((image_flags & (uint32_t)IMAGE_FLAGS_VALID_MASK) !=
+                (uint32_t)0) {
                 break;
+            }
         }
 
         /*
@@ -113,23 +120,28 @@ static int load_image(void)
             &image_offset,
             sizeof(image_offset));
 
-        if (status != FWK_SUCCESS)
+        if (status != FWK_SUCCESS) {
             return status;
+        }
         status = module_ctx.sds_api->struct_read(
             module_ctx.module_config->sds_struct_id,
             BOOTLOADER_STRUCT_IMAGE_SIZE_POS,
             &image_size,
             sizeof(image_size));
 
-        if (status != FWK_SUCCESS)
+        if (status != FWK_SUCCESS) {
             return status;
+        }
 
-        if (image_size == 0)
+        if (image_size == 0) {
             return FWK_E_SIZE;
-        if ((image_offset % 4) != 0)
+        }
+        if ((image_offset % 4) != 0) {
             return FWK_E_ALIGN;
-        if (image_offset > module_ctx.module_config->source_size)
+        }
+        if (image_offset > module_ctx.module_config->source_size) {
             return FWK_E_SIZE;
+        }
 
         /* Read the image header now that its base address is known */
         image_base = (const uint8_t *)module_ctx.module_config->source_base +
@@ -141,8 +153,9 @@ static int load_image(void)
     }
 
     if (module_ctx.module_config->destination_size > 0) {
-        if (image_size > module_ctx.module_config->destination_size)
+        if (image_size > module_ctx.module_config->destination_size) {
             return FWK_E_SIZE;
+        }
     }
 
     fwk_interrupt_global_disable(); /* We are relocating the vector table */
@@ -180,12 +193,14 @@ static int bootloader_bind(fwk_id_t id, unsigned int call_number)
     int status;
 
     /* Only the first round of binding is used (round number is zero-indexed) */
-    if (call_number == 1)
+    if (call_number == 1) {
         return FWK_SUCCESS;
+    }
 
-    if (fwk_module_is_valid_element_id(id))
+    if (fwk_module_is_valid_element_id(id)) {
         /* No element-level binding required */
         return FWK_SUCCESS;
+    }
 
     status = fwk_module_bind(FWK_ID_MODULE(FWK_MODULE_IDX_SDS),
                              FWK_ID_API(FWK_MODULE_IDX_SDS, 0),
@@ -198,11 +213,13 @@ static int bootloader_bind(fwk_id_t id, unsigned int call_number)
 static int bootloader_process_bind_request(fwk_id_t requester_id, fwk_id_t id,
     fwk_id_t api_id, const void **api)
 {
-    if (api == NULL)
+    if (api == NULL) {
         return FWK_E_PARAM;
+    }
 
-    if (!fwk_module_is_valid_module_id(id))
+    if (!fwk_module_is_valid_module_id(id)) {
         return FWK_E_PARAM;
+    }
 
     *api = &bootloader_api;
     return FWK_SUCCESS;

--- a/module/pl011/src/mod_pl011.c
+++ b/module/pl011/src/mod_pl011.c
@@ -169,8 +169,9 @@ static void mod_pl011_putch(fwk_id_t id, char ch)
     fwk_assert(ctx->powered);
     fwk_assert(ctx->clocked);
 
-    while (reg->FR & PL011_FR_TXFF)
+    while (reg->FR & PL011_FR_TXFF) {
         continue;
+    }
 
     reg->DR = ch;
 }
@@ -186,8 +187,9 @@ static bool mod_pl011_getch(fwk_id_t id, char *ch)
     fwk_assert(ctx->powered);
     fwk_assert(ctx->clocked);
 
-    if (reg->FR & PL011_FR_RXFE)
+    if (reg->FR & PL011_FR_RXFE) {
         return false;
+    }
 
     *ch = reg->DR;
 
@@ -205,8 +207,9 @@ static void mod_pl011_flush(fwk_id_t id)
     fwk_assert(ctx->powered);
     fwk_assert(ctx->clocked);
 
-    while (reg->FR & PL011_FR_BUSY)
+    while (reg->FR & PL011_FR_BUSY) {
         continue;
+    }
 }
 
 static int mod_pl011_init(

--- a/module/scmi/src/mod_scmi.c
+++ b/module/scmi/src/mod_scmi.c
@@ -557,8 +557,9 @@ static int scmi_notification_add_subscriber(
         notification_subscribers(protocol_id);
 
     status = get_agent_id(service_id, &agent_idx);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 
     fwk_assert(operation_id < MOD_SCMI_PROTOCOL_MAX_OPERATION_ID);
     /*
@@ -1597,8 +1598,9 @@ static int scmi_process_bind_request(fwk_id_t source_id, fwk_id_t target_id,
 
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS
     case MOD_SCMI_API_IDX_NOTIFICATION:
-        if (!fwk_id_is_type(target_id, FWK_ID_TYPE_MODULE))
+        if (!fwk_id_is_type(target_id, FWK_ID_TYPE_MODULE)) {
             return FWK_E_SUPPORT;
+        }
 
         *api = &mod_scmi_notification_api;
         break;

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -323,8 +323,9 @@ static int scmi_perf_protocol_message_attributes_handler(fwk_id_t service_id,
     return_values.attributes = 0;
 #ifdef BUILD_HAS_FAST_CHANNELS
     if ((parameters->message_id <= MOD_SCMI_PERF_LEVEL_GET) &&
-        (parameters->message_id >= MOD_SCMI_PERF_LIMITS_SET))
+        (parameters->message_id >= MOD_SCMI_PERF_LIMITS_SET)) {
         return_values.attributes = 1; /* Fast Channel available */
+    }
 #endif
 
     scmi_perf_ctx.scmi_api->respond(service_id, &return_values,
@@ -391,8 +392,9 @@ static int scmi_perf_domain_attributes_handler(fwk_id_t service_id,
     const struct mod_scmi_perf_domain_config *domain =
         &(*scmi_perf_ctx.config->domains)[parameters->domain_id];
 
-    if (domain->fast_channels_addr_scp != NULL)
+    if (domain->fast_channels_addr_scp != NULL) {
         fast_channels = true;
+    }
 #endif
     return_values = (struct scmi_perf_domain_attributes_p2a){
         .status = SCMI_SUCCESS,
@@ -819,22 +821,24 @@ static int scmi_perf_limits_notify(fwk_id_t service_id,
     }
 
     status = scmi_perf_ctx.scmi_api->get_agent_id(service_id, &agent_id);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         goto exit;
+    }
 
-    if (parameters->notify_enable)
+    if (parameters->notify_enable) {
         scmi_perf_ctx.scmi_notification_api->scmi_notification_add_subscriber(
             MOD_SCMI_PROTOCOL_ID_PERF,
             id,
             MOD_SCMI_PERF_NOTIFY_LIMITS,
             service_id);
-    else
+    } else {
         scmi_perf_ctx.scmi_notification_api
             ->scmi_notification_remove_subscriber(
                 MOD_SCMI_PROTOCOL_ID_PERF,
                 agent_id,
                 id,
                 MOD_SCMI_PERF_NOTIFY_LIMITS);
+    }
 
     return_values.status = SCMI_SUCCESS;
 
@@ -877,22 +881,24 @@ static int scmi_perf_level_notify(fwk_id_t service_id,
     id = parameters->domain_id;
 
     status = scmi_perf_ctx.scmi_api->get_agent_id(service_id, &agent_id);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         goto exit;
+    }
 
-    if (parameters->notify_enable)
+    if (parameters->notify_enable) {
         scmi_perf_ctx.scmi_notification_api->scmi_notification_add_subscriber(
             MOD_SCMI_PROTOCOL_ID_PERF,
             id,
             MOD_SCMI_PERF_NOTIFY_LEVEL,
             service_id);
-    else
+    } else {
         scmi_perf_ctx.scmi_notification_api
             ->scmi_notification_remove_subscriber(
                 MOD_SCMI_PROTOCOL_ID_PERF,
                 agent_id,
                 id,
                 MOD_SCMI_PERF_NOTIFY_LEVEL);
+    }
 
     return_values.status = SCMI_SUCCESS;
 
@@ -1023,8 +1029,10 @@ static void fast_channel_callback(uintptr_t param)
                     FWK_ID_ELEMENT(FWK_MODULE_IDX_DVFS, i), 0, *set_level);
             }
             if (set_limit != NULL) {
-                if ((set_limit->range_max == 0) && (set_limit->range_min == 0))
+                if ((set_limit->range_max == 0) &&
+                    (set_limit->range_min == 0)) {
                     continue;
+                }
                 scmi_perf_ctx.dvfs_api->set_level_limits(
                     FWK_ID_ELEMENT(FWK_MODULE_IDX_DVFS, i),
                     0,
@@ -1225,9 +1233,10 @@ static void scmi_perf_notify_level_updated(
 
 #ifdef BUILD_HAS_MOD_STATISTICS
     status = scmi_perf_ctx.dvfs_api->get_level_id(domain_id, level, &level_id);
-    if (status == FWK_SUCCESS)
+    if (status == FWK_SUCCESS) {
         scmi_perf_ctx.stats_api->update_domain(fwk_module_id_scmi_perf,
             FWK_ID_ELEMENT(FWK_MODULE_IDX_SCMI_PERF, idx), level_id);
+    }
 #endif
 
     domain = &(*scmi_perf_ctx.config->domains)[idx];
@@ -1286,11 +1295,12 @@ static int scmi_perf_init(fwk_id_t module_id, unsigned int element_count,
     scmi_perf_ctx.domain_count = return_val;
 #ifdef BUILD_HAS_FAST_CHANNELS
     scmi_perf_ctx.fast_channels_alarm_id = config->fast_channels_alarm_id;
-    if (config->fast_channels_rate_limit < SCMI_PERF_FC_MIN_RATE_LIMIT)
+    if (config->fast_channels_rate_limit < SCMI_PERF_FC_MIN_RATE_LIMIT) {
         scmi_perf_ctx.fast_channels_rate_limit = SCMI_PERF_FC_MIN_RATE_LIMIT;
-    else
+    } else {
         scmi_perf_ctx.fast_channels_rate_limit =
             config->fast_channels_rate_limit;
+    }
 #endif
 
     /* Initialize table */
@@ -1308,8 +1318,9 @@ static int scmi_init_notifications(int domains)
 
     status = scmi_perf_ctx.scmi_api->get_agent_count(
         &scmi_perf_ctx.agent_count);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 
     fwk_assert(scmi_perf_ctx.agent_count != 0);
 
@@ -1343,8 +1354,9 @@ static int scmi_perf_bind(fwk_id_t id, unsigned int round)
         FWK_ID_MODULE(FWK_MODULE_IDX_SCMI),
         FWK_ID_API(FWK_MODULE_IDX_SCMI, MOD_SCMI_API_IDX_NOTIFICATION),
         &scmi_perf_ctx.scmi_notification_api);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 #endif
 
 #ifdef BUILD_HAS_FAST_CHANNELS
@@ -1352,8 +1364,9 @@ static int scmi_perf_bind(fwk_id_t id, unsigned int round)
         FWK_ID_NONE)) {
         status = fwk_module_bind(scmi_perf_ctx.config->fast_channels_alarm_id,
             MOD_TIMER_API_ID_ALARM, &scmi_perf_ctx.fc_alarm_api);
-        if (status != FWK_SUCCESS)
+        if (status != FWK_SUCCESS) {
             return FWK_E_PANIC;
+        }
     }
 #endif
 
@@ -1362,8 +1375,9 @@ static int scmi_perf_bind(fwk_id_t id, unsigned int round)
         status = fwk_module_bind(FWK_ID_MODULE(FWK_MODULE_IDX_STATISTICS),
             FWK_ID_API(FWK_MODULE_IDX_STATISTICS, MOD_STATS_API_IDX_STATS),
             &scmi_perf_ctx.stats_api);
-        if (status != FWK_SUCCESS)
+        if (status != FWK_SUCCESS) {
             return FWK_E_PANIC;
+        }
     }
 #endif
 
@@ -1409,21 +1423,24 @@ static int scmi_perf_stats_start(void)
     int stats_domains = 0;
     unsigned int i;
 
-    if (!scmi_perf_ctx.config->stats_enabled)
+    if (!scmi_perf_ctx.config->stats_enabled) {
         return FWK_E_SUPPORT;
+    }
 
     /* Count how many domains have statistics */
     for (i = 0; i < scmi_perf_ctx.domain_count; i++) {
         domain = &(*scmi_perf_ctx.config->domains)[i];
-        if (domain->stats_collected)
+        if (domain->stats_collected) {
             stats_domains++;
+        }
     }
 
     status = scmi_perf_ctx.stats_api->init_stats(fwk_module_id_scmi_perf,
         scmi_perf_ctx.domain_count, stats_domains);
 
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 
     for (i = 0; i < scmi_perf_ctx.domain_count; i++) {
         domain = &(*scmi_perf_ctx.config->domains)[i];
@@ -1436,16 +1453,18 @@ static int scmi_perf_stats_start(void)
             status = scmi_perf_ctx.dvfs_api->get_opp_count(domain_id,
                 &opp_count);
 
-            if (status != FWK_SUCCESS)
+            if (status != FWK_SUCCESS) {
                 return status;
+            }
 
             status = scmi_perf_ctx.stats_api->add_domain(
                 fwk_module_id_scmi_perf,
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_SCMI_PERF, i),
                 (int)opp_count);
 
-            if (status != FWK_SUCCESS)
+            if (status != FWK_SUCCESS) {
                 return status;
+            }
         }
     }
 
@@ -1470,17 +1489,19 @@ static int scmi_perf_start(fwk_id_t id)
     if (!fwk_id_is_equal(scmi_perf_ctx.config->fast_channels_alarm_id,
         FWK_ID_NONE)) {
         if (scmi_perf_ctx.config->fast_channels_rate_limit <
-            SCMI_PERF_FC_MIN_RATE_LIMIT)
+            SCMI_PERF_FC_MIN_RATE_LIMIT) {
             fc_interval_msecs = (uint32_t)SCMI_PERF_FC_MIN_RATE_LIMIT / 1000;
-        else
+        } else {
             fc_interval_msecs = (uint32_t)
             scmi_perf_ctx.config->fast_channels_rate_limit / 1000;
+        }
         status = scmi_perf_ctx.fc_alarm_api->start(
             scmi_perf_ctx.config->fast_channels_alarm_id,
             fc_interval_msecs, MOD_TIMER_ALARM_TYPE_PERIODIC,
             fast_channel_callback, (uintptr_t)0);
-        if (status != FWK_SUCCESS)
+        if (status != FWK_SUCCESS) {
             return status;
+        }
     }
 
     for (i = 0; i < scmi_perf_ctx.domain_count; i++) {
@@ -1488,8 +1509,9 @@ static int scmi_perf_start(fwk_id_t id)
         if (domain->fast_channels_addr_scp != NULL) {
             for (j = 0; j < MOD_SCMI_PERF_FAST_CHANNEL_ADDR_INDEX_COUNT; j++) {
                 fc_elem = (void *)(uintptr_t)domain->fast_channels_addr_scp[j];
-                if (fc_elem != NULL)
+                if (fc_elem != NULL) {
                     memset(fc_elem, 0, fast_channel_elem_size[j]);
+                }
             }
         }
     }
@@ -1497,14 +1519,16 @@ static int scmi_perf_start(fwk_id_t id)
 
 #ifdef BUILD_HAS_MOD_STATISTICS
     status = scmi_perf_stats_start();
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 #endif
 
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS
     status = scmi_init_notifications(scmi_perf_ctx.domain_count);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 #endif
 
     return status;

--- a/module/scmi_power_domain/src/mod_scmi_power_domain.c
+++ b/module/scmi_power_domain/src/mod_scmi_power_domain.c
@@ -1114,8 +1114,9 @@ static int scmi_init_notifications(unsigned int domains)
     int status;
 
     status = scmi_pd_ctx.scmi_api->get_agent_count(&scmi_pd_ctx.agent_count);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
     fwk_assert(scmi_pd_ctx.agent_count != 0);
 
     status = scmi_pd_ctx.scmi_notification_api->scmi_notification_init(
@@ -1124,8 +1125,9 @@ static int scmi_init_notifications(unsigned int domains)
         domains,
         MOD_SCMI_PD_NOTIFICATION_COUNT);
 
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 
     return FWK_SUCCESS;
 }
@@ -1151,8 +1153,9 @@ static int scmi_pd_bind(fwk_id_t id, unsigned int round)
         FWK_ID_MODULE(FWK_MODULE_IDX_SCMI),
         FWK_ID_API(FWK_MODULE_IDX_SCMI, MOD_SCMI_API_IDX_NOTIFICATION),
         &scmi_pd_ctx.scmi_notification_api);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 #endif
 
 #ifdef BUILD_HAS_MOD_DEBUG
@@ -1370,8 +1373,9 @@ static int scmi_pd_start(fwk_id_t id)
     int status = FWK_SUCCESS;
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS
     status = scmi_init_notifications(scmi_pd_ctx.domain_count);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 #endif
     return status;
 }

--- a/module/scmi_sensor/src/mod_scmi_sensor.c
+++ b/module/scmi_sensor/src/mod_scmi_sensor.c
@@ -759,8 +759,9 @@ static int scmi_init_notifications(int sensor_count)
 
     status =
         scmi_sensor_ctx.scmi_api->get_agent_count(&scmi_sensor_ctx.agent_count);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 
     fwk_assert(scmi_sensor_ctx.agent_count != 0);
 
@@ -816,8 +817,9 @@ static int scmi_sensor_bind(fwk_id_t id, unsigned int round)
         FWK_ID_MODULE(FWK_MODULE_IDX_SCMI),
         FWK_ID_API(FWK_MODULE_IDX_SCMI, MOD_SCMI_API_IDX_NOTIFICATION),
         &scmi_sensor_ctx.scmi_notification_api);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 #endif
 
     return FWK_SUCCESS;
@@ -829,8 +831,9 @@ static int scmi_sensor_start(fwk_id_t id)
 
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS
     status = scmi_init_notifications(scmi_sensor_ctx.sensor_count);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
 #endif
 
     return status;

--- a/module/scmi_system_power/include/internal/scmi_system_power.h
+++ b/module/scmi_system_power/include/internal/scmi_system_power.h
@@ -60,7 +60,7 @@ struct scmi_sys_power_state_get_p2a {
  * SYSTEM_POWER_STATE_NOTIFY
  */
 
-#define STATE_NOTIFY_FLAGS_MASK 0x1
+#define STATE_NOTIFY_FLAGS_MASK 0x1U
 
 struct scmi_sys_power_state_notify_a2p {
     uint32_t flags;

--- a/module/scmi_system_power/src/mod_scmi_system_power.c
+++ b/module/scmi_system_power/src/mod_scmi_system_power.c
@@ -137,20 +137,24 @@ static void scmi_sys_power_state_notify(fwk_id_t service_id,
     int status, i;
 
     status = scmi_sys_power_ctx.scmi_api->get_agent_id(service_id, &agent_id);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return;
+    }
 
     return_values.agent_id = (uint32_t)agent_id;
     return_values.system_state = system_state;
-    if (forceful)
+    if (forceful) {
         return_values.flags = 0;
-    else
+    } else {
         return_values.flags = 1;
+    }
 
     for (i = 0; i < scmi_sys_power_ctx.agent_count; i++) {
         id =  scmi_sys_power_ctx.system_power_notifications[i];
-        if (fwk_id_is_equal(id, FWK_ID_NONE) || fwk_id_is_equal(id, service_id))
+        if (fwk_id_is_equal(id, FWK_ID_NONE) ||
+            fwk_id_is_equal(id, service_id)) {
             continue;
+        }
 
         scmi_sys_power_ctx.scmi_api->notify(id,
             MOD_SCMI_PROTOCOL_ID_SYS_POWER, SCMI_SYS_POWER_STATE_SET_NOTIFY,
@@ -388,11 +392,12 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
      * requests the notifications are sent before executing the command.
      */
     if (!(parameters->flags & STATE_SET_FLAGS_GRACEFUL_REQUEST) ||
-        (scmi_system_state != SCMI_SYSTEM_STATE_SHUTDOWN))
+        (scmi_system_state != SCMI_SYSTEM_STATE_SHUTDOWN)) {
         scmi_sys_power_state_notify(
             service_id,
             scmi_system_state,
             parameters->flags & STATE_SET_FLAGS_GRACEFUL_REQUEST);
+    }
 #endif
 
     return_values.status = SCMI_SUCCESS;
@@ -471,8 +476,9 @@ static int scmi_sys_power_state_notify_handler(fwk_id_t service_id,
     int status;
 
     status = scmi_sys_power_ctx.scmi_api->get_agent_id(service_id, &agent_id);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         goto exit;
+    }
 
     parameters = (const struct scmi_sys_power_state_notify_a2p *)payload;
 
@@ -481,10 +487,11 @@ static int scmi_sys_power_state_notify_handler(fwk_id_t service_id,
         goto exit;
     }
 
-    if (parameters->flags & STATE_NOTIFY_FLAGS_MASK)
+    if (parameters->flags & STATE_NOTIFY_FLAGS_MASK) {
         scmi_sys_power_ctx.system_power_notifications[agent_id] = service_id;
-    else
+    } else {
         scmi_sys_power_ctx.system_power_notifications[agent_id] = FWK_ID_NONE;
+    }
 
     return_values.status = SCMI_SUCCESS;
 
@@ -665,18 +672,19 @@ static int scmi_sys_power_init_notifications(void)
     int status;
     int i;
 
-
     status = scmi_sys_power_ctx.scmi_api->get_agent_count(
         &scmi_sys_power_ctx.agent_count);
-    if (status != FWK_SUCCESS)
+    if (status != FWK_SUCCESS) {
         return status;
+    }
     fwk_assert(scmi_sys_power_ctx.agent_count != 0);
 
     scmi_sys_power_ctx.system_power_notifications = fwk_mm_calloc(
         scmi_sys_power_ctx.agent_count, sizeof(fwk_id_t));
 
-    for (i = 0; i < scmi_sys_power_ctx.agent_count; i++)
+    for (i = 0; i < scmi_sys_power_ctx.agent_count; i++) {
         scmi_sys_power_ctx.system_power_notifications[i] = FWK_ID_NONE;
+    }
 
     return FWK_SUCCESS;
 
@@ -736,8 +744,9 @@ static int scmi_sys_power_bind(fwk_id_t id, unsigned int round)
             scmi_sys_power_ctx.config->alarm_id,
             MOD_TIMER_API_ID_ALARM,
             &scmi_sys_power_ctx.alarm_api);
-        if (status != FWK_SUCCESS)
+        if (status != FWK_SUCCESS) {
             return status;
+        }
         return scmi_sys_power_init_notifications();
     }
 #endif

--- a/module/scmi_system_power/src/mod_scmi_system_power.c
+++ b/module/scmi_system_power/src/mod_scmi_system_power.c
@@ -391,7 +391,7 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
      * Only send notifications if this is a forceful request. For graceful
      * requests the notifications are sent before executing the command.
      */
-    if (!(parameters->flags & STATE_SET_FLAGS_GRACEFUL_REQUEST) ||
+    if (((parameters->flags & STATE_SET_FLAGS_GRACEFUL_REQUEST) == 0U) ||
         (scmi_system_state != SCMI_SYSTEM_STATE_SHUTDOWN)) {
         scmi_sys_power_state_notify(
             service_id,

--- a/module/statistics/src/mod_stats.c
+++ b/module/statistics/src/mod_stats.c
@@ -48,12 +48,14 @@ static struct mod_stats_ctx stats_ctx;
 static struct mod_stats_info *get_module_stats_info(fwk_id_t module_id)
 {
     if (fwk_id_get_module_idx(module_id) ==
-        fwk_id_get_module_idx(fwk_module_id_scmi_perf))
+        fwk_id_get_module_idx(fwk_module_id_scmi_perf)) {
         return stats_ctx.perf_stats;
+    }
 
     if (fwk_id_get_module_idx(module_id) ==
-        fwk_id_get_module_idx(fwk_module_id_scmi_power_domain))
+        fwk_id_get_module_idx(fwk_module_id_scmi_power_domain)) {
         return stats_ctx.power_stats;
+    }
 
     return NULL;
 }
@@ -94,8 +96,9 @@ static int allocate_domain_stats(fwk_id_t module_id,
     uint32_t idx;
 
     stats = get_module_stats_info(module_id);
-    if (!stats)
+    if (!stats) {
         return FWK_E_PARAM;
+    }
 
     idx = fwk_id_get_element_idx(domain_id);
     desc_header = stats->desc_header;
@@ -183,8 +186,9 @@ _allocate_stats_context(int domain_count, int used_domains)
 
     /* Set default values indicating that the domain is not used in
      * statistics collection */
-    for (i = 0; i < domain_count; i++)
+    for (i = 0; i < domain_count; i++) {
         stats->context->se_index_map[i] = FWK_E_SUPPORT;
+    }
 
     stats->context->se_total_num = domain_count;
     stats->context->se_used_num = used_domains;
@@ -221,8 +225,9 @@ static int stats_init_module(fwk_id_t module_id,
     fwk_assert(ret == FWK_SUCCESS);
 
     ret = _allocate_header(stats, domain_count);
-    if (ret != FWK_SUCCESS)
+    if (ret != FWK_SUCCESS) {
         return ret;
+    }
 
     stats->desc_header->signature = stats->type_signature;
     stats->desc_header->domain_count = domain_count;
@@ -235,8 +240,9 @@ static int stats_start_module(fwk_id_t module_id)
     struct mod_stats_info *stats;
 
     stats = get_module_stats_info(module_id);
-    if (!stats)
+    if (!stats) {
         return FWK_E_PARAM;
+    }
 
     if (stats->mode == STATS_SETUP) {
         if (stats->context->last_stats_id == stats->context->se_used_num) {
@@ -261,14 +267,16 @@ get_domain_section_data(fwk_id_t module_id, fwk_id_t domain_id)
 
     idx = fwk_id_get_element_idx(domain_id);
     stats = get_module_stats_info(module_id);
-    if (!stats)
+    if (!stats) {
         return NULL;
+    }
 
     fwk_assert((int)idx < stats->context->se_total_num);
 
     stats_id = stats->context->se_index_map[idx];
-    if (stats_id != FWK_E_SUPPORT)
+    if (stats_id != FWK_E_SUPPORT) {
         domain_stats = stats->context->se_stats_map->se_stats[stats_id];
+    }
 
     return domain_stats;
 }
@@ -285,18 +293,21 @@ static int stats_add_domain(fwk_id_t module_id,
 
     idx = fwk_id_get_element_idx(domain_id);
     stats = get_module_stats_info(module_id);
-    if (!stats)
+    if (!stats) {
         return FWK_E_PARAM;
+    }
 
     fwk_assert((int)idx < stats->context->se_total_num);
 
     ret = allocate_domain_stats(module_id, domain_id, level_count);
-    if (ret != FWK_SUCCESS)
+    if (ret != FWK_SUCCESS) {
         return ret;
+    }
 
     domain_stats = get_domain_section_data(module_id, domain_id);
-    if (domain_stats == NULL)
+    if (domain_stats == NULL) {
         return FWK_E_PARAM;
+    }
 
     domain_stats->level_count = level_count;
 
@@ -334,23 +345,27 @@ stats_update_domain(fwk_id_t module_id, fwk_id_t domain_id, uint32_t level_id)
     int stats_id;
 
     stats = get_module_stats_info(module_id);
-    if (!stats)
+    if (!stats) {
         return FWK_E_PARAM;
+    }
 
-    if (stats->mode != STATS_INITIALIZED)
+    if (stats->mode != STATS_INITIALIZED) {
         return FWK_E_SUPPORT;
+    }
 
     domain_stats = get_domain_section_data(module_id, domain_id);
-    if (domain_stats == NULL)
+    if (domain_stats == NULL) {
         return FWK_E_PARAM;
+    }
 
     idx = fwk_id_get_element_idx(domain_id);
 
     se_map = stats->context->se_stats_map;
     stats_id = stats->context->se_index_map[idx];
 
-    if ((int)level_id >= se_map->se_level_count[stats_id])
+    if ((int)level_id >= se_map->se_level_count[stats_id]) {
         return FWK_E_PARAM;
+    }
 
     ts_now_us = _get_curret_ts_us();
 
@@ -384,11 +399,13 @@ get_statistics_desc(fwk_id_t module_id,
     uint64_t ap_stats_addr;
 
     stats = get_module_stats_info(module_id);
-    if (!stats)
+    if (!stats) {
         return FWK_E_PARAM;
+    }
 
-    if (stats->mode != STATS_INITIALIZED)
+    if (stats->mode != STATS_INITIALIZED) {
         return FWK_E_SUPPORT;
+    }
 
     ap_stats_addr = stats_ctx.config->ap_stats_addr;
     ap_stats_addr += stats->desc_header_offset;
@@ -420,17 +437,20 @@ static void update_all_domains_current_level(fwk_id_t module_id)
     int stats_id, i;
 
     stats = get_module_stats_info(module_id);
-    if (!stats)
+    if (!stats) {
         return;
+    }
 
-    if (stats->mode != STATS_INITIALIZED)
+    if (stats->mode != STATS_INITIALIZED) {
         return;
+    }
 
     for (i = 0; i < stats->context->se_total_num; i++) {
         domain_id = FWK_ID_ELEMENT(fwk_id_get_module_idx(module_id), i);
         domain_stats = get_domain_section_data(module_id, domain_id);
-        if (!domain_stats)
+        if (!domain_stats) {
             continue;
+        }
 
         se_map = stats->context->se_stats_map;
         stats_id = stats->context->se_index_map[i];
@@ -511,8 +531,9 @@ static int stats_start(fwk_id_t id)
             STATS_UPDATE_PERIOD_MS, MOD_TIMER_ALARM_TYPE_PERIODIC,
             periodic_update_callback, (uintptr_t)0);
 
-        if (status != FWK_SUCCESS)
+        if (status != FWK_SUCCESS) {
             return status;
+        }
     } else {
         FWK_LOG_ERR("[STATS]: failed to start period updates\n");
         return FWK_E_SUPPORT;
@@ -525,14 +546,16 @@ static int stats_bind(fwk_id_t id, unsigned int round)
 {
     int status;
 
-    if (round >= 1)
+    if (round >= 1) {
         return FWK_SUCCESS;
+    }
 
     if (!fwk_id_is_equal(stats_ctx.config->alarm_id, FWK_ID_NONE)) {
         status = fwk_module_bind(stats_ctx.config->alarm_id,
             MOD_TIMER_API_ID_ALARM, &stats_ctx.alarm_api);
-        if (status != FWK_SUCCESS)
+        if (status != FWK_SUCCESS) {
             return FWK_E_PANIC;
+        }
     }
 
     return FWK_SUCCESS;
@@ -544,20 +567,23 @@ static int process_bind_request(fwk_id_t source_id,
     const void **api)
 {
     /* Only allow binding to the module */
-    if (!fwk_id_is_equal(target_id, fwk_module_id_statistics))
+    if (!fwk_id_is_equal(target_id, fwk_module_id_statistics)) {
         return FWK_E_PARAM;
+    }
 
     *api = &mod_stats_api;
 
     /* Request from SCMI Performance domain statistics */
     if (fwk_id_get_module_idx(source_id) ==
-        fwk_id_get_module_idx(fwk_module_id_scmi_perf))
+        fwk_id_get_module_idx(fwk_module_id_scmi_perf)) {
         return register_module_stats(fwk_module_id_scmi_perf);
+    }
 
     /* Request from SCMI Power domain statistics*/
     if (fwk_id_get_module_idx(source_id) ==
-        fwk_id_get_module_idx(fwk_module_id_scmi_power_domain))
+        fwk_id_get_module_idx(fwk_module_id_scmi_power_domain)) {
         return register_module_stats(fwk_module_id_scmi_power_domain);
+    }
 
     return FWK_E_PARAM;
 }

--- a/module/statistics/src/mod_stats.c
+++ b/module/statistics/src/mod_stats.c
@@ -96,7 +96,7 @@ static int allocate_domain_stats(fwk_id_t module_id,
     uint32_t idx;
 
     stats = get_module_stats_info(module_id);
-    if (!stats) {
+    if (stats == NULL) {
         return FWK_E_PARAM;
     }
 
@@ -240,7 +240,7 @@ static int stats_start_module(fwk_id_t module_id)
     struct mod_stats_info *stats;
 
     stats = get_module_stats_info(module_id);
-    if (!stats) {
+    if (stats == NULL) {
         return FWK_E_PARAM;
     }
 
@@ -267,7 +267,7 @@ get_domain_section_data(fwk_id_t module_id, fwk_id_t domain_id)
 
     idx = fwk_id_get_element_idx(domain_id);
     stats = get_module_stats_info(module_id);
-    if (!stats) {
+    if (stats == NULL) {
         return NULL;
     }
 
@@ -293,7 +293,7 @@ static int stats_add_domain(fwk_id_t module_id,
 
     idx = fwk_id_get_element_idx(domain_id);
     stats = get_module_stats_info(module_id);
-    if (!stats) {
+    if (stats == NULL) {
         return FWK_E_PARAM;
     }
 
@@ -345,7 +345,7 @@ stats_update_domain(fwk_id_t module_id, fwk_id_t domain_id, uint32_t level_id)
     int stats_id;
 
     stats = get_module_stats_info(module_id);
-    if (!stats) {
+    if (stats == NULL) {
         return FWK_E_PARAM;
     }
 
@@ -399,7 +399,7 @@ get_statistics_desc(fwk_id_t module_id,
     uint64_t ap_stats_addr;
 
     stats = get_module_stats_info(module_id);
-    if (!stats) {
+    if (stats == NULL) {
         return FWK_E_PARAM;
     }
 
@@ -437,7 +437,7 @@ static void update_all_domains_current_level(fwk_id_t module_id)
     int stats_id, i;
 
     stats = get_module_stats_info(module_id);
-    if (!stats) {
+    if (stats == NULL) {
         return;
     }
 
@@ -448,7 +448,7 @@ static void update_all_domains_current_level(fwk_id_t module_id)
     for (i = 0; i < stats->context->se_total_num; i++) {
         domain_id = FWK_ID_ELEMENT(fwk_id_get_module_idx(module_id), i);
         domain_stats = get_domain_section_data(module_id, domain_id);
-        if (!domain_stats) {
+        if (domain_stats == NULL) {
             continue;
         }
 

--- a/product/juno/scp_romfw_bypass/config_sds.c
+++ b/product/juno/scp_romfw_bypass/config_sds.c
@@ -149,8 +149,9 @@ static const struct fwk_element *get_element_table(fwk_id_t module_id)
     platid.platform_identifier = SSC->SSC_VERSION;
 
     status = juno_id_get_platform(&platform_id);
-    if (!fwk_expect(status == FWK_SUCCESS))
+    if (!fwk_expect(status == FWK_SUCCESS)) {
         return NULL;
+    }
     platid.platform_type_identifier = (uint32_t)platform_id;
 
     /*


### PR DESCRIPTION
This PR contains additional fixes for MISRAC required rules 15.6 and 10.1.

Rule 15.6: The body of an iteration‑statement or a selection‑statement shall be a compound‑statement
Rule 10.1: Operands shall not be of an inappropriate essential type
