### PR TITLE
Fwk log level improvements

### DIFF
--- a/framework/include/fwk_log.h
+++ b/framework/include/fwk_log.h
@@ -184,33 +184,6 @@
  */
 
 /*!
- * \internal
- *
- * \brief Void the result of an expression.
- *
- * \details This is used to prevent the compiler from complaining about unused
- *      variables when filtering logging calls at preprocessing time.
- *
- * \param[in] EXPR The expression to void.
- */
-#define FWK_LOG_VOID_EXPR(EXPR) ((void)(EXPR));
-
-/*!
- * \internal
- *
- * \brief Void the result of multiple expressions.
- *
- * \details This is used to prevent the compiler from complaining about unused
- *      variables when filtering logging calls at preprocessing time.
- *
- * \param[in] ... The expressions to void.
- */
-#define FWK_LOG_VOID(...) \
-    do { \
-        FWK_MAP(FWK_LOG_VOID_EXPR, __VA_ARGS__) \
-    } while (0)
-
-/*!
  * \brief Flush the logging backend.
  *
  * \details Flushing ensures that all data buffered by either the framework or
@@ -234,7 +207,7 @@
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
 #    define FWK_LOG_TRACE(...) fwk_log_printf(__VA_ARGS__)
 #else
-#    define FWK_LOG_TRACE(...) FWK_LOG_VOID(__VA_ARGS__)
+#    define FWK_LOG_TRACE(...)
 #endif
 
 /*!
@@ -248,7 +221,7 @@
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
 #    define FWK_LOG_INFO(...) fwk_log_printf(__VA_ARGS__)
 #else
-#    define FWK_LOG_INFO(...) FWK_LOG_VOID(__VA_ARGS__)
+#    define FWK_LOG_INFO(...)
 #endif
 
 /*!
@@ -262,7 +235,7 @@
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_WARN
 #    define FWK_LOG_WARN(...) fwk_log_printf(__VA_ARGS__)
 #else
-#    define FWK_LOG_WARN(...) FWK_LOG_VOID(__VA_ARGS__)
+#    define FWK_LOG_WARN(...)
 #endif
 
 /*!
@@ -276,7 +249,7 @@
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_ERROR
 #    define FWK_LOG_ERR(...) fwk_log_printf(__VA_ARGS__)
 #else
-#    define FWK_LOG_ERR(...) FWK_LOG_VOID(__VA_ARGS__)
+#    define FWK_LOG_ERR(...)
 #endif
 
 /*!
@@ -290,7 +263,7 @@
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_CRIT
 #    define FWK_LOG_CRIT(...) fwk_log_printf(__VA_ARGS__)
 #else
-#    define FWK_LOG_CRIT(...) FWK_LOG_VOID(__VA_ARGS__)
+#    define FWK_LOG_CRIT(...)
 #endif
 
 /*!

--- a/framework/src/fwk_log.c
+++ b/framework/src/fwk_log.c
@@ -178,12 +178,16 @@ static void fwk_log_snprintf(
 
 static bool fwk_log_banner(void)
 {
+#ifndef FMW_LOG_MINIMAL_BANNER
     const char *banner =
         " ___  ___ ___      __ _\n"
         "/ __|/ __| _ \\___ / _(_)_ _ _ ____ __ ____ _ _ _ ___\n"
         "\\__ | (__|  _|___|  _| | '_| '  \\ V  V / _` | '_/ -_)\n"
         "|___/\\___|_|     |_| |_|_| |_|_|_\\_/\\_/\\__,_|_| \\___|\n"
         "\n" BUILD_VERSION_DESCRIBE_STRING "\n";
+#else
+    const char *banner = "SCP-firmware " BUILD_VERSION_DESCRIBE_STRING "\n";
+#endif
 
     while (banner != NULL) {
         char buffer[FMW_LOG_COLUMNS + sizeof(FWK_LOG_TERMINATOR)];

--- a/module/cmn600/src/mod_cmn600.c
+++ b/module/cmn600/src/mod_cmn600.c
@@ -32,6 +32,18 @@
 
 #define MOD_NAME "[CMN600] "
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
+static const char *const mmap_type_name[] = {
+    [MOD_CMN600_MEMORY_REGION_TYPE_IO] = "I/O",
+    [MOD_CMN600_MEMORY_REGION_TYPE_SYSCACHE] = "System Cache",
+    [MOD_CMN600_REGION_TYPE_SYSCACHE_SUB] = "Sub-System Cache",
+    [MOD_CMN600_REGION_TYPE_CCIX] = "CCIX",
+    [MOD_CMN600_REGION_TYPE_SYSCACHE_NONHASH] = "System Cache Non-hash",
+};
+#else
+static const char *const mmap_type_name[] = { "" };
+#endif
+
 static inline size_t cmn600_hnf_cache_group_count(size_t hnf_count)
 {
     return (hnf_count + CMN600_HNF_CACHE_GROUP_ENTRIES_PER_GROUP - 1) /
@@ -367,14 +379,6 @@ static void cmn600_configure(void)
     }
 }
 
-static const char * const mmap_type_name[] = {
-    [MOD_CMN600_MEMORY_REGION_TYPE_IO] = "I/O",
-    [MOD_CMN600_MEMORY_REGION_TYPE_SYSCACHE] = "System Cache",
-    [MOD_CMN600_REGION_TYPE_SYSCACHE_SUB] = "Sub-System Cache",
-    [MOD_CMN600_REGION_TYPE_CCIX] = "CCIX",
-    [MOD_CMN600_REGION_TYPE_SYSCACHE_NONHASH] = "System Cache Non-hash",
-};
-
 int cmn600_setup_sam(struct cmn600_rnsam_reg *rnsam)
 {
     unsigned int region_idx;
@@ -407,6 +411,7 @@ int cmn600_setup_sam(struct cmn600_rnsam_reg *rnsam)
         } else
             base = region->base;
 
+        (void)mmap_type_name;
         FWK_LOG_INFO(
             MOD_NAME "  [0x%08" PRIX32 "%08" PRIX32
             " - 0x%08" PRIX32 "%08" PRIX32 "] %s",
@@ -804,6 +809,7 @@ int cmn600_start(fwk_id_t id)
 
     ctx->chip_id = chip_id;
 
+    (void)mc_mode;
     FWK_LOG_INFO(MOD_NAME "Multichip mode: %s", mc_mode ? "yes" : "no");
     FWK_LOG_INFO(MOD_NAME "Chip ID: %d", chip_id);
 

--- a/module/cmn650/src/mod_cmn650.c
+++ b/module/cmn650/src/mod_cmn650.c
@@ -30,6 +30,17 @@
 
 #define MOD_NAME "[CMN650] "
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
+static const char *const mmap_type_name[] = {
+    [MOD_CMN650_MEM_REGION_TYPE_IO] = "I/O",
+    [MOD_CMN650_MEM_REGION_TYPE_SYSCACHE] = "System Cache",
+    [MOD_CMN650_REGION_TYPE_SYSCACHE_SUB] = "Sub-System Cache",
+    [MOD_CMN650_REGION_TYPE_CCIX] = "CCIX",
+};
+#else
+static const char *const mmap_type_name[] = { "" };
+#endif
+
 static struct cmn650_device_ctx *ctx;
 
 /* Chip Information */
