### PR TITLE
sensor: Reintroduce guarded scmi_senosr header inclusion

### DIFF
--- a/module/sensor/src/mod_sensor.c
+++ b/module/sensor/src/mod_sensor.c
@@ -7,6 +7,9 @@
 
 #include "sensor.h"
 
+#ifdef BUILD_HAS_SCMI_SENSOR_EVENTS
+#    include <mod_scmi_sensor.h>
+#endif
 #include <mod_sensor.h>
 
 #include <fwk_assert.h>


### PR DESCRIPTION
Previous commit `989816611` removed the scmi_sensor header inclusion,
but that breaks the build when SENSOR_EVENTS are selected.
Reintroduce the header but this time guarded by its build definition.

Change-Id: I1200d78bafa84329a35e61f222cfde45f490053d
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>