### PR TITLE
cmake: Add -Wall -Werror options to cmake builds

### DIFF
--- a/cmake/Toolchain/GNU-Baremetal.cmake
+++ b/cmake/Toolchain/GNU-Baremetal.cmake
@@ -28,6 +28,12 @@ foreach(language IN ITEMS ASM C CXX)
     string(APPEND CMAKE_${language}_FLAGS_INIT "-ffunction-sections ")
     string(APPEND CMAKE_${language}_FLAGS_INIT "-fdata-sections ")
     string(APPEND CMAKE_${language}_FLAGS_INIT "-fshort-enums ")
+    string(APPEND CMAKE_${language}_FLAGS_INIT "-Wall -Werror -Wextra ")
+    string(APPEND CMAKE_${language}_FLAGS_INIT
+           "-Wno-error=deprecated-declarations ")
+    string(APPEND CMAKE_${language}_FLAGS_INIT "-Wno-unused-parameter ")
+    string(APPEND CMAKE_${language}_FLAGS_INIT
+           "-Wno-missing-field-initializers ")
 
     string(APPEND CMAKE_${language}_FLAGS_DEBUG_INIT "-Og")
 endforeach()

--- a/contrib/cmsis/CMakeLists.txt
+++ b/contrib/cmsis/CMakeLists.txt
@@ -69,6 +69,7 @@ target_sources(
         "${CMAKE_CURRENT_SOURCE_DIR}/git/CMSIS/RTOS2/Source/os_systick.c")
 
 target_compile_definitions(rtos2-rtx INTERFACE RTX_NO_MULTITHREAD_CLIB)
+target_compile_options(rtos2-rtx INTERFACE -Wno-array-bounds)
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m[37]")
     target_sources(


### PR DESCRIPTION
Currently -Wall, -Wextra and -Werror options are missing
for cmake builds. This commit add these options for
cmake builds.

Change-Id: I6d2f74f2cd03107127b87f80aa22764694190dac
Signed-off-by: Girish Pathak <girish.pathak@arm.com>