### PR TITLE
scmi_perf: fix describe levels handler

### DIFF
--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -796,7 +796,7 @@ static int scmi_perf_describe_levels_handler(fwk_id_t service_id,
 exit:
     scmi_perf_ctx.scmi_api->respond(service_id,
         (return_values.status == SCMI_SUCCESS) ?
-            NULL : &return_values.status,
+            &return_values.status : NULL,
         (return_values.status == SCMI_SUCCESS) ?
             payload_size : sizeof(return_values.status));
 


### PR DESCRIPTION
In case of sucess, return the payload instead of null pointer

Signed-off-by: Vincent Guittot <vincent.guittot@linaro.org>