### PR TITLE
mod_system_pll: fix incorrect return value

### DIFF
--- a/module/system_pll/src/mod_system_pll.c
+++ b/module/system_pll/src/mod_system_pll.c
@@ -51,7 +51,7 @@ static unsigned int freq_to_half_cycle_ps(unsigned int freq_hz)
 
     /* Check if the given frequency is a multiple of 1 KHz */
     if (freq_hz % MOD_SYSTEM_PLL_MIN_INTERVAL != 0)
-        return FWK_E_PARAM;
+        return 0;
 
     freq_khz = freq_hz / FWK_KHZ;
     if (freq_khz == 0)


### PR DESCRIPTION
The fucntion "freq_to_half_cycle_ps" should return unsigned int values
only. But the condition that checks whether the given frequency is a
multiple of 1 KHz, will return FWK_E_PARAM which is -1. So return 0
instead of FWK_E_PARAM, if the condition fails.

Change-Id: Ib31b65757ec3824ed945a4ac5a8e4abdf860e4a7
Signed-off-by: Shriram K <shriram.k@arm.com>