### PR TITLE
scmi_clock: Add missing check for returned status value

### DIFF
--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -523,11 +523,14 @@ FWK_WEAK int mod_scmi_clock_config_set_policy(
 
         /* set the clock state for this agent to RUNNING */
         if (policy_commit == MOD_SCMI_CLOCK_POST_MESSAGE_HANDLER) {
-            set_agent_clock_state(
+            status = set_agent_clock_state(
                 agent_clock_state,
                 (uint8_t)MOD_CLOCK_STATE_RUNNING,
                 service_id,
                 clock_dev_id);
+            if (status != FWK_SUCCESS) {
+                return status;
+            }
         }
 
         /*
@@ -564,11 +567,14 @@ FWK_WEAK int mod_scmi_clock_config_set_policy(
 
         /* set the clock state for this agent to STOPPED */
         if (policy_commit == MOD_SCMI_CLOCK_POST_MESSAGE_HANDLER) {
-            set_agent_clock_state(
+            status = set_agent_clock_state(
                 agent_clock_state,
                 (uint8_t)MOD_CLOCK_STATE_STOPPED,
                 service_id,
                 clock_dev_id);
+            if (status != FWK_SUCCESS) {
+                return status;
+            }
         }
 
         /*


### PR DESCRIPTION
There are 2 calls to set_agent_clock_state() that are
missing the returned status check. This patch adds them.

Signed-off-by: Tuvshinzaya Erdenekhuu <tuvshinzaya.erdenekhuu@arm.com>
Change-Id: I517f7bb7a2a2138701a643548ec6293da59f3eb1