### PR TITLE
vs-code: Fix VS Code development container

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -6,8 +6,6 @@
         "target": "dev",
     },
 
-    "remoteUser": "user",
-
     "workspaceMount": "source=${localWorkspaceFolder},target=/scp-firmware,type=bind,consistency=default",
     "workspaceFolder": "/scp-firmware",
 


### PR DESCRIPTION
VS Code currently tries to enter the container as the `user` user, which doesn't exist. Enter it as root instead.