### PR TITLE
synquacer: no operation is required in ppu_v0 shutdown handler

### DIFF
--- a/product/synquacer/module/ppu_v0_synquacer/src/mod_ppu_v0.c
+++ b/product/synquacer/module/ppu_v0_synquacer/src/mod_ppu_v0.c
@@ -184,39 +184,11 @@ static int pd_reset(fwk_id_t pd_id)
 static int pd_shutdown(fwk_id_t pd_id,
                     enum mod_pd_system_shutdown system_shutdown)
 {
-    int status;
-    struct ppu_v0_pd_ctx *pd_ctx;
-
-    pd_ctx = ppu_v0_ctx.pd_ctx_table + fwk_id_get_element_idx(pd_id);
-
-    if (pd_ctx->config->pd_type == MOD_PD_TYPE_SYSTEM) {
-        FWK_LOG_INFO(
-            "[PPUV0] SYNQUACER SYSTEM module will shutdown the system");
-        return FWK_SUCCESS;
-    }
-
-
-    if (pd_ctx->config->pd_type == MOD_PD_TYPE_CORE) {
-        /*
-         * As it is not guaranteed that the PACTIVE signals of the core are low
-         * as the core may not be in WFI for example, deactivate the check of
-         * the PACTIVE signals by the PPU logic and the handshake with the core
-         * P-channel before to ask for the core to be powered off.
-         */
-        pd_ctx->ppu->POWER_CFG &= ~PPU_PCR_DEV_ACTIVE_EN;
-        pd_ctx->ppu->POWER_CFG &= ~PPU_PCR_DEV_REQ_EN;
-    }
-
-    status = ppu_v0_set_power_mode(pd_ctx->ppu, PPU_V0_MODE_WARM_RESET);
-
-    FWK_LOG_INFO(
-        "[PPUV0] shutdown reg=(0x%p) state=(0x%x)",
-        (void *)pd_ctx->ppu,
-        PPU_V0_MODE_WARM_RESET);
-
-    fwk_assert(status == FWK_SUCCESS);
-
-    return status;
+    /*
+     * SYNQUACER_SYSTEM module will handle the system shutdown process,
+     * no operation is required in each PPU shutdown handler.
+     */
+    return FWK_SUCCESS;
 }
 
 static int ppu_v0_prepare_core_for_system_suspend(fwk_id_t core_pd_id)


### PR DESCRIPTION
On SynQuacer platform, whole system shutdown process is handled
by the SYNQUACER_SYSTEM module with accessing the CRG hardware.

This commit modifies the ppu_v0_synquacer shutdown handler
just to return FWK_SUCCESS, because no operation is required
in each PPU shutdown handler.

Signed-off-by: Masahisa Kojima <masahisa.kojima@linaro.org>
Change-Id: Ib76c07e940636ce7cf8e637533f898268f6b9464