### PR TITLE
scmi_perf: Fix required MISRA defects rule 10.3

### DIFF
--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -1189,7 +1189,7 @@ static int scmi_perf_describe_fast_channels(fwk_id_t service_id,
         goto exit;
     }
 
-    message_id = parameters->message_id;
+    message_id = (enum scmi_perf_command_id)parameters->message_id;
 
     switch (message_id) {
     case MOD_SCMI_PERF_LEVEL_GET:


### PR DESCRIPTION
A MISRA 10.3 defect within scmi-perf will be addressed in this patch.
