### PR TITLE
cmn_booker: Limit PA width to 40 bits

### DIFF
--- a/module/cmn_booker/src/mod_cmn_booker.c
+++ b/module/cmn_booker/src/mod_cmn_booker.c
@@ -357,6 +357,8 @@ static int cmn_booker_setup_sam(struct cmn_booker_rnsam_reg *rnsam)
             /*
              * Configure memory region
              */
+            fwk_assert(region->size <= UINT64_C(1) * FWK_TIB);
+
             configure_region(&rnsam->SYS_CACHE_GRP_REGION[region_sys_count],
                              region->base,
                              region->size,

--- a/product/tc0/scp_romfw/config_cmn_booker.c
+++ b/product/tc0/scp_romfw/config_cmn_booker.c
@@ -38,7 +38,7 @@ static const struct mod_cmn_booker_mem_region_map mmap[] = {
          * Map: 0x0000_0000_0000 - 0x003FF_FFFF_FFFF (4 TB)
          */
         .base = UINT64_C(0x000000000000),
-        .size = UINT64_C(4) * FWK_TIB,
+        .size = UINT64_C(1) * FWK_TIB,
         .type = MOD_CMN_BOOKER_MEM_REGION_TYPE_SYSCACHE,
     },
     {

--- a/product/tc1/scp_romfw/config_cmn_booker.c
+++ b/product/tc1/scp_romfw/config_cmn_booker.c
@@ -39,7 +39,7 @@ static const struct mod_cmn_booker_mem_region_map mmap[7] = {
          * Map: 0x0000_0000_0000 - 0x003FF_FFFF_FFFF (4 TB)
          */
         .base = UINT64_C(0x000000000000),
-        .size = UINT64_C(4) * FWK_TIB,
+        .size = UINT64_C(1) * FWK_TIB,
         .type = MOD_CMN_BOOKER_MEM_REGION_TYPE_SYSCACHE,
     },
     {


### PR DESCRIPTION
This is the max that CMN Booker can support. The corresponding
changes have been made in TC0 and TC1.

Signed-off-by: Usama Arif <usama.arif@arm.com>
Change-Id: Ic8e52fdedbfa301c0b0b3fb1b7900e8caa375c14