### PR TITLE
dvfs/scmi_perf/sensor fixes

### DIFF
--- a/module/dvfs/include/mod_dvfs.h
+++ b/module/dvfs/include/mod_dvfs.h
@@ -70,16 +70,6 @@ struct mod_dvfs_domain_config {
      */
     fwk_id_t alarm_id;
 
-    /*!
-     * \brief Notifications identifier.
-     */
-    fwk_id_t notification_id;
-
-    /*!
-     * \brief Updates API identifier.
-     */
-    fwk_id_t updates_api_id;
-
     /*! Delay in milliseconds before retrying a request */
     uint16_t retry_ms;
 

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -1944,8 +1944,10 @@ static int scmi_perf_start(fwk_id_t id)
     struct mod_scmi_perf_fast_channel_limit *fc_limits;
     struct mod_dvfs_opp opp;
 
-    /* Initialise FastChannels level to 0 and limits to min/max OPPs */
-
+    /*
+     * Initialise FastChannels level to sustained level and limits to min/max
+     * OPPs.
+     */
     for (i = 0; i < scmi_perf_ctx.domain_count; i++) {
         domain = &(*scmi_perf_ctx.config->domains)[i];
         if (domain->fast_channels_addr_scp != NULL) {
@@ -1960,7 +1962,7 @@ static int scmi_perf_start(fwk_id_t id)
                             return status;
                         }
 
-                        memset(fc_elem, opp.level, fast_channel_elem_size[j]);
+                        memcpy(fc_elem, &opp.level, fast_channel_elem_size[j]);
                     } else {
                         /* _LIMIT_SET or _LIMIT_GET */
                         domain_ctx = &scmi_perf_ctx.domain_ctx_table[i];

--- a/module/sensor/src/mod_sensor.c
+++ b/module/sensor/src/mod_sensor.c
@@ -7,7 +7,6 @@
 
 #include "sensor.h"
 
-#include <mod_scmi_sensor.h>
 #include <mod_sensor.h>
 
 #include <fwk_assert.h>


### PR DESCRIPTION
This PR brings some small fixes to the following modules:
- dvfs: remove unused fields for the module config struct
- scmi_perf: fix fastchannels init
- sensor: remove unused header inclusion