### PR TITLE
fwk: Replace remaining `assert()` call with `fwk_assert()`

### DIFF
--- a/framework/src/fwk_id.c
+++ b/framework/src/fwk_id.c
@@ -216,8 +216,9 @@ unsigned int fwk_id_get_module_idx(fwk_id_t id)
 
 unsigned int fwk_id_get_element_idx(fwk_id_t element_id)
 {
-    assert((element_id.common.type == __FWK_ID_TYPE_ELEMENT) ||
-           (element_id.common.type == __FWK_ID_TYPE_SUB_ELEMENT));
+    fwk_assert(
+        (element_id.common.type == __FWK_ID_TYPE_ELEMENT) ||
+        (element_id.common.type == __FWK_ID_TYPE_SUB_ELEMENT));
 
     return element_id.element.element_idx;
 }


### PR DESCRIPTION
A previous commit (7b01ad845) left behind one replacement from
assert() to fwk_assert().

This commit fixes that.

Change-Id: Id98d2d09bb25d2842beeff69b7938fe259d5938c
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>