### PR TITLE
sds: clear data valid flag after SCP RAM FW has been transferred

### DIFF
--- a/module/bootloader/src/mod_bootloader.c
+++ b/module/bootloader/src/mod_bootloader.c
@@ -64,6 +64,7 @@ static int load_image(void)
 
     uint32_t image_flags;
     uint32_t image_offset;
+    uint32_t zero_flag = 0;
 #endif
 
     const uint8_t *image_base;
@@ -109,7 +110,19 @@ static int load_image(void)
                 break;
             }
         }
+        /*
+         * Clear the image flag, so that at reboot if the RAM contents are
+         * retained, then it would need to be set again by AP.
+         */
+        status = module_ctx.sds_api->struct_write(
+            module_ctx.module_config->sds_struct_id,
+            BOOTLOADER_STRUCT_VALID_POS,
+            &zero_flag,
+            sizeof(zero_flag));
 
+        if (status != FWK_SUCCESS) {
+            return status;
+        }
         /*
          * The image metadata from Trusted Firmware can now be read and
          * validated.


### PR DESCRIPTION
At reboot, the AP SRAM can retain its contents. In that case, if the
image flag indicating SCP RAM FW transfer isn't cleared, the ROM FW
will find a valid sds struct, with the flag set and copy whatever
is present in AP SRAM as SCP RAM FW for execution, before AP has
a chance to set the flag.
Hence clear the image flag, so that at reboot, the flag is set by AP only
after the RAM FW has been copied.

Signed-off-by: Usama Arif <usama.arif@arm.com>
Change-Id: I88a574daa4876102a7390e227e23016c01cbf986