### PR TITLE
MISRA 10.3 Defects within Module and Framework

### DIFF
--- a/framework/include/fwk_id.h
+++ b/framework/include/fwk_id.h
@@ -69,7 +69,7 @@ enum fwk_id_type {
 #define FWK_ID_NONE_INIT \
     { \
         .common = { \
-            .type = __FWK_ID_TYPE_NONE, \
+            .type = (uint32_t)__FWK_ID_TYPE_NONE, \
         }, \
     }
 
@@ -112,8 +112,8 @@ enum fwk_id_type {
 #define FWK_ID_MODULE_INIT(MODULE_IDX) \
     { \
         .common = { \
-            .type = __FWK_ID_TYPE_MODULE, \
-            .module_idx = MODULE_IDX, \
+            .type = (uint32_t)__FWK_ID_TYPE_MODULE, \
+            .module_idx = (uint32_t)MODULE_IDX, \
         }, \
     }
 
@@ -156,9 +156,9 @@ enum fwk_id_type {
 #define FWK_ID_ELEMENT_INIT(MODULE_IDX, ELEMENT_IDX) \
     { \
         .element = { \
-            .type = __FWK_ID_TYPE_ELEMENT, \
-            .module_idx = MODULE_IDX, \
-            .element_idx = ELEMENT_IDX, \
+            .type = (uint32_t)__FWK_ID_TYPE_ELEMENT, \
+            .module_idx = (uint32_t)MODULE_IDX, \
+            .element_idx = (uint32_t)ELEMENT_IDX, \
         }, \
     }
 
@@ -206,10 +206,10 @@ enum fwk_id_type {
 #define FWK_ID_SUB_ELEMENT_INIT(MODULE_IDX, ELEMENT_IDX, SUB_ELEMENT_IDX) \
     { \
         .sub_element = { \
-            .type = __FWK_ID_TYPE_SUB_ELEMENT, \
-            .module_idx = MODULE_IDX, \
-            .element_idx = ELEMENT_IDX, \
-            .sub_element_idx = SUB_ELEMENT_IDX, \
+            .type = (uint32_t)__FWK_ID_TYPE_SUB_ELEMENT, \
+            .module_idx = (uint32_t)MODULE_IDX, \
+            .element_idx = (uint32_t)ELEMENT_IDX, \
+            .sub_element_idx = (uint32_t)SUB_ELEMENT_IDX, \
         }, \
     }
 
@@ -257,9 +257,9 @@ enum fwk_id_type {
 #define FWK_ID_API_INIT(MODULE_IDX, API_IDX) \
     { \
         .api = { \
-            .type = __FWK_ID_TYPE_API, \
-            .module_idx = MODULE_IDX, \
-            .api_idx = API_IDX, \
+            .type = (uint32_t)__FWK_ID_TYPE_API, \
+            .module_idx = (uint32_t)MODULE_IDX, \
+            .api_idx = (uint32_t)API_IDX, \
         }, \
     }
 
@@ -304,9 +304,9 @@ enum fwk_id_type {
 #define FWK_ID_EVENT_INIT(MODULE_IDX, EVENT_IDX) \
     { \
         .event = { \
-            .type = __FWK_ID_TYPE_EVENT, \
-            .module_idx = MODULE_IDX, \
-            .event_idx = EVENT_IDX, \
+            .type = (uint32_t)__FWK_ID_TYPE_EVENT, \
+            .module_idx = (uint32_t)MODULE_IDX, \
+            .event_idx = (uint32_t)EVENT_IDX, \
         }, \
     }
 
@@ -351,9 +351,9 @@ enum fwk_id_type {
 #define FWK_ID_SIGNAL_INIT(MODULE_IDX, SIGNAL_IDX) \
     { \
         .signal = { \
-            .type = __FWK_ID_TYPE_SIGNAL, \
-            .module_idx = MODULE_IDX, \
-            .signal_idx = SIGNAL_IDX, \
+            .type = (uint32_t)__FWK_ID_TYPE_SIGNAL, \
+            .module_idx = (uint32_t)MODULE_IDX, \
+            .signal_idx = (uint32_t)SIGNAL_IDX, \
         }, \
     }
 
@@ -400,9 +400,9 @@ enum fwk_id_type {
 #define FWK_ID_NOTIFICATION_INIT(MODULE_IDX, NOTIFICATION_IDX) \
     { \
         .notification = { \
-            .type = __FWK_ID_TYPE_NOTIFICATION, \
-            .module_idx = MODULE_IDX, \
-            .notification_idx = NOTIFICATION_IDX, \
+            .type = (uint32_t)__FWK_ID_TYPE_NOTIFICATION, \
+            .module_idx = (uint32_t)MODULE_IDX, \
+            .notification_idx = (uint32_t)NOTIFICATION_IDX, \
         }, \
     }
 

--- a/framework/src/fwk_id.c
+++ b/framework/src/fwk_id.c
@@ -50,12 +50,12 @@ static void fwk_id_format(
     fwk_assert(buffer_size > 0);
 
     if (id.common.type >= FWK_ARRAY_SIZE(types)) {
-        id.common.type = __FWK_ID_TYPE_INVALID;
+        id.common.type = (uint32_t)__FWK_ID_TYPE_INVALID;
     }
 
     indices[0] = id.common.module_idx;
 
-    switch (id.common.type) {
+    switch ((enum __fwk_id_type)id.common.type) {
     case __FWK_ID_TYPE_SUB_ELEMENT:
         indices[2] = id.sub_element.sub_element_idx;
 
@@ -86,7 +86,7 @@ static void fwk_id_format(
     module_id = FWK_ID_MODULE(indices[0]);
     module_name = fwk_module_get_name(module_id);
 
-    switch (id.common.type) {
+    switch ((enum __fwk_id_type)id.common.type) {
     case __FWK_ID_TYPE_ELEMENT:
     case __FWK_ID_TYPE_SUB_ELEMENT:
         element_id = FWK_ID_ELEMENT(indices[0], indices[1]);
@@ -101,7 +101,7 @@ static void fwk_id_format(
     length += snprintf(
         buffer + length, buffer_size - length, "[%s", types[id.common.type]);
 
-    switch (id.common.type) {
+    switch ((enum __fwk_id_type)id.common.type) {
     case __FWK_ID_TYPE_MODULE:
     case __FWK_ID_TYPE_ELEMENT:
     case __FWK_ID_TYPE_SUB_ELEMENT:
@@ -120,7 +120,7 @@ static void fwk_id_format(
         break;
     }
 
-    switch (id.common.type) {
+    switch ((enum __fwk_id_type)id.common.type) {
     case __FWK_ID_TYPE_ELEMENT:
     case __FWK_ID_TYPE_SUB_ELEMENT:
     case __FWK_ID_TYPE_API:
@@ -138,7 +138,7 @@ static void fwk_id_format(
         break;
     }
 
-    switch (id.common.type) {
+    switch ((enum __fwk_id_type)id.common.type) {
     case __FWK_ID_TYPE_SUB_ELEMENT:
         length +=
             snprintf(buffer + length, buffer_size - length, ":%u", indices[2]);
@@ -191,7 +191,7 @@ enum fwk_id_type fwk_id_get_type(fwk_id_t id)
     fwk_assert(id.common.type != __FWK_ID_TYPE_INVALID);
     fwk_assert(id.common.type < __FWK_ID_TYPE_COUNT);
 
-    return id.common.type;
+    return (enum fwk_id_type)id.common.type;
 }
 
 bool fwk_id_is_equal(fwk_id_t left, fwk_id_t right)

--- a/framework/src/fwk_io.c
+++ b/framework/src/fwk_io.c
@@ -43,7 +43,8 @@ static struct fwk_io_stream fwk_io_null = {
         },
 
     .id = FWK_ID_NONE,
-    .mode = FWK_IO_MODE_READ | FWK_IO_MODE_WRITE | FWK_IO_MODE_BINARY,
+    .mode = (enum fwk_io_mode)(
+        FWK_IO_MODE_READ | FWK_IO_MODE_WRITE | FWK_IO_MODE_BINARY),
 };
 
 struct fwk_io_stream *fwk_io_stdin = &fwk_io_null;
@@ -73,8 +74,9 @@ int fwk_io_init(void)
             status = fwk_io_open(
                 &stdin_stream,
                 FMW_IO_STDIN_ID,
-                ((unsigned int)FWK_IO_MODE_READ) |
-                    ((unsigned int)FWK_IO_MODE_WRITE));
+                (enum fwk_io_mode)(
+                    ((unsigned int)FWK_IO_MODE_READ) |
+                    ((unsigned int)FWK_IO_MODE_WRITE)));
             if (fwk_expect(status == FWK_SUCCESS)) {
                 fwk_io_stdin = &stdin_stream;
                 fwk_io_stdout = &stdin_stream;
@@ -166,7 +168,7 @@ int fwk_io_getch(const struct fwk_io_stream *stream, char *ch)
         return FWK_E_PARAM;
     }
 
-    *ch = 0;
+    *ch = '\0';
 
     if (!fwk_expect(stream->adapter != NULL)) {
         return FWK_E_STATE; /* The stream is not open */
@@ -348,12 +350,12 @@ int fwk_io_vprintf(
         return FWK_E_STATE;
     }
 
-    buffer = fwk_mm_alloc_notrap(sizeof(buffer[0]), length + 1);
+    buffer = fwk_mm_alloc_notrap(sizeof(buffer[0]), (size_t)(length + 1));
     if (buffer == NULL) { /* Not enough memory for the string buffer */
         return FWK_E_NOMEM;
     }
 
-    length = vsnprintf(buffer, length + 1, format, args);
+    length = vsnprintf(buffer, (size_t)(length + 1), format, args);
     if (length >= 0) {
         status = fwk_io_puts(stream, buffer); /* Write out the buffer */
     } else {

--- a/framework/src/fwk_log.c
+++ b/framework/src/fwk_log.c
@@ -125,7 +125,7 @@ static void fwk_log_vsnprintf(
     duration_us = (uint32_t)fwk_time_duration_us(duration % FWK_S(1));
 
     /* Generate the timestamp at the beginning of the buffer */
-    length = snprintf(
+    length = (size_t)snprintf(
         buffer,
         buffer_size,
         "[%5" PRIu32 ".%06" PRIu32 "] ",
@@ -148,7 +148,7 @@ static void fwk_log_vsnprintf(
      * on a line-by-line basis.
      */
 
-    newline = strchr(buffer, '\n');
+    newline = strchr(buffer, (int)'\n');
     if (newline == NULL) {
         newline = buffer + length;
     }
@@ -194,7 +194,7 @@ static bool fwk_log_banner(void)
             return false;
         }
 
-        banner = strchr(banner, '\n');
+        banner = strchr(banner, (int)'\n');
         if (banner != NULL) {
             banner++;
         }

--- a/framework/src/fwk_module.c
+++ b/framework/src/fwk_module.c
@@ -631,7 +631,7 @@ bool fwk_module_is_valid_notification_id(fwk_id_t id)
 int fwk_module_get_element_count(fwk_id_t id)
 {
     if (fwk_module_is_valid_module_id(id)) {
-        return fwk_module_get_ctx(id)->element_count;
+        return (int)fwk_module_get_ctx(id)->element_count;
     } else {
         return FWK_E_PARAM;
     }
@@ -640,7 +640,7 @@ int fwk_module_get_element_count(fwk_id_t id)
 int fwk_module_get_sub_element_count(fwk_id_t element_id)
 {
     if (fwk_module_is_valid_element_id(element_id)) {
-        return fwk_module_get_element_ctx(element_id)->sub_element_count;
+        return (int)fwk_module_get_element_ctx(element_id)->sub_element_count;
     } else {
         return FWK_E_PARAM;
     }

--- a/framework/src/fwk_time.c
+++ b/framework/src/fwk_time.c
@@ -62,12 +62,12 @@ fwk_duration_s_t fwk_time_duration_s(fwk_duration_ns_t duration)
 
 fwk_duration_m_t fwk_time_duration_m(fwk_duration_ns_t duration)
 {
-    return duration / FWK_M(1);
+    return (uint32_t)(duration / FWK_M(1));
 }
 
 fwk_duration_h_t fwk_time_duration_h(fwk_duration_ns_t duration)
 {
-    return duration / FWK_H(1);
+    return (uint32_t)(duration / FWK_H(1));
 }
 
 FWK_WEAK struct fwk_time_driver fmw_time_driver(const void **ctx)

--- a/module/clock/src/mod_clock.c
+++ b/module/clock/src/mod_clock.c
@@ -642,7 +642,8 @@ static int clock_process_notification_response(
      * that is pending.
      */
     if (resp_params->status != FWK_SUCCESS) {
-        ctx->pd_notif.transition_pending_response_status = resp_params->status;
+        ctx->pd_notif.transition_pending_response_status =
+            (unsigned int)resp_params->status;
     }
 
     if ((--(ctx->pd_notif.transition_pending_sent)) == 0) {
@@ -654,7 +655,7 @@ static int clock_process_notification_response(
             (struct mod_pd_power_state_pre_transition_notification_resp_params
                  *)pd_response_event.params;
         pd_resp_params->status =
-            ctx->pd_notif.transition_pending_response_status;
+            (int)ctx->pd_notif.transition_pending_response_status;
         fwk_thread_put_event(&pd_response_event);
     }
 
@@ -699,21 +700,21 @@ static int clock_process_event(const struct fwk_event *event,
     }
 
     switch (fwk_id_get_event_idx(event->id)) {
-    case MOD_CLOCK_EVENT_IDX_SET_RATE_REQUEST:
-    case MOD_CLOCK_EVENT_IDX_GET_RATE_REQUEST:
-    case MOD_CLOCK_EVENT_IDX_SET_STATE_REQUEST:
-    case MOD_CLOCK_EVENT_IDX_GET_STATE_REQUEST:
+    case (unsigned int)MOD_CLOCK_EVENT_IDX_SET_RATE_REQUEST:
+    case (unsigned int)MOD_CLOCK_EVENT_IDX_GET_RATE_REQUEST:
+    case (unsigned int)MOD_CLOCK_EVENT_IDX_SET_STATE_REQUEST:
+    case (unsigned int)MOD_CLOCK_EVENT_IDX_GET_STATE_REQUEST:
         return process_request_event(event, resp_event);
 
 #ifdef BUILD_HAS_CLOCK_TREE_MGMT
-    case CLOCK_EVENT_IDX_SET_STATE_PRE_REQUEST:
+    case (unsigned int)CLOCK_EVENT_IDX_SET_STATE_PRE_REQUEST:
         return clock_management_process_state(event);
 
-    case CLOCK_EVENT_IDX_SET_RATE_PRE_REQUEST:
+    case (unsigned int)CLOCK_EVENT_IDX_SET_RATE_PRE_REQUEST:
         return clock_management_process_rate(event);
 #endif
 
-    case CLOCK_EVENT_IDX_RESPONSE:
+    case (unsigned int)CLOCK_EVENT_IDX_RESPONSE:
         return process_response_event(event);
 
     default:
@@ -724,9 +725,9 @@ static int clock_process_event(const struct fwk_event *event,
 const struct fwk_module module_clock = {
     .name = "Clock HAL",
     .type = FWK_MODULE_TYPE_HAL,
-    .api_count = MOD_CLOCK_API_COUNT,
-    .event_count = CLOCK_EVENT_IDX_COUNT,
-    .notification_count = MOD_CLOCK_NOTIFICATION_IDX_COUNT,
+    .api_count = (unsigned int)MOD_CLOCK_API_COUNT,
+    .event_count = (unsigned int)CLOCK_EVENT_IDX_COUNT,
+    .notification_count = (unsigned int)MOD_CLOCK_NOTIFICATION_IDX_COUNT,
     .init = clock_init,
     .element_init = clock_dev_init,
     .bind = clock_bind,

--- a/module/dvfs/src/mod_dvfs.c
+++ b/module/dvfs/src/mod_dvfs.c
@@ -1284,7 +1284,7 @@ static int dvfs_element_init(
     fwk_assert(ctx->config->opps != NULL);
 
     /* Initialize the context */
-    ctx->opp_count = count_opps(ctx->config->opps);
+    ctx->opp_count = (size_t)count_opps(ctx->config->opps);
     fwk_assert(ctx->opp_count > 0);
 
     /* Level limits default to the minimum and maximum available */
@@ -1389,6 +1389,6 @@ const struct fwk_module module_dvfs = {
     .process_bind_request = dvfs_process_bind_request,
     .process_event = mod_dvfs_process_event,
     .process_signal = mod_dvfs_process_signal,
-    .api_count = MOD_DVFS_API_IDX_COUNT,
-    .event_count = MOD_DVFS_INTERNAL_EVENT_IDX_COUNT,
+    .api_count = (unsigned int)MOD_DVFS_API_IDX_COUNT,
+    .event_count = (unsigned int)MOD_DVFS_INTERNAL_EVENT_IDX_COUNT,
 };

--- a/module/dw_apb_i2c/src/mod_dw_apb_i2c.c
+++ b/module/dw_apb_i2c/src/mod_dw_apb_i2c.c
@@ -342,7 +342,7 @@ static int dw_apb_i2c_start(fwk_id_t id)
 
 const struct fwk_module module_dw_apb_i2c = {
     .name = "DW APB I2C",
-    .api_count = MOD_DW_APB_I2C_API_IDX_COUNT,
+    .api_count = (unsigned int)MOD_DW_APB_I2C_API_IDX_COUNT,
     .type = FWK_MODULE_TYPE_DRIVER,
     .init = dw_apb_i2c_init,
     .element_init = dw_apb_i2c_element_init,

--- a/module/gtimer/src/mod_gtimer.c
+++ b/module/gtimer/src/mod_gtimer.c
@@ -125,8 +125,8 @@ static int set_timer(fwk_id_t dev_id, uint64_t timestamp)
 
     ctx = mod_gtimer_ctx.table + fwk_id_get_element_idx(dev_id);
 
-    ctx->hw_timer->P_CVALL = timestamp & 0xFFFFFFFF;
-    ctx->hw_timer->P_CVALH = timestamp >> 32;
+    ctx->hw_timer->P_CVALL = (uint32_t)(timestamp & 0xFFFFFFFFUL);
+    ctx->hw_timer->P_CVALH = (uint32_t)(timestamp >> 32UL);
 
     return FWK_SUCCESS;
 }

--- a/module/i2c/src/mod_i2c.c
+++ b/module/i2c/src/mod_i2c.c
@@ -314,7 +314,7 @@ static int process_request(struct mod_i2c_dev_ctx *ctx, fwk_id_t event_id)
     const struct mod_i2c_driver_api *driver_api = ctx->driver_api;
     fwk_id_t driver_id = ctx->config->driver_id;
 
-    switch (fwk_id_get_event_idx(event_id)) {
+    switch ((enum mod_i2c_event_idx)fwk_id_get_event_idx(event_id)) {
     case MOD_I2C_EVENT_IDX_REQUEST_TRANSMIT:
         ctx->state = MOD_I2C_DEV_TX;
         drv_status = driver_api->transmit_as_master(driver_id, &ctx->request);
@@ -333,6 +333,9 @@ static int process_request(struct mod_i2c_dev_ctx *ctx, fwk_id_t event_id)
     case MOD_I2C_EVENT_IDX_REQUEST_RECEIVE:
         ctx->state = MOD_I2C_DEV_RX;
         drv_status = driver_api->receive_as_master(driver_id, &ctx->request);
+        break;
+
+    default:
         break;
     }
 
@@ -451,7 +454,7 @@ static int mod_i2c_process_event(const struct fwk_event *event,
         return FWK_SUCCESS;
     }
 
-    switch (fwk_id_get_event_idx(event->id)) {
+    switch ((enum mod_i2c_internal_event_idx)fwk_id_get_event_idx(event->id)) {
     case MOD_I2C_EVENT_IDX_REQUEST_COMPLETED:
         event_param = (struct mod_i2c_event_param *)event->params;
 
@@ -507,8 +510,8 @@ static int mod_i2c_process_event(const struct fwk_event *event,
 const struct fwk_module module_i2c = {
     .name = "I2C",
     .type = FWK_MODULE_TYPE_HAL,
-    .api_count = MOD_I2C_API_IDX_COUNT,
-    .event_count = MOD_I2C_EVENT_IDX_TOTAL_COUNT,
+    .api_count = (unsigned int)MOD_I2C_API_IDX_COUNT,
+    .event_count = (unsigned int)MOD_I2C_EVENT_IDX_TOTAL_COUNT,
     .init = mod_i2c_init,
     .element_init = mod_i2c_dev_init,
     .bind = mod_i2c_bind,

--- a/module/mhu/src/mod_mhu.c
+++ b/module/mhu/src/mod_mhu.c
@@ -92,7 +92,7 @@ static void mhu_isr(void)
 
     /* Loop over all the slots */
     while (reg->STAT != 0) {
-        slot = __builtin_ctz(reg->STAT);
+        slot = (unsigned int)__builtin_ctz(reg->STAT);
 
         /*
          * If the slot is bound to an SMT channel, signal the message to the

--- a/module/mock_clock/src/mod_mock_clock.c
+++ b/module/mock_clock/src/mod_mock_clock.c
@@ -89,7 +89,8 @@ static int mod_mock_clock_set_rate(
         return FWK_E_PARAM;
     }
 
-    ctx->current_rate_index = rate_entry - ctx->config->rate_table;
+    ctx->current_rate_index =
+        (unsigned int)(rate_entry - ctx->config->rate_table);
 
     ctx->rate_initialized = true;
 
@@ -310,6 +311,6 @@ const struct fwk_module module_mock_clock = {
     .init = mod_mock_clock_init,
     .element_init = mod_mock_clock_element_init,
 
-    .api_count = MOD_MOCK_CLOCK_API_COUNT,
+    .api_count = (unsigned int)MOD_MOCK_CLOCK_API_COUNT,
     .process_bind_request = mod_mock_clock_process_bind_request,
 };

--- a/module/mock_psu/src/mod_mock_psu.c
+++ b/module/mock_psu/src/mod_mock_psu.c
@@ -420,6 +420,6 @@ const struct fwk_module module_mock_psu = {
     .element_init = mod_mock_psu_element_init,
     .bind = mod_mock_psu_bind,
 
-    .api_count = MOD_MOCK_PSU_API_IDX_COUNT,
+    .api_count = (unsigned int)MOD_MOCK_PSU_API_IDX_COUNT,
     .process_bind_request = mod_mock_psu_process_bind_request,
 };

--- a/module/pl011/src/mod_pl011.c
+++ b/module/pl011/src/mod_pl011.c
@@ -59,7 +59,7 @@ static int mod_pl011_init_ctx(struct mod_pl011_ctx *ctx)
 
     fwk_assert(!mod_pl011_ctx.initialized);
 
-    element_count = fwk_module_get_element_count(fwk_module_id_pl011);
+    element_count = (size_t)fwk_module_get_element_count(fwk_module_id_pl011);
     if (element_count == 0) {
         return FWK_SUCCESS;
     }
@@ -116,7 +116,7 @@ static void mod_pl011_set_baud_rate(const struct mod_pl011_element_cfg *cfg)
     fwk_assert((PL011_UARTCLK_MAX * UINT64_C(4)) < UINT32_MAX);
 
     /* Ensure baud rate is not higher than the clock can support */
-    clock_rate_x4 = cfg->clock_rate_hz * 4;
+    clock_rate_x4 = (uint32_t)(cfg->clock_rate_hz * 4);
     fwk_assert(cfg->baud_rate_bps <= clock_rate_x4);
 
     /* Calculate integer and fractional divisors */
@@ -136,7 +136,7 @@ static void mod_pl011_set_baud_rate(const struct mod_pl011_element_cfg *cfg)
      */
     fwk_assert((divisor_integer == 0xFFFF) == (divisor_fractional == 0));
 
-    reg->IBRD = divisor_integer;
+    reg->IBRD = (uint16_t)divisor_integer;
     reg->FBRD = divisor_fractional;
 }
 
@@ -173,7 +173,7 @@ static void mod_pl011_putch(fwk_id_t id, char ch)
         continue;
     }
 
-    reg->DR = ch;
+    reg->DR = (uint16_t)ch;
 }
 
 static bool mod_pl011_getch(fwk_id_t id, char *ch)
@@ -191,7 +191,7 @@ static bool mod_pl011_getch(fwk_id_t id, char *ch)
         return false;
     }
 
-    *ch = reg->DR;
+    *ch = (char)reg->DR;
 
     return true;
 }
@@ -351,7 +351,7 @@ static int mod_pl011_process_power_notification(
     int status = FWK_SUCCESS;
 
     switch (fwk_id_get_notification_idx(event->id)) {
-    case MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION: {
+    case (unsigned int)MOD_PD_NOTIFICATION_IDX_POWER_STATE_PRE_TRANSITION: {
         struct mod_pd_power_state_pre_transition_notification_params
             *pd_pre_transition_params;
         struct mod_pd_power_state_pre_transition_notification_resp_params
@@ -366,11 +366,11 @@ static int mod_pl011_process_power_notification(
 
         switch (pd_pre_transition_params->target_state) {
 #    ifdef BUILD_HAS_MOD_SYSTEM_POWER
-        case MOD_SYSTEM_POWER_POWER_STATE_SLEEP0:
+        case (unsigned int)MOD_SYSTEM_POWER_POWER_STATE_SLEEP0:
             FWK_FALLTHROUGH;
 #    endif
 
-        case MOD_PD_STATE_OFF:
+        case (unsigned int)MOD_PD_STATE_OFF:
             status = mod_pl011_powering_down(event->target_id);
 
             pd_resp_params->status = status; /* Inform the power domain */
@@ -384,7 +384,7 @@ static int mod_pl011_process_power_notification(
         break;
     }
 
-    case MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION: {
+    case (unsigned int)MOD_PD_NOTIFICATION_IDX_POWER_STATE_TRANSITION: {
         struct mod_pd_power_state_transition_notification_params *params =
             (struct mod_pd_power_state_transition_notification_params *)
                 event->params;
@@ -398,7 +398,7 @@ static int mod_pl011_process_power_notification(
         break;
     }
 
-    case MOD_PD_NOTIFICATION_IDX_PRE_SHUTDOWN: {
+    case (unsigned int)MOD_PD_NOTIFICATION_IDX_PRE_SHUTDOWN: {
         struct mod_pd_pre_shutdown_notif_resp_params
             *pd_pre_shutdown_resp_params =
                 (struct mod_pd_pre_shutdown_notif_resp_params *)
@@ -508,12 +508,12 @@ static int mod_pl011_process_clock_notification(
     int status = FWK_SUCCESS;
 
     switch (fwk_id_get_notification_idx(event->id)) {
-    case MOD_CLOCK_NOTIFICATION_IDX_STATE_CHANGED:
+    case (unsigned int)MOD_CLOCK_NOTIFICATION_IDX_STATE_CHANGED:
         status = mod_pl011_clock_changed(event);
 
         break;
 
-    case MOD_CLOCK_NOTIFICATION_IDX_STATE_CHANGE_PENDING:
+    case (unsigned int)MOD_CLOCK_NOTIFICATION_IDX_STATE_CHANGE_PENDING:
         status = mod_pl011_clock_change_pending(event, resp_event);
 
         break;
@@ -533,7 +533,7 @@ static int mod_pl011_process_notification(
 
     fwk_assert(fwk_id_is_type(event->target_id, FWK_ID_TYPE_ELEMENT));
 
-    module_idx = fwk_id_get_module_idx(event->id);
+    module_idx = (enum fwk_module_idx)fwk_id_get_module_idx(event->id);
 
     switch (module_idx) {
 #ifdef BUILD_HAS_MOD_POWER_DOMAIN

--- a/module/psu/src/mod_psu.c
+++ b/module/psu/src/mod_psu.c
@@ -369,7 +369,7 @@ static int mod_psu_process_bind_request(
         return FWK_E_PARAM;
     }
 
-    switch (fwk_id_get_api_idx(api_id)) {
+    switch ((enum mod_psu_api_idx)fwk_id_get_api_idx(api_id)) {
     case MOD_PSU_API_IDX_DEVICE:
         *api = &mod_psu_device_api;
 
@@ -378,6 +378,8 @@ static int mod_psu_process_bind_request(
     case MOD_PSU_API_IDX_DRIVER_RESPONSE:
         *api = &mod_psu_driver_response_api;
 
+        break;
+    default:
         break;
     }
 
@@ -409,17 +411,17 @@ static int mod_psu_process_event(
     }
 
     switch (fwk_id_get_event_idx(event->id)) {
-    case MOD_PSU_EVENT_IDX_GET_ENABLED:
-    case MOD_PSU_EVENT_IDX_GET_VOLTAGE:
-    case MOD_PSU_EVENT_IDX_SET_ENABLED:
-    case MOD_PSU_EVENT_IDX_SET_VOLTAGE:
+    case (unsigned int)MOD_PSU_EVENT_IDX_GET_ENABLED:
+    case (unsigned int)MOD_PSU_EVENT_IDX_GET_VOLTAGE:
+    case (unsigned int)MOD_PSU_EVENT_IDX_SET_ENABLED:
+    case (unsigned int)MOD_PSU_EVENT_IDX_SET_VOLTAGE:
         ctx->op.cookie = event->cookie;
 
         resp_event->is_delayed_response = true;
 
         break;
 
-    case MOD_PSU_IMPL_EVENT_IDX_RESPONSE:
+    case (unsigned int)MOD_PSU_IMPL_EVENT_IDX_RESPONSE:
         ctx->op.state = MOD_PSU_STATE_IDLE;
 
         status = fwk_thread_get_delayed_response(
@@ -434,7 +436,7 @@ static int mod_psu_process_event(
             .status = params->status,
         };
 
-        switch (fwk_id_get_event_idx(hal_event.id)) {
+        switch ((enum mod_psu_event_idx)fwk_id_get_event_idx(hal_event.id)) {
         case MOD_PSU_EVENT_IDX_GET_ENABLED:
             hal_params->enabled = params->enabled;
 
@@ -469,9 +471,9 @@ const struct fwk_module module_psu = {
     .element_init = mod_psu_element_init,
     .bind = mod_psu_bind,
 
-    .api_count = MOD_PSU_API_IDX_COUNT,
+    .api_count = (unsigned int)MOD_PSU_API_IDX_COUNT,
     .process_bind_request = mod_psu_process_bind_request,
 
-    .event_count = MOD_PSU_IMPL_EVENT_IDX_COUNT,
+    .event_count = (unsigned int)MOD_PSU_IMPL_EVENT_IDX_COUNT,
     .process_event = mod_psu_process_event,
 };

--- a/module/scmi/src/mod_scmi.c
+++ b/module/scmi/src/mod_scmi.c
@@ -226,27 +226,30 @@ static uint32_t scmi_message_header(uint8_t message_id,
 
 static uint16_t read_message_id(uint32_t message_header)
 {
-    return (message_header & SCMI_MESSAGE_HEADER_MESSAGE_ID_MASK) >>
-        SCMI_MESSAGE_HEADER_MESSAGE_ID_POS;
+    return (uint16_t)(
+        ((message_header & SCMI_MESSAGE_HEADER_MESSAGE_ID_MASK) >>
+         SCMI_MESSAGE_HEADER_MESSAGE_ID_POS));
 }
 
 static uint8_t read_message_type(uint32_t message_header)
 {
-    return (message_header & SCMI_MESSAGE_HEADER_MESSAGE_TYPE_MASK) >>
-        SCMI_MESSAGE_HEADER_MESSAGE_TYPE_POS;
+    return (uint8_t)(
+        ((message_header & SCMI_MESSAGE_HEADER_MESSAGE_TYPE_MASK) >>
+         SCMI_MESSAGE_HEADER_MESSAGE_TYPE_POS));
 }
-
 
 static uint8_t read_protocol_id(uint32_t message_header)
 {
-    return (message_header & SCMI_MESSAGE_HEADER_PROTOCOL_ID_MASK) >>
-        SCMI_MESSAGE_HEADER_PROTOCOL_ID_POS;
+    return (uint8_t)(
+        ((message_header & SCMI_MESSAGE_HEADER_PROTOCOL_ID_MASK) >>
+         SCMI_MESSAGE_HEADER_PROTOCOL_ID_POS));
 }
 
 static uint16_t read_token(uint32_t message_header)
 {
-    return (message_header & SCMI_MESSAGE_HEADER_TOKEN_MASK) >>
-        SCMI_MESSAGE_HEADER_TOKEN_POS;
+    return (uint16_t)(
+        ((message_header & SCMI_MESSAGE_HEADER_TOKEN_MASK) >>
+         SCMI_MESSAGE_HEADER_TOKEN_POS));
 }
 
 static const char *message_type_to_str(enum mod_scmi_message_type message_type)
@@ -308,7 +311,7 @@ static int get_agent_count(int *agent_count)
     }
 
     /* Include the platform in the count */
-    *agent_count = scmi_ctx.config->agent_count + 1;
+    *agent_count = (int)(scmi_ctx.config->agent_count + 1);
 
     return FWK_SUCCESS;
 }
@@ -451,9 +454,11 @@ static void scmi_notify(fwk_id_t id, int protocol_id, int message_id,
         return; /* No notification service configured */
     }
 
-    message_header = scmi_message_header(message_id,
-        MOD_SCMI_MESSAGE_TYPE_NOTIFICATION,
-        protocol_id, 0);
+    message_header = scmi_message_header(
+        (uint8_t)message_id,
+        (uint8_t)MOD_SCMI_MESSAGE_TYPE_NOTIFICATION,
+        (uint8_t)protocol_id,
+        0);
 
     p2a_ctx->transmit(p2a_ctx->transport_id, message_header, payload, size);
 }
@@ -499,10 +504,10 @@ static int scmi_notification_init(
     subscribers->element_count = element_count;
     subscribers->operation_count = operation_count;
 
-    total_count = operation_count * element_count * agent_count;
+    total_count = (int)(operation_count * element_count * agent_count);
 
     subscribers->agent_service_ids =
-        fwk_mm_calloc(total_count, sizeof(fwk_id_t));
+        fwk_mm_calloc((size_t)total_count, sizeof(fwk_id_t));
 
     /*
      * Mark all operations_idx as invalid. This will be updated
@@ -538,8 +543,7 @@ static int scmi_notification_service_idx(
      * 3. Get the offset of the 2nd array within the first array.
      */
     return (
-        agent_idx + element_idx * agent_count +
-        operation_idx * element_count * agent_count);
+        int)(agent_idx + element_idx * agent_count + operation_idx * element_count * agent_count);
 }
 
 static int scmi_notification_add_subscriber(
@@ -570,10 +574,10 @@ static int scmi_notification_add_subscriber(
         MOD_SCMI_PROTOCOL_OPERATION_IDX_INVALID) {
         operation_idx = subscribers->operation_idx++;
         fwk_assert(operation_idx < subscribers->operation_count);
-        subscribers->operation_id_to_idx[operation_id] = operation_idx;
+        subscribers->operation_id_to_idx[operation_id] = (uint8_t)operation_idx;
     }
 
-    service_id_idx = scmi_notification_service_idx(
+    service_id_idx = (unsigned int)scmi_notification_service_idx(
         agent_idx,
         element_idx,
         operation_idx,
@@ -601,7 +605,7 @@ static int scmi_notification_remove_subscriber(
 
     operation_idx = subscribers->operation_id_to_idx[operation_id];
 
-    service_id_idx = scmi_notification_service_idx(
+    service_id_idx = (unsigned int)scmi_notification_service_idx(
         agent_idx,
         element_idx,
         operation_idx,
@@ -644,7 +648,7 @@ static int scmi_notification_notify(
     for (i = 0; i < subscribers->element_count; i++) {
         /* Skip agent 0, platform agent */
         for (j = 1; j < subscribers->agent_count; j++) {
-            service_id_idx = scmi_notification_service_idx(
+            service_id_idx = (unsigned int)scmi_notification_service_idx(
                 j,
                 i,
                 operation_idx,
@@ -656,8 +660,8 @@ static int scmi_notification_notify(
             if (!fwk_id_is_equal(service_id, FWK_ID_NONE)) {
                 scmi_notify(
                     service_id,
-                    protocol_id,
-                    scmi_response_id,
+                    (int)protocol_id,
+                    (int)scmi_response_id,
                     payload_p2a,
                     payload_size);
             }
@@ -685,7 +689,7 @@ static int scmi_base_protocol_version_handler(fwk_id_t service_id,
                                               const uint32_t *payload)
 {
     struct scmi_protocol_version_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .version = SCMI_PROTOCOL_VERSION_BASE,
     };
 
@@ -728,7 +732,7 @@ static int scmi_base_protocol_attributes_handler(fwk_id_t service_id,
             continue;
         }
 
-        protocol_id = index;
+        protocol_id = (uint8_t)index;
 
         /*
          * Check that the agent has the permission to access the protocol
@@ -763,7 +767,7 @@ static int scmi_base_protocol_attributes_handler(fwk_id_t service_id,
 #endif
 
     struct scmi_protocol_attributes_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
     };
 
     return_values.attributes = SCMI_BASE_PROTOCOL_ATTRIBUTES(
@@ -783,7 +787,7 @@ static int scmi_base_protocol_message_attributes_handler(fwk_id_t service_id,
     struct scmi_protocol_message_attributes_a2p *parameters;
     unsigned int message_id;
     struct scmi_protocol_message_attributes_p2a return_values = {
-        .status = SCMI_NOT_FOUND,
+        .status = (int32_t)SCMI_NOT_FOUND,
     };
 
     parameters = (struct scmi_protocol_message_attributes_a2p *)payload;
@@ -791,7 +795,7 @@ static int scmi_base_protocol_message_attributes_handler(fwk_id_t service_id,
 
     if ((message_id < FWK_ARRAY_SIZE(base_handler_table)) &&
         (base_handler_table[message_id] != NULL)) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
     }
 
     /* For this protocol, all commands have an attributes value of 0, which
@@ -812,7 +816,7 @@ static int scmi_base_discover_vendor_handler(fwk_id_t service_id,
                                              const uint32_t *payload)
 {
     struct scmi_base_discover_vendor_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
     };
 
     if (scmi_ctx.config->vendor_identifier != NULL) {
@@ -833,7 +837,7 @@ static int scmi_base_discover_sub_vendor_handler(fwk_id_t service_id,
                                                  const uint32_t *payload)
 {
     struct scmi_base_discover_sub_vendor_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
     };
 
     if (scmi_ctx.config->sub_vendor_identifier != NULL) {
@@ -854,8 +858,7 @@ static int scmi_base_discover_implementation_version_handler(
     fwk_id_t service_id, const uint32_t *payload)
 {
     struct scmi_protocol_version_p2a return_values = {
-        .status = SCMI_SUCCESS,
-        .version = FWK_BUILD_VERSION
+        .status = (int32_t)SCMI_SUCCESS, .version = FWK_BUILD_VERSION
     };
 
     respond(service_id, &return_values, sizeof(return_values));
@@ -872,7 +875,7 @@ static int scmi_base_discover_list_protocols_handler(fwk_id_t service_id,
     int status;
     const struct scmi_base_discover_list_protocols_a2p *parameters;
     struct scmi_base_discover_list_protocols_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
         .num_protocols = 0,
     };
     unsigned int skip;
@@ -955,7 +958,7 @@ static int scmi_base_discover_list_protocols_handler(fwk_id_t service_id,
             continue;
         }
 
-        protocol_id = index;
+        protocol_id = (uint8_t)index;
 
 #ifdef BUILD_HAS_MOD_RESOURCE_PERMS
         /*
@@ -1023,11 +1026,11 @@ static int scmi_base_discover_list_protocols_handler(fwk_id_t service_id,
     }
 
     if (skip > protocol_count) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto error;
     }
 
-    return_values.status = SCMI_SUCCESS;
+    return_values.status = (int32_t)SCMI_SUCCESS;
     return_values.num_protocols = avail_protocol_count;
 
     status = write_payload(service_id, 0,
@@ -1058,7 +1061,7 @@ static int scmi_base_discover_agent_handler(fwk_id_t service_id,
 {
     const struct scmi_base_discover_agent_a2p *parameters;
     struct scmi_base_discover_agent_p2a return_values = {
-        .status = SCMI_NOT_FOUND,
+        .status = (int32_t)SCMI_NOT_FOUND,
     };
     const struct mod_scmi_agent *agent;
 
@@ -1080,7 +1083,7 @@ static int scmi_base_discover_agent_handler(fwk_id_t service_id,
     }
 #endif
 
-    return_values.status = SCMI_SUCCESS;
+    return_values.status = (int32_t)SCMI_SUCCESS;
 
     if (parameters->agent_id == MOD_SCMI_PLATFORM_ID) {
         static const char name[] = "platform";
@@ -1156,7 +1159,7 @@ static int scmi_base_set_device_permissions(
 {
     const struct scmi_base_set_device_permissions_a2p *parameters;
     struct scmi_base_set_device_permissions_p2a return_values = {
-        .status = SCMI_NOT_FOUND,
+        .status = (int32_t)SCMI_NOT_FOUND,
     };
     int status = FWK_SUCCESS;
 
@@ -1168,12 +1171,12 @@ static int scmi_base_set_device_permissions(
     }
 
     if (parameters->agent_id == MOD_SCMI_PLATFORM_ID) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         goto exit;
     }
 
     if (parameters->flags & ~MOD_RES_PERMS_PERMISSIONS_MASK) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         status = FWK_E_PARAM;
         goto exit;
     }
@@ -1183,16 +1186,16 @@ static int scmi_base_set_device_permissions(
 
     switch (status) {
     case FWK_SUCCESS:
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         break;
     case FWK_E_PARAM:
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         break;
     case FWK_E_ACCESS:
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         break;
     default:
-        return_values.status = SCMI_NOT_SUPPORTED;
+        return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
         break;
     }
 
@@ -1215,7 +1218,7 @@ static int scmi_base_set_protocol_permissions(
 {
     const struct scmi_base_set_protocol_permissions_a2p *parameters;
     struct scmi_base_set_protocol_permissions_p2a return_values = {
-        .status = SCMI_NOT_FOUND,
+        .status = (int32_t)SCMI_NOT_FOUND,
     };
     int status = FWK_SUCCESS;
 
@@ -1227,18 +1230,18 @@ static int scmi_base_set_protocol_permissions(
     }
 
     if (parameters->agent_id == MOD_SCMI_PLATFORM_ID) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         goto exit;
     }
 
     if (parameters->flags & ~MOD_RES_PERMS_PERMISSIONS_MASK) {
         status = FWK_E_PARAM;
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }
 
     if (parameters->command_id == MOD_SCMI_PROTOCOL_ID_BASE) {
-        return_values.status = SCMI_DENIED;
+        return_values.status = (int32_t)SCMI_DENIED;
         goto exit;
     }
 
@@ -1250,16 +1253,16 @@ static int scmi_base_set_protocol_permissions(
 
     switch (status) {
     case FWK_SUCCESS:
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         break;
     case FWK_E_PARAM:
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         break;
     case FWK_E_ACCESS:
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         break;
     default:
-        return_values.status = SCMI_NOT_SUPPORTED;
+        return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
         break;
     }
 
@@ -1282,7 +1285,7 @@ static int scmi_base_reset_agent_config(
 {
     const struct scmi_base_reset_agent_config_a2p *parameters;
     struct scmi_base_reset_agent_config_p2a return_values = {
-        .status = SCMI_NOT_FOUND,
+        .status = (int32_t)SCMI_NOT_FOUND,
     };
     int status;
 
@@ -1293,12 +1296,12 @@ static int scmi_base_reset_agent_config(
     }
 
     if (parameters->agent_id == MOD_SCMI_PLATFORM_ID) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         goto exit;
     }
 
     if (parameters->flags & ~MOD_RES_PERMS_PERMISSIONS_MASK) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }
 
@@ -1307,16 +1310,16 @@ static int scmi_base_reset_agent_config(
 
     switch (status) {
     case FWK_SUCCESS:
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         break;
     case FWK_E_PARAM:
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         break;
     case FWK_E_ACCESS:
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         break;
     default:
-        return_values.status = SCMI_NOT_SUPPORTED;
+        return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
         break;
     }
 
@@ -1378,19 +1381,19 @@ static int scmi_base_message_handler(fwk_id_t protocol_id, fwk_id_t service_id,
     fwk_assert(payload != NULL);
 
     if (message_id >= FWK_ARRAY_SIZE(base_handler_table)) {
-        return_value = SCMI_NOT_FOUND;
+        return_value = (int32_t)SCMI_NOT_FOUND;
         goto error;
     }
 
     if (payload_size != base_payload_size_table[message_id]) {
-        return_value = SCMI_PROTOCOL_ERROR;
+        return_value = (int32_t)SCMI_PROTOCOL_ERROR;
         goto error;
     }
 
 #ifdef BUILD_HAS_MOD_RESOURCE_PERMS
     if (scmi_base_permissions_handler(
             service_id, payload, payload_size, message_id) != FWK_SUCCESS) {
-        return_value = SCMI_DENIED;
+        return_value = (int32_t)SCMI_DENIED;
         goto error;
     }
 #endif
@@ -1543,7 +1546,7 @@ static int scmi_bind(fwk_id_t id, unsigned int round)
         }
 
         scmi_ctx.scmi_protocol_id_to_idx[scmi_protocol_id] =
-            protocol_idx + PROTOCOL_TABLE_RESERVED_ENTRIES_COUNT;
+            (uint8_t)(protocol_idx + PROTOCOL_TABLE_RESERVED_ENTRIES_COUNT);
         protocol->message_handler = protocol_api->message_handler;
     }
 
@@ -1568,7 +1571,7 @@ static int scmi_process_bind_request(fwk_id_t source_id, fwk_id_t target_id,
 
     api_idx = fwk_id_get_api_idx(api_id);
 
-    switch (api_idx) {
+    switch ((enum mod_scmi_api_idx)api_idx) {
     case MOD_SCMI_API_IDX_PROTOCOL:
         if (!fwk_id_is_type(target_id, FWK_ID_TYPE_MODULE)) {
             return FWK_E_SUPPORT;
@@ -1654,7 +1657,8 @@ static int scmi_process_event(const struct fwk_event *event,
 
     ctx->scmi_protocol_id = read_protocol_id(message_header);
     ctx->scmi_message_id = read_message_id(message_header);
-    ctx->scmi_message_type = read_message_type(message_header);
+    ctx->scmi_message_type =
+        (enum mod_scmi_message_type)read_message_type(message_header);
     ctx->scmi_token = read_token(message_header);
 
     FWK_LOG_TRACE(
@@ -1810,11 +1814,11 @@ static int scmi_process_notification(const struct fwk_event *event,
 /* SCMI module definition */
 const struct fwk_module module_scmi = {
     .name = "SCMI",
-    .api_count = MOD_SCMI_API_IDX_COUNT,
+    .api_count = (unsigned int)MOD_SCMI_API_IDX_COUNT,
     .event_count = 1,
-    #ifdef BUILD_HAS_NOTIFICATION
-    .notification_count = MOD_SCMI_NOTIFICATION_IDX_COUNT,
-    #endif
+#ifdef BUILD_HAS_NOTIFICATION
+    .notification_count = (unsigned int)MOD_SCMI_NOTIFICATION_IDX_COUNT,
+#endif
     .type = FWK_MODULE_TYPE_SERVICE,
     .init = scmi_init,
     .element_init = scmi_service_init,
@@ -1822,7 +1826,7 @@ const struct fwk_module module_scmi = {
     .start = scmi_start,
     .process_bind_request = scmi_process_bind_request,
     .process_event = scmi_process_event,
-    #ifdef BUILD_HAS_NOTIFICATION
+#ifdef BUILD_HAS_NOTIFICATION
     .process_notification = scmi_process_notification,
-    #endif
+#endif
 };

--- a/module/scmi_apcore/src/mod_scmi_apcore.c
+++ b/module/scmi_apcore/src/mod_scmi_apcore.c
@@ -123,7 +123,7 @@ static int scmi_apcore_protocol_version_handler(fwk_id_t service_id,
     const uint32_t *payload)
 {
     struct scmi_protocol_version_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .version = MOD_SCMI_PROTOCOL_VERSION_APCORE,
     };
 
@@ -139,7 +139,7 @@ static int scmi_apcore_protocol_attributes_handler(fwk_id_t service_id,
     const uint32_t *payload)
 {
     struct scmi_protocol_attributes_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .attributes = 0,
     };
 
@@ -167,7 +167,7 @@ static int scmi_apcore_protocol_message_attributes_handler(fwk_id_t service_id,
     const struct scmi_protocol_message_attributes_a2p *parameters;
     unsigned int message_id;
     struct scmi_protocol_message_attributes_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .attributes = 0,
     };
 
@@ -177,7 +177,7 @@ static int scmi_apcore_protocol_message_attributes_handler(fwk_id_t service_id,
 
     if ((message_id >= FWK_ARRAY_SIZE(handler_table)) ||
         (handler_table[message_id] == NULL)) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
     }
 
     response_size = (return_values.status == SCMI_SUCCESS) ?
@@ -200,7 +200,7 @@ static int scmi_apcore_reset_address_set_handler(fwk_id_t service_id,
     enum scmi_agent_type agent_type;
     const struct scmi_apcore_reset_address_set_a2p *parameters;
     struct scmi_apcore_reset_address_set_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR
+        .status = (int32_t)SCMI_GENERIC_ERROR
     };
 
     parameters = (const struct scmi_apcore_reset_address_set_a2p *)payload;
@@ -217,13 +217,13 @@ static int scmi_apcore_reset_address_set_handler(fwk_id_t service_id,
 
     /* Only the PSCI agent may set the reset address */
     if (agent_type != SCMI_AGENT_TYPE_PSCI) {
-        return_values.status = SCMI_DENIED;
+        return_values.status = (int32_t)SCMI_DENIED;
         goto exit;
     }
 
     /* An agent previously requested that the configuration be locked */
     if (scmi_apcore_ctx.locked) {
-        return_values.status = SCMI_DENIED;
+        return_values.status = (int32_t)SCMI_DENIED;
         goto exit;
     }
 
@@ -234,7 +234,7 @@ static int scmi_apcore_reset_address_set_handler(fwk_id_t service_id,
     if ((parameters->reset_address_high != 0) &&
         (scmi_apcore_ctx.config->reset_register_width ==
          MOD_SCMI_APCORE_REG_WIDTH_32)) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }
 
@@ -242,11 +242,11 @@ static int scmi_apcore_reset_address_set_handler(fwk_id_t service_id,
     if (scmi_apcore_ctx.config->reset_register_width ==
         MOD_SCMI_APCORE_REG_WIDTH_32) {
         if ((parameters->reset_address_low % 4) != 0) {
-            return_values.status = SCMI_INVALID_PARAMETERS;
+            return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
             goto exit;
         }
     } else if ((parameters->reset_address_low % 8) != 0) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }
 
@@ -256,7 +256,7 @@ static int scmi_apcore_reset_address_set_handler(fwk_id_t service_id,
         goto exit;
     }
 
-    return_values.status = SCMI_SUCCESS;
+    return_values.status = (int32_t)SCMI_SUCCESS;
 
     /* Lock the configuration if requested */
     if (parameters->attributes & MOD_SCMI_APCORE_RESET_ADDRESS_SET_LOCK_MASK) {
@@ -281,7 +281,7 @@ static int scmi_apcore_reset_address_get_handler(fwk_id_t service_id,
     uint64_t reset_address;
     enum scmi_agent_type agent_type;
     struct scmi_apcore_reset_address_get_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR
+        .status = (int32_t)SCMI_GENERIC_ERROR
     };
 
     status = scmi_apcore_ctx.scmi_api->get_agent_id(service_id, &agent_id);
@@ -296,7 +296,7 @@ static int scmi_apcore_reset_address_get_handler(fwk_id_t service_id,
 
     /* Only the PSCI agent may get the current reset address */
     if (agent_type != SCMI_AGENT_TYPE_PSCI) {
-        return_values.status = SCMI_DENIED;
+        return_values.status = (int32_t)SCMI_DENIED;
         goto exit;
     }
 
@@ -309,14 +309,15 @@ static int scmi_apcore_reset_address_get_handler(fwk_id_t service_id,
         return_values.reset_address_high = 0;
     } else {
         reset_address = *(uint64_t *)reg_group->base_register;
-        return_values.reset_address_high = (reset_address >> 32) & UINT32_MAX;
+        return_values.reset_address_high =
+            (uint32_t)((reset_address >> 32) & UINT32_MAX);
     }
 
     return_values.reset_address_low = (uint32_t)reset_address;
 
     return_values.attributes |=
         (scmi_apcore_ctx.locked << MOD_SCMI_APCORE_RESET_ADDRESS_GET_LOCK_POS);
-    return_values.status = SCMI_SUCCESS;
+    return_values.status = (int32_t)SCMI_SUCCESS;
 
 exit:
     scmi_apcore_ctx.scmi_api->respond(
@@ -330,7 +331,7 @@ exit:
 static int scmi_apcore_get_scmi_protocol_id(fwk_id_t protocol_id,
     uint8_t *scmi_protocol_id)
 {
-    *scmi_protocol_id = MOD_SCMI_PROTOCOL_ID_APCORE;
+    *scmi_protocol_id = (uint8_t)MOD_SCMI_PROTOCOL_ID_APCORE;
 
     return FWK_SUCCESS;
 }
@@ -350,12 +351,12 @@ static int scmi_apcore_message_handler(
     fwk_assert(payload != NULL);
 
     if (message_id >= FWK_ARRAY_SIZE(handler_table)) {
-        return_value = SCMI_NOT_FOUND;
+        return_value = (int32_t)SCMI_NOT_FOUND;
         goto error;
     }
 
     if (payload_size != payload_size_table[message_id]) {
-        return_value = SCMI_PROTOCOL_ERROR;
+        return_value = (int32_t)SCMI_PROTOCOL_ERROR;
         goto error;
     }
 

--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -250,7 +250,7 @@ static int get_agent_clock_state(
         return status;
     }
 
-    idx = (agent_id * scmi_clock_ctx.clock_devices) + clock_idx;
+    idx = (int)((agent_id * scmi_clock_ctx.clock_devices) + clock_idx);
 
     *state = agent_clock_state[idx];
 
@@ -286,7 +286,7 @@ static int set_agent_clock_state(
         return status;
     }
 
-    idx = (agent_id * scmi_clock_ctx.clock_devices) + clock_idx;
+    idx = (int)((agent_id * scmi_clock_ctx.clock_devices) + clock_idx);
 
     agent_clock_state[idx] = state;
 
@@ -360,10 +360,10 @@ static void get_state_respond(fwk_id_t clock_dev_id,
                 fwk_module_get_name(clock_dev_id),
                 sizeof(return_values.clock_name) - 1);
 
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         response_size = sizeof(return_values);
     } else {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
 
         response_size = sizeof(return_values.status);
     }
@@ -387,10 +387,10 @@ static void get_rate_respond(fwk_id_t service_id,
         return_values.rate[0] = (uint32_t)*rate;
         return_values.rate[1] = (uint32_t)(*rate >> 32);
 
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         response_size = sizeof(return_values);
     } else {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
 
         response_size = sizeof(return_values.status);
     }
@@ -404,15 +404,15 @@ static void request_response(int response_status,
                              fwk_id_t service_id)
 {
     struct scmi_clock_generic_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR
+        .status = (int32_t)SCMI_GENERIC_ERROR
     };
 
     if (response_status == FWK_E_SUPPORT) {
-        return_values.status = SCMI_NOT_SUPPORTED;
+        return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
     }
 
     if (response_status == FWK_E_RANGE) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
     }
 
     scmi_clock_ctx.scmi_api->respond(service_id,
@@ -428,13 +428,13 @@ static void set_request_respond(fwk_id_t service_id, int status)
     struct scmi_clock_generic_p2a return_values = { 0 };
 
     if (status == FWK_E_RANGE || status == FWK_E_PARAM) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
     } else if (status == FWK_E_SUPPORT) {
-        return_values.status = SCMI_NOT_SUPPORTED;
+        return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
     } else if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
     } else {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
     }
 
     scmi_clock_ctx.scmi_api->respond(service_id,
@@ -495,7 +495,7 @@ FWK_WEAK int mod_scmi_clock_config_set_policy(
                  clock_id++) {
                 if (agent->device_table[clock_id].starts_enabled) {
                     idx = (agent_id * scmi_clock_ctx.clock_devices) + clock_id;
-                    agent_clock_state[idx] = MOD_CLOCK_STATE_RUNNING;
+                    agent_clock_state[idx] = (uint8_t)MOD_CLOCK_STATE_RUNNING;
 
                     clock_count[clock_id]++;
                 }
@@ -524,7 +524,7 @@ FWK_WEAK int mod_scmi_clock_config_set_policy(
         if (policy_commit == MOD_SCMI_CLOCK_POST_MESSAGE_HANDLER) {
             set_agent_clock_state(
                 agent_clock_state,
-                MOD_CLOCK_STATE_RUNNING,
+                (uint8_t)MOD_CLOCK_STATE_RUNNING,
                 service_id,
                 clock_dev_id);
         }
@@ -565,7 +565,7 @@ FWK_WEAK int mod_scmi_clock_config_set_policy(
         if (policy_commit == MOD_SCMI_CLOCK_POST_MESSAGE_HANDLER) {
             set_agent_clock_state(
                 agent_clock_state,
-                MOD_CLOCK_STATE_STOPPED,
+                (uint8_t)MOD_CLOCK_STATE_STOPPED,
                 service_id,
                 clock_dev_id);
         }
@@ -754,7 +754,7 @@ static int scmi_clock_protocol_version_handler(fwk_id_t service_id,
     const uint32_t *payload)
 {
     struct scmi_protocol_version_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .version = SCMI_PROTOCOL_VERSION_CLOCK,
     };
 
@@ -772,12 +772,12 @@ static int scmi_clock_protocol_attributes_handler(fwk_id_t service_id,
     int status;
     const struct mod_scmi_clock_agent *agent;
     struct scmi_protocol_attributes_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
     };
 
     status = get_agent_entry(service_id, &agent);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
         goto exit;
     }
 
@@ -802,7 +802,7 @@ static int scmi_clock_protocol_message_attributes_handler(fwk_id_t service_id,
     const struct scmi_protocol_message_attributes_a2p *parameters;
     unsigned int message_id;
     struct scmi_protocol_message_attributes_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .attributes = 0,
     };
 
@@ -812,7 +812,7 @@ static int scmi_clock_protocol_message_attributes_handler(fwk_id_t service_id,
 
     if ((message_id >= FWK_ARRAY_SIZE(handler_table)) ||
         (handler_table[message_id] == NULL)) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
@@ -836,7 +836,7 @@ static int scmi_clock_attributes_handler(fwk_id_t service_id,
     size_t response_size;
     const struct scmi_clock_attributes_a2p *parameters;
     struct scmi_clock_attributes_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR
+        .status = (int32_t)SCMI_GENERIC_ERROR
     };
 
     parameters = (const struct scmi_clock_attributes_a2p*)payload;
@@ -846,7 +846,7 @@ static int scmi_clock_attributes_handler(fwk_id_t service_id,
                                     &clock_device,
                                     &agent);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
@@ -857,7 +857,7 @@ static int scmi_clock_attributes_handler(fwk_id_t service_id,
         NULL,
         parameters->clock_id);
     if (status == FWK_E_BUSY) {
-        return_values.status = SCMI_BUSY;
+        return_values.status = (int32_t)SCMI_BUSY;
         status = FWK_SUCCESS;
         goto exit;
     }
@@ -887,7 +887,7 @@ static int scmi_clock_rate_get_handler(fwk_id_t service_id,
     size_t response_size;
     const struct scmi_clock_rate_get_a2p *parameters;
     struct scmi_clock_rate_get_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR
+        .status = (int32_t)SCMI_GENERIC_ERROR
     };
 
     parameters = (const struct scmi_clock_rate_get_a2p*)payload;
@@ -897,7 +897,7 @@ static int scmi_clock_rate_get_handler(fwk_id_t service_id,
                                     &clock_device,
                                     &agent);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
@@ -908,7 +908,7 @@ static int scmi_clock_rate_get_handler(fwk_id_t service_id,
         NULL,
         parameters->clock_id);
     if (status == FWK_E_BUSY) {
-        return_values.status = SCMI_BUSY;
+        return_values.status = (int32_t)SCMI_BUSY;
         status = FWK_SUCCESS;
         goto exit;
     }
@@ -944,17 +944,17 @@ static int scmi_clock_rate_set_handler(fwk_id_t service_id,
     enum mod_clock_round_mode round_mode;
     const struct scmi_clock_rate_set_a2p *parameters;
     struct scmi_clock_rate_set_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR
+        .status = (int32_t)SCMI_GENERIC_ERROR
     };
     enum mod_scmi_clock_policy_status policy_status;
 
     parameters = (const struct scmi_clock_rate_set_a2p*)payload;
-    round_up = parameters->flags & SCMI_CLOCK_RATE_SET_ROUND_UP_MASK;
-    round_auto = parameters->flags & SCMI_CLOCK_RATE_SET_ROUND_AUTO_MASK;
-    asynchronous = parameters->flags & SCMI_CLOCK_RATE_SET_ASYNC_MASK;
+    round_up = (parameters->flags & SCMI_CLOCK_RATE_SET_ROUND_UP_MASK) != 0;
+    round_auto = (parameters->flags & SCMI_CLOCK_RATE_SET_ROUND_AUTO_MASK) != 0;
+    asynchronous = (parameters->flags & SCMI_CLOCK_RATE_SET_ASYNC_MASK) != 0;
 
     if ((parameters->flags & ~SCMI_CLOCK_RATE_SET_FLAGS_MASK) != 0) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }
 
@@ -963,13 +963,13 @@ static int scmi_clock_rate_set_handler(fwk_id_t service_id,
                                     &clock_device,
                                     &agent);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
     if (asynchronous) {
         /* Support for async clock set commands not yet implemented */
-        return_values.status = SCMI_NOT_SUPPORTED;
+        return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
         goto exit;
     }
 
@@ -996,11 +996,11 @@ static int scmi_clock_rate_set_handler(fwk_id_t service_id,
         parameters->clock_id);
 
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
         goto exit;
     }
     if (policy_status == MOD_SCMI_CLOCK_SKIP_MESSAGE_HANDLER) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         goto exit;
     }
 
@@ -1017,7 +1017,7 @@ static int scmi_clock_rate_set_handler(fwk_id_t service_id,
         &data,
         parameters->clock_id);
     if (status == FWK_E_BUSY) {
-        return_values.status = SCMI_BUSY;
+        return_values.status = (int32_t)SCMI_BUSY;
         status = FWK_SUCCESS;
         goto exit;
     }
@@ -1049,24 +1049,24 @@ static int scmi_clock_config_set_handler(fwk_id_t service_id,
     const struct mod_scmi_clock_device *clock_device;
     unsigned int agent_id;
     struct scmi_clock_rate_set_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR
+        .status = (int32_t)SCMI_GENERIC_ERROR
     };
     enum mod_scmi_clock_policy_status policy_status;
 
     parameters = (const struct scmi_clock_config_set_a2p*)payload;
-    enable = parameters->attributes & SCMI_CLOCK_CONFIG_SET_ENABLE_MASK;
+    enable = (parameters->attributes & SCMI_CLOCK_CONFIG_SET_ENABLE_MASK) != 0;
 
     status = get_clock_device_entry(service_id,
                                     parameters->clock_id,
                                     &clock_device,
                                     &agent);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
     if ((parameters->attributes & ~SCMI_CLOCK_CONFIG_SET_ENABLE_MASK) != 0) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }
 
@@ -1089,11 +1089,11 @@ static int scmi_clock_config_set_handler(fwk_id_t service_id,
         service_id,
         parameters->clock_id);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
         goto exit;
     }
     if (policy_status == MOD_SCMI_CLOCK_SKIP_MESSAGE_HANDLER) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         goto exit;
     }
 
@@ -1104,7 +1104,7 @@ static int scmi_clock_config_set_handler(fwk_id_t service_id,
         &data,
         parameters->clock_id);
     if (status == FWK_E_BUSY) {
-        return_values.status = SCMI_BUSY;
+        return_values.status = (int32_t)SCMI_BUSY;
         status = FWK_SUCCESS;
         goto exit;
     }
@@ -1143,7 +1143,7 @@ static int scmi_clock_describe_rates_handler(fwk_id_t service_id,
     struct mod_clock_info info;
     const struct scmi_clock_describe_rates_a2p *parameters;
     struct scmi_clock_describe_rates_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR
+        .status = (int32_t)SCMI_GENERIC_ERROR
     };
 
     parameters = (const struct scmi_clock_describe_rates_a2p*)payload;
@@ -1155,7 +1155,7 @@ static int scmi_clock_describe_rates_handler(fwk_id_t service_id,
                                     &clock_device,
                                     &agent);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
@@ -1179,7 +1179,7 @@ static int scmi_clock_describe_rates_handler(fwk_id_t service_id,
         /* The clock has a discrete list of frequencies */
 
         if (index >= info.range.rate_count) {
-            return_values.status = SCMI_OUT_OF_RANGE;
+            return_values.status = (int32_t)SCMI_OUT_OF_RANGE;
             goto exit;
         }
 
@@ -1195,7 +1195,8 @@ static int scmi_clock_describe_rates_handler(fwk_id_t service_id,
              clock's maximum rate.
            - The number of rates that can be returned in each payload.
          */
-        rate_count = FWK_MIN(SCMI_CLOCK_RATES_MAX(max_payload_size),
+        rate_count = (unsigned int)FWK_MIN(
+            SCMI_CLOCK_RATES_MAX(max_payload_size),
             info.range.rate_count - index);
 
         /*
@@ -1204,7 +1205,8 @@ static int scmi_clock_describe_rates_handler(fwk_id_t service_id,
          * the clock supports minus the index, with the number of rates being
          * returned in this payload subtracted.
          */
-        remaining_rates = (info.range.rate_count - index) - rate_count;
+        remaining_rates =
+            (unsigned int)(info.range.rate_count - index) - rate_count;
 
         /* Give the number of rates sent in the message payload */
         return_values.num_rates_flags =
@@ -1267,7 +1269,7 @@ static int scmi_clock_describe_rates_handler(fwk_id_t service_id,
         payload_size += sizeof(clock_range);
     }
 
-    return_values.status = SCMI_SUCCESS;
+    return_values.status = (int32_t)SCMI_SUCCESS;
     status = scmi_clock_ctx.scmi_api->write_payload(service_id, 0,
         &return_values, sizeof(return_values));
 
@@ -1286,7 +1288,7 @@ exit:
 static int scmi_clock_get_scmi_protocol_id(fwk_id_t protocol_id,
                                            uint8_t *scmi_protocol_id)
 {
-    *scmi_protocol_id = MOD_SCMI_PROTOCOL_ID_CLOCK;
+    *scmi_protocol_id = (uint8_t)MOD_SCMI_PROTOCOL_ID_CLOCK;
 
     return FWK_SUCCESS;
 }
@@ -1305,12 +1307,12 @@ static int scmi_clock_message_handler(fwk_id_t protocol_id, fwk_id_t service_id,
     fwk_assert(payload != NULL);
 
     if (message_id >= FWK_ARRAY_SIZE(handler_table)) {
-        return_value = SCMI_NOT_FOUND;
+        return_value = (int32_t)SCMI_NOT_FOUND;
         goto error;
     }
 
     if (payload_size != payload_size_table[message_id]) {
-        return_value = SCMI_PROTOCOL_ERROR;
+        return_value = (int32_t)SCMI_PROTOCOL_ERROR;
         goto error;
     }
 
@@ -1431,7 +1433,7 @@ static int process_request_event(const struct fwk_event *event)
     clock_dev_idx = fwk_id_get_element_idx(params->clock_dev_id);
     service_id = clock_ops_get_service(clock_dev_idx);
 
-    switch (fwk_id_get_event_idx(event->id)) {
+    switch ((enum scmi_clock_event_idx)fwk_id_get_event_idx(event->id)) {
     case SCMI_CLOCK_EVENT_IDX_GET_STATE:
         status = scmi_clock_ctx.clock_api->get_state(params->clock_dev_id,
                                                      &clock_state);
@@ -1513,7 +1515,7 @@ static int process_response_event(const struct fwk_event *event)
     if (params->status != FWK_SUCCESS) {
         request_response(params->status, service_id);
     } else {
-        switch (fwk_id_get_event_idx(event->id)) {
+        switch ((enum mod_clock_event_idx)fwk_id_get_event_idx(event->id)) {
         case MOD_CLOCK_EVENT_IDX_GET_STATE_REQUEST:
             clock_state = params->value.state;
 
@@ -1567,7 +1569,7 @@ static int scmi_clock_process_event(const struct fwk_event *event,
 const struct fwk_module module_scmi_clock = {
     .name = "SCMI Clock Management Protocol",
     .api_count = 1,
-    .event_count = SCMI_CLOCK_EVENT_IDX_COUNT,
+    .event_count = (unsigned int)SCMI_CLOCK_EVENT_IDX_COUNT,
     .type = FWK_MODULE_TYPE_PROTOCOL,
     .init = scmi_clock_init,
     .bind = scmi_clock_bind,

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -267,7 +267,7 @@ static int scmi_perf_protocol_version_handler(fwk_id_t service_id,
                                               const uint32_t *payload)
 {
     struct scmi_protocol_version_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .version = SCMI_PROTOCOL_VERSION_PERF,
     };
 
@@ -281,7 +281,7 @@ static int scmi_perf_protocol_attributes_handler(fwk_id_t service_id,
                                                  const uint32_t *payload)
 {
     struct scmi_perf_protocol_attributes_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .attributes =
             SCMI_PERF_PROTOCOL_ATTRIBUTES(true, scmi_perf_ctx.domain_count),
     };
@@ -317,7 +317,7 @@ static int scmi_perf_protocol_message_attributes_handler(fwk_id_t service_id,
             .status = SCMI_SUCCESS,
         };
     } else {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
     }
 
     return_values.attributes = 0;
@@ -345,7 +345,7 @@ static int scmi_perf_domain_attributes_handler(fwk_id_t service_id,
     fwk_id_t domain_id;
     struct mod_dvfs_opp opp;
     struct scmi_perf_domain_attributes_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
     bool notifications = false;
     bool fast_channels = false;
@@ -355,7 +355,7 @@ static int scmi_perf_domain_attributes_handler(fwk_id_t service_id,
     /* Validate the domain identifier */
     if (parameters->domain_id >= scmi_perf_ctx.domain_count) {
         status = FWK_SUCCESS;
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
 
         goto exit;
     }
@@ -370,11 +370,11 @@ static int scmi_perf_domain_attributes_handler(fwk_id_t service_id,
         ((uint32_t)MOD_SCMI_PERF_PERMS_SET_LEVEL);
 #else
     status = scmi_perf_permissions_handler(
-        service_id, payload, MOD_SCMI_PERF_LIMITS_SET);
+        service_id, payload, (unsigned int)MOD_SCMI_PERF_LIMITS_SET);
     if (status == FWK_SUCCESS)
-        permissions = MOD_SCMI_PERF_PERMS_SET_LIMITS;
+        permissions = (uint8_t)MOD_SCMI_PERF_PERMS_SET_LIMITS;
     status = scmi_perf_permissions_handler(
-        service_id, payload, MOD_SCMI_PERF_LEVEL_SET);
+        service_id, payload, (unsigned int)MOD_SCMI_PERF_LEVEL_SET);
     if (status == FWK_SUCCESS)
         permissions |= MOD_SCMI_PERF_PERMS_SET_LEVEL;
 #endif
@@ -441,7 +441,7 @@ static int scmi_perf_describe_levels_handler(fwk_id_t service_id,
     struct mod_dvfs_opp opp;
     uint16_t latency;
     struct scmi_perf_describe_levels_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
 
     payload_size = sizeof(return_values);
@@ -462,7 +462,7 @@ static int scmi_perf_describe_levels_handler(fwk_id_t service_id,
 
     /* Validate the domain identifier */
     if (parameters->domain_id >= scmi_perf_ctx.domain_count) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
 
         goto exit;
     }
@@ -477,7 +477,7 @@ static int scmi_perf_describe_levels_handler(fwk_id_t service_id,
     /* Validate level index */
     level_index = parameters->level_index;
     if (level_index >= opp_count) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
 
         goto exit;
     }
@@ -548,7 +548,7 @@ static int scmi_perf_limits_set_handler(fwk_id_t service_id,
     uint32_t range_min, range_max;
     fwk_id_t domain_id;
     struct scmi_perf_limits_set_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
     enum mod_scmi_perf_policy_status policy_status;
 
@@ -556,7 +556,7 @@ static int scmi_perf_limits_set_handler(fwk_id_t service_id,
 
     if (parameters->domain_id >= scmi_perf_ctx.domain_count) {
         status = FWK_SUCCESS;
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
 
         goto exit;
     }
@@ -567,7 +567,7 @@ static int scmi_perf_limits_set_handler(fwk_id_t service_id,
     }
 
     if (parameters->range_min > parameters->range_max) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }
 
@@ -579,11 +579,11 @@ static int scmi_perf_limits_set_handler(fwk_id_t service_id,
         &range_max, agent_id, domain_id);
 
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
         goto exit;
     }
     if (policy_status == MOD_SCMI_PERF_SKIP_MESSAGE_HANDLER) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         goto exit;
     }
     status = scmi_perf_ctx.dvfs_api->set_level_limits(
@@ -595,11 +595,10 @@ static int scmi_perf_limits_set_handler(fwk_id_t service_id,
     /*
      * Return immediately to the caller, fire-and-forget.
      */
-
     if ((status == FWK_SUCCESS) || (status == FWK_PENDING)) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
     } else {
-        return_values.status = SCMI_OUT_OF_RANGE;
+        return_values.status = (int32_t)SCMI_OUT_OF_RANGE;
     }
 
 exit:
@@ -618,13 +617,13 @@ static int scmi_perf_limits_get_handler(fwk_id_t service_id,
     const struct scmi_perf_limits_get_a2p *parameters;
     struct scmi_perf_event_parameters *evt_params;
     struct scmi_perf_limits_get_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
 
     parameters = (const struct scmi_perf_limits_get_a2p *)payload;
     if (parameters->domain_id >= scmi_perf_ctx.domain_count) {
         status = FWK_SUCCESS;
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
 
         goto exit;
     }
@@ -635,7 +634,7 @@ static int scmi_perf_limits_get_handler(fwk_id_t service_id,
     if (!fwk_id_is_equal(
             scmi_perf_ctx.perf_ops_table[parameters->domain_id].service_id,
             FWK_ID_NONE)){
-        return_values.status = SCMI_BUSY;
+        return_values.status = (int32_t)SCMI_BUSY;
         status = FWK_SUCCESS;
 
         goto exit;
@@ -652,7 +651,7 @@ static int scmi_perf_limits_get_handler(fwk_id_t service_id,
 
     status = fwk_thread_put_event(&event);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
 
         goto exit;
     }
@@ -677,7 +676,7 @@ static int scmi_perf_level_set_handler(fwk_id_t service_id,
     const struct scmi_perf_level_set_a2p *parameters;
     fwk_id_t domain_id;
     struct scmi_perf_level_set_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
     uint32_t perf_level;
     enum mod_scmi_perf_policy_status policy_status;
@@ -685,7 +684,7 @@ static int scmi_perf_level_set_handler(fwk_id_t service_id,
 
     if (parameters->domain_id >= scmi_perf_ctx.domain_count) {
         status = FWK_SUCCESS;
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
 
         goto exit;
     }
@@ -705,11 +704,11 @@ static int scmi_perf_level_set_handler(fwk_id_t service_id,
         domain_id);
 
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
         goto exit;
     }
     if (policy_status == MOD_SCMI_PERF_SKIP_MESSAGE_HANDLER) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         goto exit;
     }
     status = scmi_perf_ctx.dvfs_api->set_level(domain_id, agent_id, perf_level);
@@ -718,9 +717,9 @@ static int scmi_perf_level_set_handler(fwk_id_t service_id,
      * Return immediately to the caller, fire-and-forget.
      */
     if ((status == FWK_SUCCESS) || (status == FWK_PENDING)) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
     } else if (status == FWK_E_RANGE) {
-        return_values.status = SCMI_OUT_OF_RANGE;
+        return_values.status = (int32_t)SCMI_OUT_OF_RANGE;
     }
 
 exit:
@@ -738,15 +737,15 @@ static int scmi_perf_level_get_handler(fwk_id_t service_id,
     const struct scmi_perf_level_get_a2p *parameters;
     struct scmi_perf_event_parameters *evt_params;
     struct scmi_perf_level_get_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
 
-    return_values.status = SCMI_GENERIC_ERROR;
+    return_values.status = (int32_t)SCMI_GENERIC_ERROR;
 
     parameters = (const struct scmi_perf_level_get_a2p *)payload;
     if (parameters->domain_id >= scmi_perf_ctx.domain_count) {
         status = FWK_SUCCESS;
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
 
         goto exit;
     }
@@ -755,7 +754,7 @@ static int scmi_perf_level_get_handler(fwk_id_t service_id,
     if (!fwk_id_is_equal(
             scmi_perf_ctx.perf_ops_table[parameters->domain_id].service_id,
             FWK_ID_NONE)){
-        return_values.status = SCMI_BUSY;
+        return_values.status = (int32_t)SCMI_BUSY;
         status = FWK_SUCCESS;
 
         goto exit;
@@ -773,7 +772,7 @@ static int scmi_perf_level_get_handler(fwk_id_t service_id,
 
     status = fwk_thread_put_event(&event);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
 
         goto exit;
     }
@@ -800,14 +799,14 @@ static int scmi_perf_limits_notify(fwk_id_t service_id,
     unsigned int id;
     const struct scmi_perf_notify_limits_a2p *parameters;
     struct scmi_perf_notify_limits_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
 
     parameters = (const struct scmi_perf_notify_limits_a2p *)payload;
     id = parameters->domain_id;
     if (id >= scmi_perf_ctx.domain_count) {
         status = FWK_SUCCESS;
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
 
         goto exit;
     }
@@ -815,7 +814,7 @@ static int scmi_perf_limits_notify(fwk_id_t service_id,
     if ((parameters->notify_enable &
          ~SCMI_PERF_NOTIFY_LIMITS_NOTIFY_ENABLE_MASK) != 0x0) {
         status = FWK_SUCCESS;
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
 
         goto exit;
     }
@@ -840,7 +839,7 @@ static int scmi_perf_limits_notify(fwk_id_t service_id,
                 MOD_SCMI_PERF_NOTIFY_LIMITS);
     }
 
-    return_values.status = SCMI_SUCCESS;
+    return_values.status = (int32_t)SCMI_SUCCESS;
 
 exit:
     scmi_perf_ctx.scmi_api->respond(service_id, &return_values,
@@ -858,14 +857,14 @@ static int scmi_perf_level_notify(fwk_id_t service_id,
     unsigned int id;
     const struct scmi_perf_notify_level_a2p *parameters;
     struct scmi_perf_notify_level_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
 
     parameters = (const struct scmi_perf_notify_level_a2p *)payload;
     id = parameters->domain_id;
     if (id >= scmi_perf_ctx.domain_count) {
         status = FWK_SUCCESS;
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
 
         goto exit;
     }
@@ -873,7 +872,7 @@ static int scmi_perf_level_notify(fwk_id_t service_id,
     if ((parameters->notify_enable &
          ~SCMI_PERF_NOTIFY_LEVEL_NOTIFY_ENABLE_MASK) != 0x0) {
         status = FWK_SUCCESS;
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
 
         goto exit;
     }
@@ -900,7 +899,7 @@ static int scmi_perf_level_notify(fwk_id_t service_id,
                 MOD_SCMI_PERF_NOTIFY_LEVEL);
     }
 
-    return_values.status = SCMI_SUCCESS;
+    return_values.status = (int32_t)SCMI_SUCCESS;
 
 exit:
     scmi_perf_ctx.scmi_api->respond(service_id, &return_values,
@@ -1080,7 +1079,7 @@ FWK_WEAK int scmi_perf_level_set_policy(
 static int scmi_perf_get_scmi_protocol_id(fwk_id_t protocol_id,
                                           uint8_t *scmi_protocol_id)
 {
-    *scmi_protocol_id = MOD_SCMI_PROTOCOL_ID_PERF;
+    *scmi_protocol_id = (uint8_t)MOD_SCMI_PROTOCOL_ID_PERF;
 
     return FWK_SUCCESS;
 }
@@ -1099,12 +1098,12 @@ static int scmi_perf_message_handler(fwk_id_t protocol_id, fwk_id_t service_id,
     fwk_assert(payload != NULL);
 
     if (message_id >= FWK_ARRAY_SIZE(handler_table)) {
-        return_value = SCMI_NOT_FOUND;
+        return_value = (int32_t)SCMI_NOT_FOUND;
         goto error;
     }
 
     if (payload_size != payload_size_table[message_id]) {
-        return_value = SCMI_PROTOCOL_ERROR;
+        return_value = (int32_t)SCMI_PROTOCOL_ERROR;
         goto error;
     }
 
@@ -1112,9 +1111,9 @@ static int scmi_perf_message_handler(fwk_id_t protocol_id, fwk_id_t service_id,
     status = scmi_perf_permissions_handler(service_id, payload, message_id);
     if (status != FWK_SUCCESS) {
         if (status == FWK_E_PARAM)
-            return_value = SCMI_NOT_FOUND;
+            return_value = (int32_t)SCMI_NOT_FOUND;
         else
-            return_value = SCMI_DENIED;
+            return_value = (int32_t)SCMI_DENIED;
         goto error;
     }
 #endif
@@ -1141,7 +1140,7 @@ static void scmi_perf_respond(
     fwk_id_t domain_id,
     int size)
 {
-    int idx = fwk_id_get_element_idx(domain_id);
+    int idx = (int)fwk_id_get_element_idx(domain_id);
     fwk_id_t service_id;
 
     /*
@@ -1179,7 +1178,7 @@ static void scmi_perf_notify_limits_updated(
     const struct mod_scmi_perf_domain_config *domain;
     struct mod_scmi_perf_fast_channel_limit *get_limit;
 
-    idx = fwk_id_get_element_idx(domain_id);
+    idx = (int)fwk_id_get_element_idx(domain_id);
 
     domain = &(*scmi_perf_ctx.config->domains)[idx];
     if (domain->fast_channels_addr_scp != NULL) {
@@ -1194,7 +1193,7 @@ static void scmi_perf_notify_limits_updated(
 
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS
     limits_changed.agent_id = (uint32_t)cookie;
-    limits_changed.domain_id = idx;
+    limits_changed.domain_id = (uint32_t)idx;
     limits_changed.range_min = range_min;
     limits_changed.range_max = range_max;
 
@@ -1229,7 +1228,7 @@ static void scmi_perf_notify_level_updated(
     int status;
 #endif
 
-    idx = fwk_id_get_element_idx(domain_id);
+    idx = (int)fwk_id_get_element_idx(domain_id);
 
 #ifdef BUILD_HAS_MOD_STATISTICS
     status = scmi_perf_ctx.dvfs_api->get_level_id(domain_id, level, &level_id);
@@ -1250,7 +1249,7 @@ static void scmi_perf_notify_level_updated(
 
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS
     level_changed.agent_id = (uint32_t)cookie;
-    level_changed.domain_id = idx;
+    level_changed.domain_id = (uint32_t)idx;
     level_changed.performance_level = level;
 
     scmi_perf_ctx.scmi_notification_api->scmi_notification_notify(
@@ -1288,11 +1287,11 @@ static int scmi_perf_init(fwk_id_t module_id, unsigned int element_count,
         return FWK_E_SUPPORT;
     }
 
-    scmi_perf_ctx.perf_ops_table = fwk_mm_calloc(return_val,
-        sizeof(struct perf_operations));
+    scmi_perf_ctx.perf_ops_table =
+        fwk_mm_calloc((size_t)return_val, sizeof(struct perf_operations));
 
     scmi_perf_ctx.config = config;
-    scmi_perf_ctx.domain_count = return_val;
+    scmi_perf_ctx.domain_count = (uint32_t)return_val;
 #ifdef BUILD_HAS_FAST_CHANNELS
     scmi_perf_ctx.fast_channels_alarm_id = config->fast_channels_alarm_id;
     if (config->fast_channels_rate_limit < SCMI_PERF_FC_MIN_RATE_LIMIT) {
@@ -1399,7 +1398,7 @@ static int scmi_perf_bind(fwk_id_t id, unsigned int round)
 static int scmi_perf_process_bind_request(fwk_id_t source_id,
     fwk_id_t target_id, fwk_id_t api_id, const void **api)
 {
-    switch (fwk_id_get_api_idx(api_id)) {
+    switch ((enum scmi_perf_api_idx)fwk_id_get_api_idx(api_id)) {
     case MOD_SCMI_PERF_PROTOCOL_API:
         *api = &scmi_perf_mod_scmi_to_protocol_api;
         break;
@@ -1525,7 +1524,7 @@ static int scmi_perf_start(fwk_id_t id)
 #endif
 
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS
-    status = scmi_init_notifications(scmi_perf_ctx.domain_count);
+    status = scmi_init_notifications((int)scmi_perf_ctx.domain_count);
     if (status != FWK_SUCCESS) {
         return status;
     }
@@ -1559,8 +1558,10 @@ static int process_request_event(const struct fwk_event *event)
                 .performance_level = opp.level,
             };
 
-            scmi_perf_respond(&return_values_level, params->domain_id,
-                              sizeof(return_values_level));
+            scmi_perf_respond(
+                &return_values_level,
+                params->domain_id,
+                (int)sizeof(return_values_level));
 
             return status;
         } else if (status == FWK_PENDING) {
@@ -1571,8 +1572,10 @@ static int process_request_event(const struct fwk_event *event)
                 .status = SCMI_HARDWARE_ERROR,
             };
 
-            scmi_perf_respond(&return_values_level, params->domain_id,
-                              sizeof(return_values_level.status));
+            scmi_perf_respond(
+                &return_values_level,
+                params->domain_id,
+                (int)sizeof(return_values_level.status));
 
             return FWK_E_DEVICE;
         }
@@ -1591,8 +1594,10 @@ static int process_request_event(const struct fwk_event *event)
                 .range_max = limits.maximum,
             };
 
-            scmi_perf_respond(&return_values_limits, params->domain_id,
-                              sizeof(return_values_limits));
+            scmi_perf_respond(
+                &return_values_limits,
+                params->domain_id,
+                (int)sizeof(return_values_limits));
 
             return status;
         } else if (status == FWK_PENDING) {
@@ -1603,8 +1608,10 @@ static int process_request_event(const struct fwk_event *event)
                 .status = SCMI_HARDWARE_ERROR,
             };
 
-            scmi_perf_respond(&return_values_limits, params->domain_id,
-                              sizeof(return_values_limits.status));
+            scmi_perf_respond(
+                &return_values_limits,
+                params->domain_id,
+                (int)sizeof(return_values_limits.status));
 
             return FWK_E_DEVICE;
         }
@@ -1629,10 +1636,12 @@ static int process_response_event(const struct fwk_event *event)
             .status = params_level->status,
             .performance_level = params_level->performance_level,
         };
-        scmi_perf_respond(&return_values_level, event->source_id,
+        scmi_perf_respond(
+            &return_values_level,
+            event->source_id,
             (return_values_level.status == SCMI_SUCCESS) ?
-            sizeof(return_values_level) :
-            sizeof(return_values_level.status));
+                (int)sizeof(return_values_level) :
+                (int)sizeof(return_values_level.status));
     }
 
     return FWK_SUCCESS;
@@ -1659,8 +1668,8 @@ static int scmi_perf_process_event(const struct fwk_event *event,
 /* SCMI Performance Management Protocol Definition */
 const struct fwk_module module_scmi_perf = {
     .name = "SCMI Performance Management Protocol",
-    .api_count = MOD_SCMI_PERF_API_COUNT,
-    .event_count = SCMI_PERF_EVENT_IDX_COUNT,
+    .api_count = (unsigned int)MOD_SCMI_PERF_API_COUNT,
+    .event_count = (unsigned int)SCMI_PERF_EVENT_IDX_COUNT,
     .type = FWK_MODULE_TYPE_PROTOCOL,
     .init = scmi_perf_init,
     .bind = scmi_perf_bind,

--- a/module/scmi_power_domain/src/mod_scmi_power_domain.c
+++ b/module/scmi_power_domain/src/mod_scmi_power_domain.c
@@ -251,9 +251,9 @@ static int scmi_device_state_to_pd_state(uint32_t scmi_state,
 
     if (scmi_state_id == SCMI_PD_DEVICE_STATE_ID) {
         if (ctx_lost) {
-            *pd_state = MOD_PD_STATE_OFF;
+            *pd_state = (unsigned int)MOD_PD_STATE_OFF;
         } else {
-            *pd_state = MOD_PD_STATE_ON;
+            *pd_state = (unsigned int)MOD_PD_STATE_ON;
         }
     } else {
         /* Implementation Defined state */
@@ -279,7 +279,7 @@ static int scmi_pd_protocol_version_handler(fwk_id_t service_id,
                                             const uint32_t *payload)
 {
     struct scmi_protocol_version_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .version = SCMI_PROTOCOL_VERSION_POWER_DOMAIN,
     };
 
@@ -293,7 +293,7 @@ static int scmi_pd_protocol_attributes_handler(fwk_id_t service_id,
                                                const uint32_t *payload)
 {
     struct scmi_pd_protocol_attributes_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
     };
 
     return_values.attributes = scmi_pd_ctx.domain_count;
@@ -315,20 +315,20 @@ static int scmi_pd_power_domain_attributes_handler(fwk_id_t service_id,
     unsigned int agent_id;
     enum scmi_agent_type agent_type;
     struct scmi_pd_power_domain_attributes_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
 
     parameters = (const struct scmi_pd_power_domain_attributes_a2p *)payload;
 
     domain_idx = parameters->domain_id;
     if (domain_idx > UINT16_MAX) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
     pd_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, domain_idx);
     if (!fwk_module_is_valid_element_id(pd_id)) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
@@ -387,7 +387,7 @@ static int scmi_pd_power_domain_attributes_handler(fwk_id_t service_id,
         break;
 
     case MOD_PD_TYPE_SYSTEM:
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         /* Fallthrough. */
 
     default:
@@ -397,7 +397,7 @@ static int scmi_pd_power_domain_attributes_handler(fwk_id_t service_id,
     strncpy((char *)return_values.name, fwk_module_get_name(pd_id),
             sizeof(return_values.name) - 1);
 
-    return_values.status = SCMI_SUCCESS;
+    return_values.status = (int32_t)SCMI_SUCCESS;
 
 exit:
     scmi_pd_ctx.scmi_api->respond(service_id, &return_values,
@@ -412,7 +412,7 @@ static int scmi_pd_protocol_message_attributes_handler(
 {
     const struct scmi_protocol_message_attributes_a2p *parameters;
     struct scmi_protocol_message_attributes_p2a return_values = {
-        .status = SCMI_NOT_FOUND,
+        .status = (int32_t)SCMI_NOT_FOUND,
     };
 
     parameters = (const struct scmi_protocol_message_attributes_a2p *)
@@ -420,7 +420,7 @@ static int scmi_pd_protocol_message_attributes_handler(
 
     if ((parameters->message_id < FWK_ARRAY_SIZE(handler_table)) &&
         (handler_table[parameters->message_id] != NULL)) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
     }
 
     scmi_pd_ctx.scmi_api->respond(service_id, &return_values,
@@ -481,7 +481,7 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
     fwk_id_t pd_id;
     unsigned int pd_power_state;
     struct scmi_pd_power_state_set_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR
+        .status = (int32_t)SCMI_GENERIC_ERROR
     };
     enum mod_pd_type pd_type;
     uint32_t power_state;
@@ -505,7 +505,7 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
 
     domain_idx = parameters->domain_id;
     if (domain_idx > UINT16_MAX) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
@@ -513,14 +513,14 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
         ((parameters->power_state &
           ~SCMI_PD_POWER_STATE_SET_POWER_STATE_MASK) != 0x0U)) {
         status = FWK_SUCCESS;
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
 
         goto exit;
     }
 
     pd_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, domain_idx);
     if (!fwk_module_is_valid_element_id(pd_id)) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
@@ -532,9 +532,8 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
     if (((pd_type == MOD_PD_TYPE_CORE) ||
          (pd_type == MOD_PD_TYPE_CLUSTER)) &&
         (agent_type != SCMI_AGENT_TYPE_PSCI)) {
-
-         return_values.status = SCMI_NOT_SUPPORTED;
-         goto exit;
+        return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
+        goto exit;
     }
 
     power_state = parameters->power_state;
@@ -542,11 +541,11 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
         agent_id, pd_id);
 
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
         goto exit;
     }
     if (policy_status == MOD_SCMI_PD_SKIP_MESSAGE_HANDLER) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         goto exit;
     }
 
@@ -558,13 +557,13 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
          */
         status = scmi_power_scp_set_core_state(pd_id, power_state);
         if (status == FWK_E_PARAM) {
-            return_values.status = SCMI_INVALID_PARAMETERS;
+            return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         }
         break;
 
     case MOD_PD_TYPE_CLUSTER:
         if (!is_sync) {
-            return_values.status = SCMI_NOT_SUPPORTED;
+            return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
             goto exit;
         }
 
@@ -636,7 +635,7 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
 
     case MOD_PD_TYPE_DEVICE:
         if (!is_sync) {
-            return_values.status = SCMI_NOT_SUPPORTED;
+            return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
             goto exit;
         }
 
@@ -644,7 +643,7 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
                                                &pd_power_state);
         if (status != FWK_SUCCESS) {
             status = FWK_SUCCESS;
-            return_values.status = SCMI_INVALID_PARAMETERS;
+            return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
             goto exit;
         }
 
@@ -677,7 +676,7 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
         break;
 
     case MOD_PD_TYPE_SYSTEM:
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         /* Fallthrough. */
 
     default:
@@ -685,7 +684,7 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
     }
 
     if (status == FWK_SUCCESS) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
     }
 
 exit:
@@ -704,7 +703,7 @@ static int scmi_pd_power_state_get_handler(fwk_id_t service_id,
     unsigned int domain_idx;
     fwk_id_t pd_id;
     struct scmi_pd_power_state_get_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR
+        .status = (int32_t)SCMI_GENERIC_ERROR
     };
     enum mod_pd_type pd_type;
     unsigned int pd_power_state;
@@ -718,13 +717,13 @@ static int scmi_pd_power_state_get_handler(fwk_id_t service_id,
 
     domain_idx = parameters->domain_id;
     if (domain_idx > UINT16_MAX) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
     pd_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, domain_idx);
     if (!fwk_module_is_valid_element_id(pd_id)) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
@@ -771,7 +770,7 @@ static int scmi_pd_power_state_get_handler(fwk_id_t service_id,
         break;
 
     case MOD_PD_TYPE_SYSTEM:
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         /* Fallthrough. */
 
     default:
@@ -779,7 +778,7 @@ static int scmi_pd_power_state_get_handler(fwk_id_t service_id,
     }
 
     if (status == FWK_SUCCESS) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         return_values.power_state = power_state;
     }
 
@@ -804,30 +803,30 @@ static int scmi_pd_power_state_notify_handler(
     fwk_id_t pd_id;
     const struct scmi_pd_power_state_notify_a2p *parameters;
     struct scmi_pd_power_state_notify_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
 
     parameters = (const struct scmi_pd_power_state_notify_a2p *)payload;
     domain_idx = parameters->domain_id;
     if (domain_idx >= scmi_pd_ctx.domain_count) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
     pd_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, domain_idx);
     if (!fwk_module_is_valid_element_id(pd_id)) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
     status = scmi_pd_ctx.pd_api->get_domain_type(pd_id, &pd_type);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
     if ((parameters->notify_enable & ~SCMI_PD_NOTIFY_ENABLE_MASK) != 0x0) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }
 
@@ -840,13 +839,13 @@ static int scmi_pd_power_state_notify_handler(
      * agent that is notified"
      */
     if (pd_type != MOD_PD_TYPE_DEVICE && pd_type != MOD_PD_TYPE_DEVICE_DEBUG) {
-        return_values.status = SCMI_NOT_SUPPORTED;
+        return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
         goto exit;
     }
 
     status = scmi_pd_ctx.scmi_api->get_agent_id(service_id, &agent_id);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
@@ -864,7 +863,7 @@ static int scmi_pd_power_state_notify_handler(
             command_id);
     }
 
-    return_values.status = SCMI_SUCCESS;
+    return_values.status = (int32_t)SCMI_SUCCESS;
 
 exit:
     scmi_pd_ctx.scmi_api->respond(
@@ -919,7 +918,7 @@ static unsigned int get_pd_domain_id(
     const struct scmi_pd_power_state_set_a2p *params_set;
     const struct scmi_pd_power_state_get_a2p *params_get;
 
-    switch (message_id) {
+    switch ((enum scmi_pd_command_id)message_id) {
     case MOD_SCMI_PD_POWER_STATE_SET:
         params_set = (const struct scmi_pd_power_state_set_a2p *)payload;
         return params_set->domain_id;
@@ -951,7 +950,7 @@ static int scmi_pd_permissions_handler(
 
     status = scmi_pd_ctx.scmi_api->get_agent_id(service_id, &agent_id);
     if (status != FWK_SUCCESS) {
-        *return_values = SCMI_GENERIC_ERROR;
+        *return_values = (int32_t)SCMI_GENERIC_ERROR;
         return FWK_E_PARAM;
     }
 
@@ -966,19 +965,19 @@ static int scmi_pd_permissions_handler(
 
     domain_id = get_pd_domain_id(payload, message_id);
     if (domain_id > UINT16_MAX) {
-        *return_values = SCMI_NOT_FOUND;
+        *return_values = (int32_t)SCMI_NOT_FOUND;
         return FWK_E_ACCESS;
     }
 
     pd_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, domain_id);
     if (!fwk_module_is_valid_element_id(pd_id)) {
-        *return_values = SCMI_NOT_FOUND;
+        *return_values = (int32_t)SCMI_NOT_FOUND;
         return FWK_E_ACCESS;
     }
 
     status = scmi_pd_ctx.pd_api->get_domain_type(pd_id, &pd_type);
     if (status != FWK_SUCCESS) {
-        *return_values = SCMI_GENERIC_ERROR;
+        *return_values = (int32_t)SCMI_GENERIC_ERROR;
         return FWK_E_ACCESS;
     }
 
@@ -989,7 +988,7 @@ static int scmi_pd_permissions_handler(
         return FWK_SUCCESS;
     }
 
-    *return_values = SCMI_DENIED;
+    *return_values = (int32_t)SCMI_DENIED;
     return FWK_E_ACCESS;
 }
 
@@ -1001,7 +1000,7 @@ static int scmi_pd_permissions_handler(
 static int scmi_pd_get_scmi_protocol_id(fwk_id_t protocol_id,
                                         uint8_t *scmi_protocol_id)
 {
-    *scmi_protocol_id = MOD_SCMI_PROTOCOL_ID_POWER_DOMAIN;
+    *scmi_protocol_id = (uint8_t)MOD_SCMI_PROTOCOL_ID_POWER_DOMAIN;
 
     return FWK_SUCCESS;
 }
@@ -1020,12 +1019,12 @@ static int scmi_pd_message_handler(fwk_id_t protocol_id, fwk_id_t service_id,
     fwk_assert(payload != NULL);
 
     if (message_id >= FWK_ARRAY_SIZE(handler_table)) {
-        return_value = SCMI_NOT_FOUND;
+        return_value = (int32_t)SCMI_NOT_FOUND;
         goto error;
     }
 
     if (payload_size != payload_size_table[message_id]) {
-        return_value = SCMI_PROTOCOL_ERROR;
+        return_value = (int32_t)SCMI_PROTOCOL_ERROR;
         goto error;
     }
 
@@ -1065,8 +1064,8 @@ static int scmi_pd_init(fwk_id_t module_id, unsigned int element_count,
         return FWK_E_SUPPORT;
     }
 
-    scmi_pd_ctx.domain_count = fwk_module_get_element_count(
-        fwk_module_id_power_domain);
+    scmi_pd_ctx.domain_count =
+        (unsigned int)fwk_module_get_element_count(fwk_module_id_power_domain);
     if (scmi_pd_ctx.domain_count <= 1) {
         return FWK_E_SUPPORT;
     }

--- a/module/scmi_sensor/src/mod_scmi_sensor.c
+++ b/module/scmi_sensor/src/mod_scmi_sensor.c
@@ -167,7 +167,7 @@ static int scmi_sensor_protocol_version_handler(fwk_id_t service_id,
                                                 const uint32_t *payload)
 {
     struct scmi_protocol_version_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .version = SCMI_PROTOCOL_VERSION_SENSOR,
     };
 
@@ -181,7 +181,7 @@ static int scmi_sensor_protocol_attributes_handler(fwk_id_t service_id,
                                                    const uint32_t *payload)
 {
     struct scmi_sensor_protocol_attributes_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .attributes = scmi_sensor_ctx.sensor_count,
         .sensor_reg_len = 0, /* Unsupported */
     };
@@ -209,7 +209,7 @@ static int scmi_sensor_protocol_msg_attributes_handler(fwk_id_t service_id,
             .attributes = 0,
         };
     } else {
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
     }
 
     scmi_sensor_ctx.scmi_api->respond(service_id, &return_values,
@@ -231,7 +231,7 @@ static int scmi_sensor_protocol_desc_get_handler(fwk_id_t service_id,
     unsigned int num_descs, desc_index, desc_index_max;
     struct mod_sensor_scmi_info sensor_info;
     struct scmi_sensor_protocol_description_get_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
     fwk_id_t sensor_id;
 
@@ -254,7 +254,7 @@ static int scmi_sensor_protocol_desc_get_handler(fwk_id_t service_id,
     desc_index = parameters->desc_index;
 
     if (desc_index >= scmi_sensor_ctx.sensor_count) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }
 
@@ -273,7 +273,7 @@ static int scmi_sensor_protocol_desc_get_handler(fwk_id_t service_id,
         sensor_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_SENSOR, desc_index);
         if (!fwk_module_is_valid_element_id(sensor_id)) {
             /* domain_idx did not map to a sensor device */
-            return_values.status = SCMI_NOT_FOUND;
+            return_values.status = (int32_t)SCMI_NOT_FOUND;
             goto exit_unexpected;
         }
 
@@ -350,7 +350,7 @@ static int scmi_sensor_protocol_desc_get_handler(fwk_id_t service_id,
     status = scmi_sensor_ctx.scmi_api->write_payload(service_id, 0,
         &return_values, sizeof(return_values));
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
     }
     goto exit;
 
@@ -500,19 +500,20 @@ static int scmi_sensor_reading_get_handler(fwk_id_t service_id,
     int status;
 
     parameters = (const struct scmi_sensor_protocol_reading_get_a2p *)payload;
-    return_values.status = SCMI_GENERIC_ERROR;
+    return_values.status = (int32_t)SCMI_GENERIC_ERROR;
 
     if (parameters->sensor_id >= scmi_sensor_ctx.sensor_count) {
         /* Sensor does not exist */
         status = FWK_SUCCESS;
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
     flags = parameters->flags;
+
     if ((flags & ~SCMI_SENSOR_PROTOCOL_READING_GET_ASYNC_FLAG_MASK) !=
         (uint32_t)0) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         status = FWK_SUCCESS;
         goto exit;
     }
@@ -520,7 +521,7 @@ static int scmi_sensor_reading_get_handler(fwk_id_t service_id,
     /* Reject asynchronous read requests for now */
     if ((flags & SCMI_SENSOR_PROTOCOL_READING_GET_ASYNC_FLAG_MASK) !=
         (uint32_t)0) {
-        return_values.status = SCMI_NOT_SUPPORTED;
+        return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
         status = FWK_SUCCESS;
         goto exit;
     }
@@ -531,7 +532,7 @@ static int scmi_sensor_reading_get_handler(fwk_id_t service_id,
     if (!fwk_id_is_equal(
             scmi_sensor_ctx.sensor_ops_table[sensor_idx].service_id,
             FWK_ID_NONE)){
-        return_values.status = SCMI_BUSY;
+        return_values.status = (int32_t)SCMI_BUSY;
         status = FWK_SUCCESS;
 
         goto exit;
@@ -549,7 +550,7 @@ static int scmi_sensor_reading_get_handler(fwk_id_t service_id,
 
     status = fwk_thread_put_event(&event);
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
 
         goto exit;
     }
@@ -573,7 +574,7 @@ exit:
 static int scmi_sensor_get_scmi_protocol_id(fwk_id_t protocol_id,
                                             uint8_t *scmi_protocol_id)
 {
-    *scmi_protocol_id = MOD_SCMI_PROTOCOL_ID_SENSOR;
+    *scmi_protocol_id = (uint8_t)MOD_SCMI_PROTOCOL_ID_SENSOR;
 
     return FWK_SUCCESS;
 }
@@ -652,13 +653,13 @@ static int scmi_sensor_message_handler(fwk_id_t protocol_id,
     fwk_assert(payload != NULL);
 
     if (message_id >= FWK_ARRAY_SIZE(handler_table)) {
-        return_value = SCMI_NOT_FOUND;
+        return_value = (int32_t)SCMI_NOT_FOUND;
         goto error;
     }
 
     if (payload_size != payload_size_table[message_id]) {
         /* Incorrect payload size or message is not supported */
-        return_value = SCMI_PROTOCOL_ERROR;
+        return_value = (int32_t)SCMI_PROTOCOL_ERROR;
         goto error;
     }
 
@@ -667,11 +668,11 @@ static int scmi_sensor_message_handler(fwk_id_t protocol_id,
         service_id, payload, payload_size, message_id);
     if (status != FWK_SUCCESS) {
         if (status == FWK_E_ACCESS) {
-            return_value = SCMI_DENIED;
+            return_value = (int32_t)SCMI_DENIED;
         } else if (message_id == MOD_SCMI_SENSOR_DESCRIPTION_GET) {
-            return_value = SCMI_INVALID_PARAMETERS;
+            return_value = (int32_t)SCMI_INVALID_PARAMETERS;
         } else {
-            return_value = SCMI_NOT_FOUND;
+            return_value = (int32_t)SCMI_NOT_FOUND;
         }
         goto error;
     }
@@ -727,7 +728,7 @@ static int scmi_sensor_init(fwk_id_t module_id,
         return FWK_E_SUPPORT;
     }
 
-    scmi_sensor_ctx.sensor_count = fwk_module_get_element_count(
+    scmi_sensor_ctx.sensor_count = (unsigned int)fwk_module_get_element_count(
         FWK_ID_MODULE(FWK_MODULE_IDX_SENSOR));
     if (scmi_sensor_ctx.sensor_count == 0) {
         return FWK_E_SUPPORT;
@@ -830,7 +831,7 @@ static int scmi_sensor_start(fwk_id_t id)
     int status = FWK_SUCCESS;
 
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS
-    status = scmi_init_notifications(scmi_sensor_ctx.sensor_count);
+    status = scmi_init_notifications((int)scmi_sensor_ctx.sensor_count);
     if (status != FWK_SUCCESS) {
         return status;
     }
@@ -844,7 +845,7 @@ static int scmi_sensor_process_bind_request(fwk_id_t source_id,
                                             fwk_id_t api_id,
                                             const void **api)
 {
-    switch (fwk_id_get_api_idx(api_id)) {
+    switch ((enum scmi_sensor_api_idx)fwk_id_get_api_idx(api_id)) {
     case SCMI_SENSOR_API_IDX_REQUEST:
         if (!fwk_id_is_equal(source_id, FWK_ID_MODULE(FWK_MODULE_IDX_SCMI))) {
             return FWK_E_ACCESS;
@@ -912,9 +913,9 @@ static int scmi_sensor_process_event(const struct fwk_event *event,
         };
 
         if (params->status == FWK_SUCCESS) {
-            return_values.status = SCMI_SUCCESS;
+            return_values.status = (int32_t)SCMI_SUCCESS;
         } else {
-            return_values.status = SCMI_HARDWARE_ERROR;
+            return_values.status = (int32_t)SCMI_HARDWARE_ERROR;
         }
 
         scmi_sensor_respond(&return_values, event->source_id);
@@ -925,8 +926,8 @@ static int scmi_sensor_process_event(const struct fwk_event *event,
 
 const struct fwk_module module_scmi_sensor = {
     .name = "SCMI sensor management",
-    .api_count = SCMI_SENSOR_API_IDX_COUNT,
-    .event_count = SCMI_SENSOR_EVENT_IDX_COUNT,
+    .api_count = (unsigned int)SCMI_SENSOR_API_IDX_COUNT,
+    .event_count = (unsigned int)SCMI_SENSOR_EVENT_IDX_COUNT,
     .type = FWK_MODULE_TYPE_PROTOCOL,
     .init = scmi_sensor_init,
     .bind = scmi_sensor_bind,

--- a/module/scmi_system_power/src/mod_scmi_system_power.c
+++ b/module/scmi_system_power/src/mod_scmi_system_power.c
@@ -111,7 +111,7 @@ static int system_state_get(enum scmi_system_state *system_state)
         return status;
     }
 
-    switch (state) {
+    switch ((enum mod_pd_state)state) {
     case MOD_PD_STATE_OFF:
         *system_state = SCMI_SYSTEM_STATE_SHUTDOWN;
         break;
@@ -186,7 +186,7 @@ static int scmi_sys_power_version_handler(fwk_id_t service_id,
                                           const uint32_t *payload)
 {
     struct scmi_protocol_version_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .version = SCMI_PROTOCOL_VERSION_SYS_POWER,
     };
 
@@ -202,7 +202,7 @@ static int scmi_sys_power_attributes_handler(fwk_id_t service_id,
                                              const uint32_t *payload)
 {
     struct scmi_protocol_attributes_p2a return_values = {
-        .status = SCMI_SUCCESS,
+        .status = (int32_t)SCMI_SUCCESS,
         .attributes = 0,
     };
 
@@ -230,7 +230,7 @@ static int scmi_sys_power_msg_attributes_handler(fwk_id_t service_id,
  */
 #ifndef BUILD_HAS_SCMI_NOTIFICATIONS
     if (message_id == MOD_SCMI_SYS_POWER_STATE_NOTIFY) {
-        return_values.status = SCMI_NOT_SUPPORTED;
+        return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
 
         goto exit;
     }
@@ -238,8 +238,7 @@ static int scmi_sys_power_msg_attributes_handler(fwk_id_t service_id,
 
     if ((message_id >= FWK_ARRAY_SIZE(handler_table)) ||
         (handler_table[message_id] == NULL)) {
-
-        return_values.status = SCMI_NOT_FOUND;
+        return_values.status = (int32_t)SCMI_NOT_FOUND;
         goto exit;
     }
 
@@ -270,7 +269,7 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
     int status = FWK_SUCCESS;
     const struct scmi_sys_power_state_set_a2p *parameters;
     struct scmi_sys_power_state_set_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
     unsigned int agent_id;
     enum scmi_agent_type agent_type;
@@ -281,7 +280,7 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
     parameters = (const struct scmi_sys_power_state_set_a2p *)payload;
 
     if (parameters->flags & (uint32_t)(~STATE_SET_FLAGS_MASK)) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }
 
@@ -297,8 +296,7 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
 
     if ((agent_type != SCMI_AGENT_TYPE_PSCI) &&
         (agent_type != SCMI_AGENT_TYPE_MANAGEMENT)) {
-
-        return_values.status = SCMI_NOT_SUPPORTED;
+        return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
         goto exit;
     }
 
@@ -312,17 +310,17 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
         &policy_status,
         &scmi_system_state,
         service_id,
-        (parameters->flags & (uint32_t)STATE_SET_FLAGS_GRACEFUL_REQUEST));
+        (parameters->flags & (uint32_t)STATE_SET_FLAGS_GRACEFUL_REQUEST) != 0);
 
     if (status != FWK_SUCCESS) {
-        return_values.status = SCMI_GENERIC_ERROR;
+        return_values.status = (int32_t)SCMI_GENERIC_ERROR;
         goto exit;
     }
     if (policy_status == MOD_SCMI_SYS_POWER_SKIP_MESSAGE_HANDLER) {
-        return_values.status = SCMI_SUCCESS;
+        return_values.status = (int32_t)SCMI_SUCCESS;
         goto exit;
     }
-    switch (scmi_system_state) {
+    switch ((enum scmi_system_state)scmi_system_state) {
     case SCMI_SYSTEM_STATE_SHUTDOWN:
     case SCMI_SYSTEM_STATE_COLD_RESET:
     case SCMI_SYSTEM_STATE_WARM_RESET:
@@ -346,7 +344,7 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
         if (status != FWK_SUCCESS) {
             if (status == FWK_E_STATE) {
                 status = FWK_SUCCESS;
-                return_values.status = SCMI_DENIED;
+                return_values.status = (int32_t)SCMI_DENIED;
             }
             goto exit;
         }
@@ -356,8 +354,7 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
         if ((agent_type != SCMI_AGENT_TYPE_MANAGEMENT) ||
             (scmi_sys_power_ctx.config->system_view !=
              MOD_SCMI_SYSTEM_VIEW_OSPM)) {
-
-            return_values.status = SCMI_NOT_SUPPORTED;
+            return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
             goto exit;
         }
 
@@ -368,8 +365,7 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
 
         if ((scmi_system_state != SCMI_SYSTEM_STATE_SHUTDOWN) &&
             (scmi_system_state != SCMI_SYSTEM_STATE_SUSPEND)) {
-
-            return_values.status = SCMI_DENIED;
+            return_values.status = (int32_t)SCMI_DENIED;
             goto exit;
         }
 
@@ -382,7 +378,7 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
         break;
 
     default:
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     };
 
@@ -396,11 +392,11 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
         scmi_sys_power_state_notify(
             service_id,
             scmi_system_state,
-            parameters->flags & STATE_SET_FLAGS_GRACEFUL_REQUEST);
+            (parameters->flags & STATE_SET_FLAGS_GRACEFUL_REQUEST) != 0);
     }
 #endif
 
-    return_values.status = SCMI_SUCCESS;
+    return_values.status = (int32_t)SCMI_SUCCESS;
 
 exit:
     scmi_sys_power_ctx.scmi_api->respond(service_id, &return_values,
@@ -418,7 +414,7 @@ static int scmi_sys_power_state_get_handler(fwk_id_t service_id,
 {
     int status = FWK_SUCCESS;
     struct scmi_sys_power_state_get_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
     enum scmi_system_state system_state;
     unsigned int agent_id;
@@ -434,7 +430,7 @@ static int scmi_sys_power_state_get_handler(fwk_id_t service_id,
         goto exit;
     }
 
-    return_values.status = SCMI_NOT_SUPPORTED;
+    return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
     if (scmi_sys_power_ctx.config->system_view == MOD_SCMI_SYSTEM_VIEW_FULL) {
         goto exit;
     } else {
@@ -471,7 +467,7 @@ static int scmi_sys_power_state_notify_handler(fwk_id_t service_id,
     unsigned int agent_id;
     const struct scmi_sys_power_state_notify_a2p *parameters;
     struct scmi_sys_power_state_notify_p2a return_values = {
-        .status = SCMI_GENERIC_ERROR,
+        .status = (int32_t)SCMI_GENERIC_ERROR,
     };
     int status;
 
@@ -483,7 +479,7 @@ static int scmi_sys_power_state_notify_handler(fwk_id_t service_id,
     parameters = (const struct scmi_sys_power_state_notify_a2p *)payload;
 
     if (parameters->flags & (~STATE_NOTIFY_FLAGS_MASK)) {
-        return_values.status = SCMI_INVALID_PARAMETERS;
+        return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }
 
@@ -493,7 +489,7 @@ static int scmi_sys_power_state_notify_handler(fwk_id_t service_id,
         scmi_sys_power_ctx.system_power_notifications[agent_id] = FWK_ID_NONE;
     }
 
-    return_values.status = SCMI_SUCCESS;
+    return_values.status = (int32_t)SCMI_SUCCESS;
 
 exit:
     scmi_sys_power_ctx.scmi_api->respond(service_id, &return_values,
@@ -599,7 +595,7 @@ static int scmi_sys_power_permissions_handler(
 static int scmi_sys_power_get_scmi_protocol_id(fwk_id_t protocol_id,
                                                uint8_t *scmi_protocol_id)
 {
-    *scmi_protocol_id = MOD_SCMI_PROTOCOL_ID_SYS_POWER;
+    *scmi_protocol_id = (uint8_t)MOD_SCMI_PROTOCOL_ID_SYS_POWER;
 
     return FWK_SUCCESS;
 }
@@ -622,13 +618,13 @@ static int scmi_sys_power_handler(fwk_id_t protocol_id,
     fwk_assert(payload != NULL);
 
     if (message_id >= FWK_ARRAY_SIZE(handler_table)) {
-        return_value = SCMI_NOT_FOUND;
+        return_value = (int32_t)SCMI_NOT_FOUND;
         goto error;
     }
 
     if (payload_size != payload_size_table[message_id]) {
         /* Incorrect payload size or message is not supported */
-        return_value = SCMI_PROTOCOL_ERROR;
+        return_value = (int32_t)SCMI_PROTOCOL_ERROR;
         goto error;
     }
 
@@ -636,7 +632,7 @@ static int scmi_sys_power_handler(fwk_id_t protocol_id,
     status = scmi_sys_power_permissions_handler(
         service_id, payload, payload_size, message_id);
     if (status != FWK_SUCCESS) {
-        return_value = SCMI_DENIED;
+        return_value = (int32_t)SCMI_DENIED;
         goto error;
     }
 #endif
@@ -679,8 +675,8 @@ static int scmi_sys_power_init_notifications(void)
     }
     fwk_assert(scmi_sys_power_ctx.agent_count != 0);
 
-    scmi_sys_power_ctx.system_power_notifications = fwk_mm_calloc(
-        scmi_sys_power_ctx.agent_count, sizeof(fwk_id_t));
+    scmi_sys_power_ctx.system_power_notifications =
+        fwk_mm_calloc((size_t)scmi_sys_power_ctx.agent_count, sizeof(fwk_id_t));
 
     for (i = 0; i < scmi_sys_power_ctx.agent_count; i++) {
         scmi_sys_power_ctx.system_power_notifications[i] = FWK_ID_NONE;

--- a/module/sds/src/mod_sds.c
+++ b/module/sds/src/mod_sds.c
@@ -157,8 +157,10 @@ static bool header_is_valid(const volatile struct region_descriptor *region,
     return true;
 }
 
-static bool validate_structure_access(uint32_t structure_size, uint32_t offset,
-                                      size_t access_size)
+static bool validate_structure_access(
+    uint32_t structure_size,
+    uint32_t offset,
+    size_t access_size)
 {
     if ((offset >= structure_size) || (access_size > structure_size)) {
         return FWK_E_PARAM;
@@ -297,7 +299,7 @@ static int struct_alloc(const struct mod_sds_structure_desc *struct_desc)
 
     /* Zero the memory reserved for the structure, avoiding the header */
     for (unsigned int i = 0; i < padded_size; i++) {
-        (*free_mem_base)[i] = 0u;
+        (*free_mem_base)[i] = '\0';
     }
     *free_mem_base += padded_size;
     *free_mem_size -= padded_size;
@@ -520,8 +522,8 @@ static int init_sds(void)
 
     element_count = fwk_module_get_element_count(fwk_module_id_sds);
     for (element_idx = 0; element_idx < element_count; ++element_idx) {
-        struct_desc = fwk_module_get_data(
-            fwk_id_build_element_id(fwk_module_id_sds, element_idx));
+        struct_desc = fwk_module_get_data(fwk_id_build_element_id(
+            fwk_module_id_sds, (unsigned int)element_idx));
 
         status = struct_init(struct_desc);
         if (status != FWK_SUCCESS) {
@@ -698,7 +700,7 @@ const struct fwk_module module_sds = {
     .type = FWK_MODULE_TYPE_SERVICE,
     .api_count = 1,
     .event_count = 0,
-    .notification_count = MOD_SDS_NOTIFICATION_IDX_COUNT,
+    .notification_count = (unsigned int)MOD_SDS_NOTIFICATION_IDX_COUNT,
     .init = sds_init,
     .element_init = sds_element_init,
     .process_bind_request = sds_process_bind_request,

--- a/module/sensor/src/mod_sensor.c
+++ b/module/sensor/src/mod_sensor.c
@@ -404,8 +404,7 @@ static int sensor_process_event(const struct fwk_event *event,
 
     ctx = ctx_table + fwk_id_get_element_idx(event->target_id);
 
-    switch (fwk_id_get_event_idx(event->id)) {
-
+    switch ((enum mod_sensor_event_idx)fwk_id_get_event_idx(event->id)) {
     case SENSOR_EVENT_IDX_READ_REQUEST:
         ctx->cookie = event->cookie;
         resp_event->is_delayed_response = true;
@@ -432,8 +431,8 @@ static int sensor_process_event(const struct fwk_event *event,
 
 const struct fwk_module module_sensor = {
     .name = "SENSOR",
-    .api_count = MOD_SENSOR_API_IDX_COUNT,
-    .event_count = SENSOR_EVENT_IDX_COUNT,
+    .api_count = (unsigned int)MOD_SENSOR_API_IDX_COUNT,
+    .event_count = (unsigned int)SENSOR_EVENT_IDX_COUNT,
     .type = FWK_MODULE_TYPE_HAL,
     .init = sensor_init,
     .element_init = sensor_dev_init,

--- a/module/smt/src/mod_smt.c
+++ b/module/smt/src/mod_smt.c
@@ -514,7 +514,7 @@ static int smt_process_bind_request(fwk_id_t source_id,
     channel_ctx =
         &smt_ctx.channel_ctx_table[fwk_id_get_element_idx(target_id)];
 
-    switch (fwk_id_get_api_idx(api_id)) {
+    switch ((enum mod_smt_api_idx)fwk_id_get_api_idx(api_id)) {
     case MOD_SMT_API_IDX_DRIVER_INPUT:
         /* Driver input API */
 
@@ -635,8 +635,8 @@ static int smt_process_notification(
 const struct fwk_module module_smt = {
     .name = "smt",
     .type = FWK_MODULE_TYPE_SERVICE,
-    .api_count = MOD_SMT_API_IDX_COUNT,
-    .notification_count = MOD_SMT_NOTIFICATION_IDX_COUNT,
+    .api_count = (unsigned int)MOD_SMT_API_IDX_COUNT,
+    .notification_count = (unsigned int)MOD_SMT_NOTIFICATION_IDX_COUNT,
     .init = smt_init,
     .element_init = smt_channel_init,
     .bind = smt_bind,

--- a/module/statistics/src/mod_stats.c
+++ b/module/statistics/src/mod_stats.c
@@ -180,7 +180,8 @@ _allocate_stats_context(int domain_count, int used_domains)
 
     stats = fwk_mm_calloc(1, sizeof(struct mod_stats_info));
     stats->context = fwk_mm_calloc(1, sizeof(struct mod_stats_context));
-    stats->context->se_index_map = fwk_mm_calloc(domain_count, sizeof(int));
+    stats->context->se_index_map =
+        (int *)fwk_mm_calloc((size_t)domain_count, sizeof(int));
 
     stats->mode = STATS_SETUP;
 
@@ -200,11 +201,14 @@ _allocate_stats_context(int domain_count, int used_domains)
     se_map_size *= sizeof(struct mod_stats_domain_stats_data *);
     se_map_size += sizeof(struct mod_stats_map);
 
-    stats->context->se_stats_map = fwk_mm_calloc(1, se_map_size);
+    stats->context->se_stats_map =
+        (struct mod_stats_map *)fwk_mm_calloc(1, (size_t)se_map_size);
     se_map = stats->context->se_stats_map;
 
-    se_map->se_level_count = fwk_mm_calloc(used_domains, sizeof(int));
-    se_map->se_curr_level = fwk_mm_calloc(used_domains, sizeof(uint32_t));
+    se_map->se_level_count =
+        (int *)fwk_mm_calloc((size_t)used_domains, sizeof(int));
+    se_map->se_curr_level =
+        (uint32_t *)fwk_mm_calloc((size_t)used_domains, sizeof(uint32_t));
 
     return stats;
 }
@@ -230,7 +234,7 @@ static int stats_init_module(fwk_id_t module_id,
     }
 
     stats->desc_header->signature = stats->type_signature;
-    stats->desc_header->domain_count = domain_count;
+    stats->desc_header->domain_count = (uint16_t)domain_count;
 
     return FWK_SUCCESS;
 }
@@ -309,7 +313,7 @@ static int stats_add_domain(fwk_id_t module_id,
         return FWK_E_PARAM;
     }
 
-    domain_stats->level_count = level_count;
+    domain_stats->level_count = (uint16_t)level_count;
 
     for (i = 0; i < level_count; i++) {
         level_stats = &domain_stats->level[i];
@@ -381,7 +385,7 @@ stats_update_domain(fwk_id_t module_id, fwk_id_t domain_id, uint32_t level_id)
     level_stats = &domain_stats->level[level_id];
     level_stats->usage_count++;
     domain_stats->ts_last_change_us = ts_now_us;
-    domain_stats->curr_level_id = level_id;
+    domain_stats->curr_level_id = (uint16_t)level_id;
     se_map->se_curr_level[stats_id] = level_id;
 
     fwk_interrupt_global_enable();
@@ -597,5 +601,5 @@ const struct fwk_module module_statistics = {
     .start = stats_start,
     .bind = stats_bind,
     .process_bind_request = process_bind_request,
-    .api_count = MOD_STATS_API_IDX_COUNT,
+    .api_count = (unsigned int)MOD_STATS_API_IDX_COUNT,
 };

--- a/module/system_power/src/mod_system_power.c
+++ b/module/system_power/src/mod_system_power.c
@@ -200,7 +200,7 @@ static int shutdown(
     /* Shutdown external PPUs */
     ext_ppus_shutdown(system_shutdown);
 
-    system_power_ctx.requested_state = MOD_PD_STATE_OFF;
+    system_power_ctx.requested_state = (unsigned int)MOD_PD_STATE_OFF;
 
     /* Shutdown system PPUs */
     status = shutdown_system_power_ppus(system_shutdown);
@@ -229,7 +229,7 @@ static int system_power_set_state(fwk_id_t pd_id, unsigned int state)
     system_power_ctx.requested_state = state;
 
     switch (state) {
-    case MOD_PD_STATE_ON:
+    case (unsigned int)MOD_PD_STATE_ON:
         status = disable_all_irqs();
         if (status != FWK_SUCCESS) {
             return status;
@@ -244,7 +244,7 @@ static int system_power_set_state(fwk_id_t pd_id, unsigned int state)
 
         break;
 
-    case MOD_SYSTEM_POWER_POWER_STATE_SLEEP0:
+    case (unsigned int)MOD_SYSTEM_POWER_POWER_STATE_SLEEP0:
         ext_ppus_set_state(MOD_PD_STATE_OFF);
 
         fwk_interrupt_clear_pending(soc_wakeup_irq);
@@ -282,7 +282,7 @@ static int system_power_set_state(fwk_id_t pd_id, unsigned int state)
 
         break;
 
-    case MOD_PD_STATE_OFF:
+    case (unsigned int)MOD_PD_STATE_OFF:
         status = disable_all_irqs();
         if (status != FWK_SUCCESS) {
             return status;
@@ -554,7 +554,7 @@ static int system_power_start(fwk_id_t id)
 const struct fwk_module module_system_power = {
     .name = "SYSTEM_POWER",
     .type = FWK_MODULE_TYPE_DRIVER,
-    .api_count = MOD_SYSTEM_POWER_API_COUNT,
+    .api_count = (unsigned int)MOD_SYSTEM_POWER_API_COUNT,
     .init = system_power_mod_init,
     .element_init = system_power_mod_element_init,
     .bind = system_power_bind,

--- a/module/timer/src/mod_timer.c
+++ b/module/timer/src/mod_timer.c
@@ -669,7 +669,7 @@ static int timer_start(fwk_id_t id)
 /* Module descriptor */
 const struct fwk_module module_timer = {
     .name = "Timer HAL",
-    .api_count = MOD_TIMER_API_COUNT,
+    .api_count = (unsigned int)MOD_TIMER_API_COUNT,
     .type = FWK_MODULE_TYPE_HAL,
     .init = timer_init,
     .element_init = timer_device_init,


### PR DESCRIPTION
MISRA 10.3 defects relating to framework and module files will be addressed in this PR. 

The 10.3 rule states "the value of an expression shall not be assigned to an object with a narrower essential type or of a different essential type category".