@@ -419,13 +430,6 @@ static void cmn650_configure(void)
     }
 }
 
-static const char *const mmap_type_name[] = {
-    [MOD_CMN650_MEM_REGION_TYPE_IO] = "I/O",
-    [MOD_CMN650_MEM_REGION_TYPE_SYSCACHE] = "System Cache",
-    [MOD_CMN650_REGION_TYPE_SYSCACHE_SUB] = "Sub-System Cache",
-    [MOD_CMN650_REGION_TYPE_CCIX] = "CCIX",
-};
-
 static int cmn650_setup_sam(struct cmn650_rnsam_reg *rnsam)
 {
     unsigned int bit_pos;
@@ -445,6 +449,8 @@ static int cmn650_setup_sam(struct cmn650_rnsam_reg *rnsam)
     const struct mod_cmn650_config *config = ctx->config;
 
     FWK_LOG_INFO(MOD_NAME "Configuring SAM for node %d", get_node_id(rnsam));
+
+    (void)mmap_type_name;
 
     for (region_idx = 0; region_idx < config->mmap_count; region_idx++) {
         region = &config->mmap_table[region_idx];

--- a/module/cmn700/src/mod_cmn700.c
+++ b/module/cmn700/src/mod_cmn700.c
@@ -30,6 +30,16 @@
 
 #define MOD_NAME "[CMN700] "
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
+static const char *const mmap_type_name[] = {
+    [MOD_CMN700_MEM_REGION_TYPE_IO] = "I/O",
+    [MOD_CMN700_MEM_REGION_TYPE_SYSCACHE] = "System Cache",
+    [MOD_CMN700_REGION_TYPE_SYSCACHE_SUB] = "Sub-System Cache",
+};
+#else
+static const char *const mmap_type_name[] = { "" };
+#endif
+
 static struct cmn700_device_ctx *ctx;
 
 /* Chip Information */
@@ -463,12 +473,6 @@ static void cmn700_configure(void)
     }
 }
 
