### PR TITLE
dvfs/perf: Fix cmake target_link_libraries

### DIFF
--- a/module/dvfs/CMakeLists.txt
+++ b/module/dvfs/CMakeLists.txt
@@ -18,4 +18,5 @@ target_sources(
     PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_dvfs.c")
 
 target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-clock module-psu
-                                                   module-timer)
+                                                   module-timer
+                                                   module-scmi-perf)

--- a/module/scmi_perf/CMakeLists.txt
+++ b/module/scmi_perf/CMakeLists.txt
@@ -11,10 +11,12 @@ target_include_directories(${SCP_MODULE_TARGET}
                            PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 target_sources(${SCP_MODULE_TARGET}
-               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_scmi_perf.c"
-                        if(SCP_ENABLE_PLUGIN_HANDLER)
-                        ${CMAKE_CURRENT_SOURCE_DIR}/src/perf_plugins_handler.c)
-                        endif()
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_scmi_perf.c")
+
+if(SCP_ENABLE_PLUGIN_HANDLER)
+    target_sources(${SCP_MODULE_TARGET}
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/perf_plugins_handler.c)
+endif()
 
 target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-dvfs module-scmi
                                                    module-timer)


### PR DESCRIPTION
The scmi_perf module was left behind in a recent change for
the dvfs module.
This patch fixes the build with cmake.

Change-Id: I3c4b19f4a1b59a172b30f1cf1d1fb71f96f5e75d
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>