### PR TITLE
SCMI minor improvements & inclusive terminology

### DIFF
--- a/doc/cmake_readme.md
+++ b/doc/cmake_readme.md
@@ -115,6 +115,8 @@ few common options can be configured.
 
 - SCP_ENABLE_RESOURCE_PERMISSIONS: Enable/disable resource permissions settings.
 
+- SCP_ENABLE_PLUGIN_HANDLER: Enable the Performance Plugin handler extension.
+
 It can be also used to provide some platform specific settings.
 e.g. For ARM Juno platform. See below
 

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -68,6 +68,10 @@ if(SCP_ENABLE_FAST_CHANNELS)
     target_compile_definitions(framework PUBLIC "BUILD_HAS_FAST_CHANNELS")
 endif()
 
+if(SCP_ENABLE_PLUGIN_HANDLER)
+    target_compile_definitions(framework PUBLIC "BUILD_HAS_SCMI_PERF_PLUGIN_HANDLER")
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_definitions(framework PUBLIC BUILD_MODE_DEBUG)
 endif()

--- a/module/scmi/include/internal/scmi.h
+++ b/module/scmi/include/internal/scmi.h
@@ -63,9 +63,10 @@ enum scmi_agent_type {
 /*!
  * \brief Channel type.
  *
- * \details Defines the channel direction in terms of the master to the slave.
+ * \details Defines the channel direction in terms of the requester to the
+ *      completer.
  *
- * \note The integer values of this enumeration are based on the master of
+ * \note The integer values of this enumeration are based on the requester of
  *      communications in that configuration.
  */
 enum scmi_channel_type {

--- a/module/scmi/include/mod_scmi.h
+++ b/module/scmi/include/mod_scmi.h
@@ -586,38 +586,6 @@ struct mod_scmi_from_protocol_api {
 };
 
 /*!
- * \brief Identify if an SCMI entity is the communications master for a given
- *      channel type.
- *
- * \param type Channel type.
- * \param role Entity role.
- *
- * \retval true The entity is the communications master of the channel.
- * \retval false The entity is the communications slave of the channel.
- */
-static inline bool mod_scmi_is_master(enum scmi_channel_type type,
-                                      enum scmi_role role)
-{
-    return (int)type == (int)role;
-}
-
-/*!
- * \brief Identify if an SCMI entity is the communications slave for a given
- *      channel type.
- *
- * \param type Channel type.
- * \param role Entity role.
- *
- * \retval true The entity is the communications slave of the channel.
- * \retval false The entity is the communications master of the channel.
- */
-static inline bool mod_scmi_is_slave(enum scmi_channel_type type,
-                                     enum scmi_role role)
-{
-    return (int)type != (int)role;
-}
-
-/*!
  * \brief SCMI notification indices.
  */
 enum mod_scmi_notification_idx {

--- a/module/scmi/src/mod_scmi.c
+++ b/module/scmi/src/mod_scmi.c
@@ -259,13 +259,13 @@ static const char *message_type_to_str(enum mod_scmi_message_type message_type)
 {
     switch (message_type) {
     case MOD_SCMI_MESSAGE_TYPE_COMMAND:
-        return "Command";
+        return "Cmd";
 
     case MOD_SCMI_MESSAGE_TYPE_DELAYED_RESPONSE:
-        return "Delayed response";
+        return "Del-Resp";
 
     case MOD_SCMI_MESSAGE_TYPE_NOTIFICATION:
-        return "Notification";
+        return "Notif";
 
     default:
         return "Invalid message";
@@ -395,8 +395,7 @@ static void respond(fwk_id_t service_id, const void *payload, size_t size)
     if ((payload != NULL) && (*((int32_t *)payload) < SCMI_SUCCESS)) {
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_ERROR
         FWK_LOG_ERR(
-            "[SCMI] %s: %s [%" PRIu16
-            " (0x%x:0x%x)] returned with an error (%d)",
+            "[SCMI] %s: %s [%" PRIu16 " (0x%x:0x%x)] returned error (%d)",
             service_name,
             message_type_name,
             ctx->scmi_token,

--- a/module/scmi_perf/CMakeLists.txt
+++ b/module/scmi_perf/CMakeLists.txt
@@ -14,8 +14,13 @@ target_sources(${SCP_MODULE_TARGET}
                PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_scmi_perf.c")
 
 if(SCP_ENABLE_PLUGIN_HANDLER)
-    target_sources(${SCP_MODULE_TARGET}
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/perf_plugins_handler.c)
+    if(NOT SCP_ENABLE_FAST_CHANNELS)
+        MESSAGE(FATAL_ERROR "ERROR: Plugin-handler requires FastChannels")
+    endif()
+
+    target_sources(
+        ${SCP_MODULE_TARGET}
+        PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/perf_plugins_handler.c")
 endif()
 
 target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-dvfs module-scmi

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -14,7 +14,7 @@
 #include <mod_scmi.h>
 #include <mod_scmi_perf.h>
 #ifdef BUILD_HAS_SCMI_PERF_PLUGIN_HANDLER
-#    include <perf_plugins_handler.h>
+#    include "perf_plugins_handler.h"
 #endif
 #include <mod_timer.h>
 

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -1452,11 +1452,11 @@ static void scmi_perf_notify_limits_updated(
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS
     struct scmi_perf_limits_changed limits_changed;
 #endif
-    int idx;
+    unsigned int idx;
     const struct mod_scmi_perf_domain_config *domain;
     struct mod_scmi_perf_fast_channel_limit *get_limit;
 
-    idx = (int)fwk_id_get_element_idx(domain_id);
+    idx = fwk_id_get_element_idx(domain_id);
 
     domain = &(*scmi_perf_ctx.config->domains)[idx];
     if (domain->fast_channels_addr_scp != NULL) {

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -74,7 +74,6 @@ static int scmi_perf_level_notify(
 /* Forward declaration */
 static void scmi_perf_notify_limits_updated(
     fwk_id_t domain_id,
-    uintptr_t cookie,
     uint32_t range_min,
     uint32_t range_max);
 
@@ -395,7 +394,7 @@ int perf_set_limits(
     }
 
     scmi_perf_notify_limits_updated(
-        domain_id, 0, limits->minimum, limits->maximum);
+        domain_id, limits->minimum, limits->maximum);
 
     domain_ctx->level_limits.minimum = limits->minimum;
     domain_ctx->level_limits.maximum = limits->maximum;
@@ -439,7 +438,7 @@ void perf_eval_performance(
     }
 
     scmi_perf_notify_limits_updated(
-        domain_id, 0, limits->minimum, limits->maximum);
+        domain_id, limits->minimum, limits->maximum);
 
     /* adjust_opp_for_new_limits */
     if (*level < limits->minimum) {
@@ -1447,7 +1446,6 @@ static void scmi_perf_respond(
  */
 static void scmi_perf_notify_limits_updated(
     fwk_id_t domain_id,
-    uintptr_t cookie,
     uint32_t range_min,
     uint32_t range_max)
 {
@@ -1482,7 +1480,7 @@ static void scmi_perf_notify_limits_updated(
 #endif
 
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS
-    limits_changed.agent_id = (uint32_t)cookie;
+    limits_changed.agent_id = (uint32_t)0;
     limits_changed.domain_id = (uint32_t)idx;
     limits_changed.range_min = range_min;
     limits_changed.range_max = range_max;

--- a/module/scmi_perf/src/perf_plugins_handler.c
+++ b/module/scmi_perf/src/perf_plugins_handler.c
@@ -13,8 +13,8 @@
  *      the real frequency domains available in hardware.
  */
 
-#include <perf_plugins_handler.h>
-#include <scmi_perf.h>
+#include "perf_plugins_handler.h"
+#include "scmi_perf.h"
 
 #include <mod_dvfs.h>
 


### PR DESCRIPTION
This PR brings assorted minor improvements:
- shorten logging strings
- simplification scmi_perf_notify_limits_update()
- remove redundant casting
- Cmake build fixes for Performance Plugin Handler
- enforce (cmake) build requirements for Performance Plugin Handler

and replace/remove non-inclusive terminology in scmi module.