-static const char *const mmap_type_name[] = {
-    [MOD_CMN700_MEM_REGION_TYPE_IO] = "I/O",
-    [MOD_CMN700_MEM_REGION_TYPE_SYSCACHE] = "System Cache",
-    [MOD_CMN700_REGION_TYPE_SYSCACHE_SUB] = "Sub-System Cache",
-};
-
 static int cmn700_setup_sam(struct cmn700_rnsam_reg *rnsam)
 {
     unsigned int bit_pos;
@@ -487,6 +491,8 @@ static int cmn700_setup_sam(struct cmn700_rnsam_reg *rnsam)
     const struct mod_cmn700_hierarchical_hashing *hier_hash_cfg;
 
     FWK_LOG_INFO(MOD_NAME "Configuring SAM for node %d", get_node_id(rnsam));
+
+    (void)mmap_type_name;
 
     for (region_idx = 0; region_idx < config->mmap_count; region_idx++) {
         region = &config->mmap_table[region_idx];

--- a/module/cmn_booker/src/mod_cmn_booker.c
+++ b/module/cmn_booker/src/mod_cmn_booker.c
@@ -27,6 +27,16 @@
 
 #define MOD_NAME "[CMN_BOOKER] "
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
+static const char *const mmap_type_name[] = {
+    [MOD_CMN_BOOKER_MEM_REGION_TYPE_IO] = "I/O",
+    [MOD_CMN_BOOKER_MEM_REGION_TYPE_SYSCACHE] = "System Cache",
+    [MOD_CMN_BOOKER_REGION_TYPE_SYSCACHE_SUB] = "Sub-System Cache",
+};
+#else
+static const char *const mmap_type_name[] = { "" };
+#endif
+
 static struct cmn_booker_ctx *ctx;
 
 static void process_node_hnf(struct cmn_booker_hnf_reg *hnf)
@@ -289,12 +299,6 @@ static void cmn_booker_configure(void)
     }
 }
 
