### PR TITLE
n1sdp: add dynamic calculations of PLL parameters

### DIFF
--- a/product/n1sdp/module/n1sdp_pll/include/internal/n1sdp_pll.h
+++ b/product/n1sdp/module/n1sdp_pll/include/internal/n1sdp_pll.h
@@ -44,6 +44,11 @@
 /*! The maximum feedback divider value */
 #define MOD_N1SDP_PLL_FBDIV_MAX      1600
 
+/*! The minimum frequency output that post divider requires. */
+#define MOD_N1SDP_PLL_FVCO_MIN (800UL * FWK_MHZ)
+/*! The maximum frequency output that post divider handles. */
+#define MOD_N1SDP_PLL_FVCO_MAX (3200UL * FWK_MHZ)
+
 /*! The minimum reference clock divider value */
 #define MOD_N1SDP_PLL_REFDIV_MIN     1
 /*! The maximum reference clock divider value */

--- a/product/n1sdp/module/n1sdp_pll/include/mod_n1sdp_pll.h
+++ b/product/n1sdp/module/n1sdp_pll/include/mod_n1sdp_pll.h
@@ -67,34 +67,6 @@ struct mod_n1sdp_pll_dev_config {
 };
 
 /*!
- * \brief PLL parameter values for non-absolute frequencies.
- */
-struct n1sdp_pll_custom_freq_param_entry {
-    /*! Required output frequency value in MHz */
-    uint16_t freq_value_mhz;
-
-    /*! Feedback divider value for this frequency */
-    uint16_t fbdiv;
-
-    /*! Reference clock divider value for this frequency */
-    uint8_t refdiv;
-
-    /*! Post divider 1 value for this frequency */
-    uint8_t postdiv;
-};
-
-/*!
- * \brief N1SDP PLL module configuration.
- */
-struct n1sdp_pll_module_config {
-    /*! Pointer to custom frequency table */
-    struct n1sdp_pll_custom_freq_param_entry *custom_freq_table;
-
-    /*! Size of custom frequency table */
-    size_t custom_freq_table_size;
-};
-
-/*!
  * \}
  */
 

--- a/product/n1sdp/scp_ramfw/config_clock.h
+++ b/product/n1sdp/scp_ramfw/config_clock.h
@@ -13,7 +13,7 @@
 /*
  * DDR Subsystem clock in MHz
  */
-#define DDR_CLOCK_MHZ                  1333
+#define DDR_CLOCK_MHZ (4000.0 / 3) // 1333Mhz
 
 /*
  * SCC & PIK clock rates.

--- a/product/n1sdp/scp_ramfw/config_n1sdp_pll.c
+++ b/product/n1sdp/scp_ramfw/config_n1sdp_pll.c
@@ -16,15 +16,6 @@
 #include <fwk_macros.h>
 #include <fwk_module.h>
 
-static struct n1sdp_pll_custom_freq_param_entry freq_table[] = {
-    {
-        .freq_value_mhz = 1333,
-        .fbdiv = 160,
-        .refdiv = 3,
-        .postdiv = 2,
-    },
-};
-
 static const struct fwk_element n1sdp_pll_element_table[] = {
     [CLOCK_PLL_IDX_CPU0] = {
         .name = "CPU_PLL_0",
@@ -90,11 +81,5 @@ static const struct fwk_element *n1sdp_pll_get_element_table
 }
 
 const struct fwk_module_config config_n1sdp_pll = {
-    .data =
-        &(struct n1sdp_pll_module_config){
-            .custom_freq_table = freq_table,
-            .custom_freq_table_size = FWK_ARRAY_SIZE(freq_table),
-        },
-
     .elements = FWK_MODULE_DYNAMIC_ELEMENTS(n1sdp_pll_get_element_table),
 };


### PR DESCRIPTION
To find optimal pll parameter values such as fbdiv, refdiv
and postdiv to achieve the closest freq to the actual rate.

Signed-off-by: Arnold Gabriel Benedict <arnoldgabriel.benedict@arm.com>
Change-Id: I02738ca43b9ceef833306d19130245f240a482b8