### PR TITLE
framework: Remove signal type __FWK_ID_TYPE_SIGNAL

### DIFF
--- a/framework/include/internal/fwk_id.h
+++ b/framework/include/internal/fwk_id.h
@@ -46,9 +46,6 @@ enum __fwk_id_type {
     /* Notification */
     __FWK_ID_TYPE_NOTIFICATION,
 
-    /* Signal */
-    __FWK_ID_TYPE_SIGNAL,
-
     /* Number of defined types */
     __FWK_ID_TYPE_COUNT,
 };
@@ -100,13 +97,6 @@ union __fwk_id {
         uint32_t event_idx : 6; /* Event index */
         uint32_t reserved : 14; /* Reserved */
     } event; /* Event variant */
-
-    struct {
-        uint32_t type : 4; /* Identifier type */
-        uint32_t module_idx : 8; /* Module index */
-        uint32_t signal_idx : 6; /* Signal index */
-        uint32_t reserved : 14; /* Reserved */
-    } signal; /* Signal variant */
 
     struct {
         uint32_t type : 4; /* Identifier type */

--- a/framework/src/fwk_id.c
+++ b/framework/src/fwk_id.c
@@ -96,7 +96,6 @@ static void fwk_id_format(char *buffer, size_t buffer_size, fwk_id_t id)
     case __FWK_ID_TYPE_API:
     case __FWK_ID_TYPE_EVENT:
     case __FWK_ID_TYPE_NOTIFICATION:
-    case __FWK_ID_TYPE_SIGNAL:
         length +=
             snprintf(buffer + length, buffer_size - length, ":%u", indices[1]);
 


### PR DESCRIPTION
This change removes unused types
 __FWK_ID_TYPE_SIGNAL and 'struct signal'
which are not needed as it's use was removed in the
below commit(part of light event patchset)

f74c34fc8 framework, dvfs: Remove signals.

Change-Id: I46b0c90ffc55893df5c2cebf461637ba91a8f3ce
Signed-off-by: Girish Pathak <girish.pathak@arm.com>