### PR TITLE
Fix to protect fwk_signal_ctx from interrupts

### DIFF
--- a/framework/src/fwk_thread.c
+++ b/framework/src/fwk_thread.c
@@ -200,15 +200,17 @@ static bool fwk_process_signal()
                 break;
             }
         }
-        fwk_interrupt_global_enable();
 
         if (i == FWK_MODULE_SIGNAL_COUNT) {
             fwk_signal_ctx.current_signal.target_id = FWK_ID_NONE;
+            fwk_interrupt_global_enable();
             return false;
         }
 
         fwk_signal_ctx.pending_signals--;
         fwk_signal_ctx.signals[i].target_id = FWK_ID_NONE;
+        fwk_interrupt_global_enable();
+
         execute_signal_handler(signal.target_id, signal.signal_id);
 
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE


### PR DESCRIPTION
Since fwk_process_signal() enable global interrupt before updating 
fwk_signal_ctx.pending_signals, there can race with the increment
operation in fwk_thread_put_signal().
Call fwk_interrupt_global_enable() after updating the fwk_signal_ctx,
so that it can be protected by fwk_thread_put_signal().

Reported-by: Kazuhiko Sakamoto <sakamoto.kazuhiko@socionext.com>
Signed-off-by: Masami Hiramatsu <masami.hiramatsu@linaro.org>