-static const char * const mmap_type_name[] = {
-    [MOD_CMN_BOOKER_MEM_REGION_TYPE_IO] = "I/O",
-    [MOD_CMN_BOOKER_MEM_REGION_TYPE_SYSCACHE] = "System Cache",
-    [MOD_CMN_BOOKER_REGION_TYPE_SYSCACHE_SUB] = "Sub-System Cache",
-};
-
 static int cmn_booker_setup_sam(struct cmn_booker_rnsam_reg *rnsam)
 {
     unsigned int bit_pos;
@@ -313,6 +317,7 @@ static int cmn_booker_setup_sam(struct cmn_booker_rnsam_reg *rnsam)
     for (region_idx = 0; region_idx < config->mmap_count; region_idx++) {
         region = &config->mmap_table[region_idx];
 
+        (void)mmap_type_name;
         FWK_LOG_INFO(
             MOD_NAME "  [0x%x%x - 0x%x%x] %s",
             HIGH_WORD(region->base), LOW_WORD(region->base),

--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -296,7 +296,10 @@ static const uint32_t core_composite_state_mask_table[] = {
  * Internal variables
  */
 static struct mod_pd_ctx mod_pd_ctx;
+
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_ERROR
 static const char driver_error_msg[] = "[PD] Driver error %s (%d) in %s @%d";
+#endif
 
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
 static const char * const default_state_name_table[] = {
@@ -1302,6 +1305,7 @@ void perform_shutdown(
         pd_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, pd_idx);
         api = pd->driver_api;
 
+        (void)pd_id;
         FWK_LOG_INFO("[PD] Shutting down %s", fwk_module_get_name(pd_id));
 
         if (api->shutdown != NULL) {
@@ -1894,12 +1898,14 @@ static int pd_start(fwk_id_t id)
         /* Get the current power state of the power domain from its driver. */
         status = pd->driver_api->get_state(pd->driver_id, &state);
         if (status != FWK_SUCCESS) {
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_ERROR
             FWK_LOG_ERR(
                 driver_error_msg,
                 fwk_status_str(status),
                 status,
                 __func__,
                 __LINE__);
+#endif
         } else {
             pd->requested_state = pd->state_requested_to_driver = state;
 

--- a/product/juno/include/fmw_log.h
+++ b/product/juno/include/fmw_log.h
@@ -1,0 +1,13 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FMW_LOG_H
+#define FMW_LOG_H
+
+#define FMW_LOG_MINIMAL_BANNER
+
+#endif /* FMW_LOG_H */

--- a/product/morello/module/cmn_skeena/src/mod_cmn_skeena.c
+++ b/product/morello/module/cmn_skeena/src/mod_cmn_skeena.c
@@ -413,6 +413,7 @@ static void cmn_skeena_configure(void)
     }
 }
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
 static const char *const mmap_type_name[] = {
     [MOD_CMN_SKEENA_MEMORY_REGION_TYPE_IO] = "I/O",
     [MOD_CMN_SKEENA_MEMORY_REGION_TYPE_SYSCACHE] = "System Cache",
@@ -420,6 +421,7 @@ static const char *const mmap_type_name[] = {
     [MOD_CMN_SKEENA_REGION_TYPE_CCIX] = "CCIX",
     [MOD_CMN_SKEENA_REGION_TYPE_SYSCACHE_NONHASH] = "System Cache Non-hash",
 };
+#endif
 
 int cmn_skeena_setup_sam(struct cmn_skeena_rnsam_reg *rnsam)
 {
@@ -460,6 +462,7 @@ int cmn_skeena_setup_sam(struct cmn_skeena_rnsam_reg *rnsam)
         } else
             base = region->base;
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
         FWK_LOG_INFO(
             MOD_NAME "  [0x%08" PRIX32 "%08" PRIX32 " - 0x%08" PRIX32
                      "%08" PRIX32 "] %s",
@@ -468,6 +471,7 @@ int cmn_skeena_setup_sam(struct cmn_skeena_rnsam_reg *rnsam)
             (uint32_t)((base + region->size - 1) >> 32),
             (uint32_t)(base + region->size - 1),
             mmap_type_name[region->type]);
+#endif
 
         switch (region->type) {
         case MOD_CMN_SKEENA_MEMORY_REGION_TYPE_IO:
@@ -917,6 +921,7 @@ int cmn_skeena_start(fwk_id_t id)
 
     ctx->chip_id = chip_id;
 
+    (void)mc_mode;
     FWK_LOG_INFO(MOD_NAME "Multichip mode: %s", mc_mode ? "yes" : "no");
     FWK_LOG_INFO(MOD_NAME "Chip ID: %d", chip_id);
 

--- a/product/morello/module/morello_rom/src/mod_morello_rom.c
+++ b/product/morello/module/morello_rom/src/mod_morello_rom.c
@@ -149,6 +149,7 @@ static int morello_rom_process_event(
         morello_rom_ctx.rom_config->image_type, &entry, fip_base, fip_size);
     const char *image_type =
         get_image_type_str(morello_rom_ctx.rom_config->image_type);
+    (void)image_type;
 
     if (status != FWK_SUCCESS) {
         FWK_LOG_INFO(

--- a/product/morello/module/morello_system/src/mod_morello_system.c
+++ b/product/morello/module/morello_system/src/mod_morello_system.c
@@ -297,6 +297,7 @@ static int morello_system_fill_platform_info(void)
     sds_platform_info.local_ddr_size = 8ULL * FWK_GIB;
 
     size = sds_platform_info.local_ddr_size + sds_platform_info.remote_ddr_size;
+    (void)size;
     FWK_LOG_INFO(
         "[MORELLO SYSTEM] Total DDR Size in Bytes: 0x%" PRIX32 "%08" PRIX32,
         (uint32_t)(size >> 32),
@@ -568,11 +569,13 @@ static int morello_system_start(fwk_id_t id)
             CS_CNTCONTROL->CS_CNTCR |= (1 << 0);
             CS_CNTCONTROL->CS_CNTCVLW = 0x00000000;
             CS_CNTCONTROL->CS_CNTCVUP = 0x0000FFFF;
-        } else
+        } else {
             FWK_LOG_INFO(
                 "[MORELLO SYSTEM] CSYS PWR UP REQ IRQ register failed");
-    } else
+        }
+    } else {
         FWK_LOG_INFO("[MORELLO SYSTEM] CDBG PWR UP REQ IRQ register failed");
+    }
 
     FWK_LOG_INFO("[MORELLO SYSTEM] Requesting SYSTOP initialization...");
 

--- a/product/n1sdp/module/n1sdp_c2c/src/mod_n1sdp_c2c_i2c.c
+++ b/product/n1sdp/module/n1sdp_c2c/src/mod_n1sdp_c2c_i2c.c
@@ -60,6 +60,7 @@
 #define CCIX_PROP_MAX_PACK_SIZE_256          1
 #define CCIX_PROP_MAX_PACK_SIZE_512          2
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
 static const char * const cmd_str[] = {
     [N1SDP_C2C_CMD_CHECK_SLAVE] = "Check slave alive",
     [N1SDP_C2C_CMD_PCIE_POWER_ON] = "PCIe power ON",
@@ -81,6 +82,9 @@ static const char * const cmd_str[] = {
     [N1SDP_C2C_CMD_POWER_DOMAIN_GET_STATE] = "Get power state",
     [N1SDP_C2C_CMD_SHUTDOWN_OR_REBOOT] = "Shutdown/Reboot",
 };
+#else
+static const char *const cmd_str[] = { "" };
+#endif
 
 /* Module context */
 struct n1sdp_c2c_ctx {
@@ -151,6 +155,7 @@ static int n1sdp_c2c_master_tx_command(uint8_t cmd)
 {
     int status;
 
+    (void)cmd_str;
     FWK_LOG_INFO("[C2C] %s in slave...", cmd_str[cmd]);
 
     n1sdp_c2c_ctx.master_tx_data[0] = cmd;
@@ -232,6 +237,7 @@ static int n1sdp_c2c_multichip_run_command(uint8_t cmd, bool run_in_slave)
         }
     }
 
+    (void)cmd_str;
     FWK_LOG_INFO("[C2C] %s in master...", cmd_str[cmd]);
 
     switch (cmd) {

--- a/product/n1sdp/module/n1sdp_dmc620/src/dimm_spd.c
+++ b/product/n1sdp/module/n1sdp_dmc620/src/dimm_spd.c
@@ -128,6 +128,7 @@ static void dimm_device_data(uint8_t *spd_data, uint8_t dimm_id)
             part_num[j++] = spd_data[i];
         }
 
+        (void)part_num;
         FWK_LOG_INFO("    Module part number = %s", part_num);
 
         FWK_LOG_INFO(

--- a/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
+++ b/product/n1sdp/module/n1sdp_pcie/src/mod_n1sdp_pcie.c
@@ -97,7 +97,11 @@ struct n1sdp_pcie_ctx {
 
 struct n1sdp_pcie_ctx pcie_ctx;
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
 static const char * const pcie_type[2] = {"PCIe", "CCIX"};
+#else
+static const char *const pcie_type[] = { "" };
+#endif
 
 /*
  * CCIX configuration API
@@ -359,6 +363,7 @@ static int n1sdp_pcie_link_training(fwk_id_t id, bool ep_mode)
 
     neg_config = (dev_ctx->ctrl_apb->RP_CONFIG_OUT &
         RP_CONFIG_OUT_NEGOTIATED_SPD_MASK) >> RP_CONFIG_OUT_NEGOTIATED_SPD_POS;
+    (void)neg_config;
     FWK_LOG_INFO(
         "[%s] Negotiated speed: GEN%d", pcie_type[did], neg_config + 1);
 
@@ -676,6 +681,14 @@ static int n1sdp_pcie_init(fwk_id_t module_id, unsigned int element_count,
         sizeof(pcie_ctx.device_ctx_table[0]));
 
     pcie_ctx.pcie_instance_count = element_count;
+
+    /*
+     * pcie_type is used only for logging purposes in this file. Depending on
+     * the chosen LOG_LEVEL at build time, the variable could be resolved as
+     * unused. We mark the variable as unused here to prevent the warning being
+     * raised in the above cases.
+     */
+    (void)pcie_type;
 
     return FWK_SUCCESS;
 }

--- a/product/n1sdp/module/n1sdp_rom/src/mod_n1sdp_rom.c
+++ b/product/n1sdp/module/n1sdp_rom/src/mod_n1sdp_rom.c
@@ -126,14 +126,20 @@ static int n1sdp_rom_process_event(const struct fwk_event *event,
         &entry,
         n1sdp_rom_ctx.rom_config->fip_base_address,
         n1sdp_rom_ctx.rom_config->fip_nvm_size);
+
     const char *image_type =
         get_image_type_str(n1sdp_rom_ctx.rom_config->image_type);
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
     if (status != FWK_SUCCESS) {
         FWK_LOG_INFO(
             "[ROM] Failed to locate %s_BL2, error: %d\n", image_type, status);
         return status;
     }
+#else
+    (void)status;
+    (void)image_type;
+#endif
 
     FWK_LOG_INFO("[ROM] Located %s_BL2:\n", image_type);
     FWK_LOG_INFO("[ROM]   address: %p\n", entry.base);

--- a/product/rdv1mc/module/platform_system/src/mod_platform_system.c
+++ b/product/rdv1mc/module/platform_system/src/mod_platform_system.c
@@ -350,11 +350,12 @@ int platform_system_process_notification(
             /* Unsubscribe to the notification */
             return fwk_notification_unsubscribe(
                 event->id, event->source_id, event->target_id);
-        } else
+        } else {
             FWK_LOG_INFO(
                 "[PLATFORM SYSTEM] Detected as Slave chip: %d, "
                 "wait for SCMI\n",
                 chip_id);
+        }
 
         return FWK_SUCCESS;
     } else if (fwk_id_is_equal(

--- a/product/synquacer/module/synquacer_memc/src/synquacer_ddr.c
+++ b/product/synquacer/module/synquacer_memc/src/synquacer_ddr.c
@@ -35,10 +35,12 @@ extern const struct mod_f_i2c_api *f_i2c_api;
 
 #define CONFIG_DDR_ERROR_FORCE_STOP
 
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
 static char *dimm_module_type[] = { "Extended DIMM", "RDIMM",    "UDIMM",
                                     "SO-DIMM",       "LRDIMM",   "Mini-RDIMM",
                                     "Mini-UDIMM",    "Reserved", "72b-SO-RDIMM",
                                     "72b-SO-UDIMM" };
+#endif
 
 typedef struct spd_ddr_info_s {
     uint8_t base_module_type;
@@ -338,12 +340,15 @@ bool fw_spd_ddr_info_get(spd_ddr_info_t *spd_ddr_info_p)
              (4 * (1 << sdram_width)) * logical_ranks_per_dimm)
             << 8;
         spd_ddr_info_p->slot_bitmap |= (1 << check_dimm_slot);
+
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
         FWK_LOG_INFO(
             "[SYSTEM] slot DIMM%d: %" PRIu32 "MB %s %s",
             check_dimm_slot,
             spd_ddr_info_p->sdram_slot_total[check_dimm_slot],
             dimm_module_type[spd_ddr_info_p->base_module_type],
             ((spd_ddr_info_p->ecc_available) ? "ECC" : "non-ECC"));
+#endif
 
         /* dq_map_control data make */
         for (i = 0; i < 5; i++) {
@@ -821,8 +826,9 @@ static void dram_init_for_ecc(void)
     for (dst_ddr_addr = DRAM_AREA_1_START_ADDR, dma_dst_addr = 0x80000000U;
          (dst_ddr_addr < DRAM_AREA_1_END_ADDR) && (dram_size != 0);
          dma_dst_addr += DMA330_ERASE_BLOCK_SIZE) {
-        if ((dst_ddr_addr & 0x3fffffffULL) == 0)
+        if ((dst_ddr_addr & 0x3fffffffULL) == 0) {
             FWK_LOG_INFO("[DDR] +");
+        }
 
         dma330_zero_clear(0xce000000U, dma_dst_addr);
         dst_ddr_addr += DMA330_ERASE_BLOCK_SIZE;
@@ -833,8 +839,9 @@ static void dram_init_for_ecc(void)
     for (dst_ddr_addr = DRAM_AREA_2_START_ADDR, dma_dst_addr = 0x80000000U;
          (dst_ddr_addr < DRAM_AREA_2_END_ADDR) && (dram_size != 0);
          dma_dst_addr += DMA330_ERASE_BLOCK_SIZE) {
-        if ((dst_ddr_addr & 0x3fffffffULL) == 0)
+        if ((dst_ddr_addr & 0x3fffffffULL) == 0) {
             FWK_LOG_INFO("[DDR] -");
+        }
 
         if ((dst_ddr_addr & 0x1fffffffULL) == 0) {
             dmab_mmu500_init(dst_ddr_addr);
@@ -850,8 +857,9 @@ static void dram_init_for_ecc(void)
     for (dst_ddr_addr = DRAM_AREA_3_START_ADDR, dma_dst_addr = 0x80000000U;
          (dst_ddr_addr < DRAM_AREA_3_END_ADDR) && (dram_size != 0);
          dma_dst_addr += DMA330_ERASE_BLOCK_SIZE) {
-        if ((dst_ddr_addr & 0x3fffffffULL) == 0)
+        if ((dst_ddr_addr & 0x3fffffffULL) == 0) {
             FWK_LOG_INFO("[DDR] x");
+        }
 
         if ((dst_ddr_addr & 0x1fffffffULL) == 0) {
             dmab_mmu500_init(dst_ddr_addr);

--- a/product/synquacer/module/synquacer_system/src/synquacer_main.c
+++ b/product/synquacer/module/synquacer_system/src/synquacer_main.c
@@ -358,11 +358,12 @@ int synquacer_main(void)
             MOD_PD_STATE_ON,
             MOD_PD_STATE_ON));
 
-    if (status == FWK_SUCCESS)
+    if (status == FWK_SUCCESS) {
         FWK_LOG_INFO("[SYNQUACER SYSTEM] finished powering up AP");
-    else
+    } else {
         FWK_LOG_ERR(
             "[SYNQUACER SYSTEM] failed to power up AP. status=%d", status);
+    }
 
     return status;
 }

--- a/product/synquacer/module/synquacer_system/src/synquacer_pd_manage.c
+++ b/product/synquacer/module/synquacer_system/src/synquacer_pd_manage.c
@@ -257,12 +257,13 @@ static void sni_power_domain_on_mp(uint32_t dev_bitmap)
 
     /* waiting pmu-on */
     r = pmu_wait(pmu_bitmap, true);
-    if (r != 0)
+    if (r != 0) {
         FWK_LOG_ERR(
             "[PPU] sni-pmu timeout expected:(0x%08" PRIx32
             ") result: (0x%08" PRIx32 ").",
             pmu_bitmap,
             pmu_read_pd_power_status());
+    }
 
     /* adb400 reset clear */
     if ((dev_bitmap & DEV_BMAP_PCIE_BLK) != 0)


### PR DESCRIPTION
Currently the FWX_LOG_<LEVEL> macros provide a way to print or not messages in accordance with the LOG_LEVEL chosen at build time. The strings however are voided but not removed. This PR brings some improvements in order to remove unused strings in the FWK_LOG. Some preparatory patches are required in order to accommodate for such change in the logging framework.