### PR TITLE
product/synquacer: implement system power-off

### DIFF
--- a/product/synquacer/module/synquacer_system/src/mod_synquacer_system.c
+++ b/product/synquacer/module/synquacer_system/src/mod_synquacer_system.c
@@ -27,7 +27,8 @@ enum synquacer_system_event {
     SYNQUACER_SYSTEM_EVENT_COUNT
 };
 
-int reboot_chip(void);
+int synquacer_reboot_chip(void);
+int synquacer_shutdown(void);
 void power_domain_reboot(void);
 void main_initialize(void);
 int synquacer_main(void);
@@ -39,9 +40,18 @@ int synquacer_main(void);
 static int synquacer_system_shutdown(
     enum mod_pd_system_shutdown system_shutdown)
 {
-    FWK_LOG_INFO("[SYNQUACER SYSTEM] requesting synquacer system_shutdown");
-
-    reboot_chip();
+    switch (system_shutdown) {
+    case MOD_PD_SYSTEM_SHUTDOWN:
+        FWK_LOG_INFO("[SYNQUACER SYSTEM] system is shutting down");
+        synquacer_shutdown();
+        break;
+    case MOD_PD_SYSTEM_COLD_RESET:
+        FWK_LOG_INFO("[SYNQUACER SYSTEM] system is cold reset");
+        synquacer_reboot_chip();
+        break;
+    default:
+        return FWK_E_SUPPORT;
+    }
 
     return FWK_E_DEVICE;
 }


### PR DESCRIPTION
This commit implements the system power-off handling
by turning off the ATX power supply through GPIO.

Before this commit, system power-off handling is implemented
in Trusted Firmware-A running on the application
processor(cortex-a53). Since SCP is responsible for managing
system power, system power-off should be implemented in SCP-firmware.

Together with this SCP-firmware update, Trusted Firmware-A
PSCI system_off handling also needs to be updated to call
SCMI SYSTEM_POWER_STATE_SET command.

Signed-off-by: Masahisa Kojima <masahisa.kojima@linaro.org>
Change-Id: Ia96bc13ea5e74f892295dee3a4896bf5a7e6fb46