### PR TITLE
Remove deprecated function fwk_thread_put_event_and_wait() from Power domain module  

### DIFF
--- a/module/power_domain/include/mod_power_domain.h
+++ b/module/power_domain/include/mod_power_domain.h
@@ -486,30 +486,6 @@ struct mod_pd_restricted_api {
     int (*get_domain_parent_id)(fwk_id_t pd_id, fwk_id_t *parent_pd_id);
 
     /*!
-     * \brief Set the state of a power domain and possibly of one or several of
-     *        its ancestors.
-     *
-     * \note The function sets the state of the power domain identified by
-     *      'pd_id' and possibly of one or several of its ancestors. When the
-     *      function returns the state transition is completed.
-     *
-     * \param pd_id Identifier of the power domain whose state has to be set.
-     *
-     * \param state State the power domain has to be put into and
-     *      possibly the state(s) its ancestor(s) has(have) to be put into. The
-     *      module will ensure that, for each power state transition, the parent
-     *      and the children of the power domain involved are in a state where
-     *      the transition can be completed.
-     *
-     * \retval ::FWK_SUCCESS The power state transition was completed.
-     * \retval ::FWK_E_ACCESS Invalid access, the framework has rejected the
-     *      call to the API.
-     * \retval ::FWK_E_HANDLER The function is not called from a thread.
-     * \retval ::FWK_E_PARAM One or more parameters were invalid.
-     */
-    int (*set_state)(fwk_id_t pd_id, uint32_t state);
-
-    /*!
      * \brief Request an asynchronous power state transition.
      *
      * \warning Successful completion of this function does not indicate
@@ -532,7 +508,7 @@ struct mod_pd_restricted_api {
      *      call to the API.
      * \retval ::FWK_E_PARAM One or more parameters were invalid.
      */
-    int (*set_state_async)(fwk_id_t pd_id, bool resp_requested, uint32_t state);
+    int (*set_state)(fwk_id_t pd_id, bool resp_requested, uint32_t state);
 
     /*!
      * \brief Get the state of a given power domain.
@@ -616,7 +592,7 @@ struct mod_pd_restricted_api {
  */
 struct mod_pd_driver_input_api {
     /*!
-     * \brief Request an asynchronous composite power state transition.
+     * \brief Request an composite power state transition.
      *
      * \warning Successful completion of this function does not indicate
      *      completion of a transition, but instead that a request has been
@@ -638,7 +614,7 @@ struct mod_pd_driver_input_api {
      *      call to the API.
      * \retval ::FWK_E_PARAM One or more parameters were invalid.
      */
-    int (*set_state_async)(
+    int (*set_state)(
         fwk_id_t pd_id,
         bool resp_requested,
         uint32_t composite_state);

--- a/module/power_domain/include/mod_power_domain.h
+++ b/module/power_domain/include/mod_power_domain.h
@@ -816,6 +816,12 @@ enum mod_pd_public_event_idx {
     MOD_PD_PUBLIC_EVENT_IDX_COUNT,
 };
 
+/*! Set state requires a response */
+#define MOD_PD_SET_STATE_REQ_RESP true
+
+/*! Set state does not require a response */
+#define MOD_PD_SET_STATE_NO_RESP false
+
 /*!
  * \brief Parameters of the set state response event
  */

--- a/module/power_domain/include/mod_power_domain.h
+++ b/module/power_domain/include/mod_power_domain.h
@@ -528,21 +528,25 @@ struct mod_pd_restricted_api {
     int (*get_state)(fwk_id_t pd_id, unsigned int *state);
 
     /*!
-     * \brief Reset of a power domain.
+     * \brief Request for a power domain to be reset.
      *
-     * \note The function resets the power domain identified by 'pd_id'. When
-     *      the function returns the power domain reset is completed.
+     * \note The function queues a reset request. When the function returns the
+     *      power domain has not been reset, the reset has just been requested
+     *      to the power domain module.
      *
      * \param pd_id Identifier of the power domain to reset.
      *
-     * \retval ::FWK_SUCCESS Power state retrieving request transmitted.
+     * \param resp_requested True if the caller wants to be notified with an
+     *      event response at the end of the reset request processing.
+     *
+     * \retval ::FWK_SUCCESS Reset request transmitted.
      * \retval ::FWK_E_ACCESS Invalid access, the framework has rejected the
      *      call to the API.
      * \retval ::FWK_E_HANDLER The function is not called from a thread.
      * \retval ::FWK_E_NOMEM Failed to allocate a request descriptor.
      * \retval ::FWK_E_PARAM The power domain identifier is unknown.
      */
-    int (*reset)(fwk_id_t pd_id);
+    int (*reset)(fwk_id_t pd_id, bool resp_requested);
 
     /*!
      * \brief Suspend the system.
@@ -638,7 +642,7 @@ struct mod_pd_driver_input_api {
      * \retval ::FWK_E_NOMEM Failed to allocate a request descriptor.
      * \retval ::FWK_E_PARAM The power domain identifier is unknown.
      */
-    int (*reset_async)(fwk_id_t pd_id, bool resp_requested);
+    int (*reset)(fwk_id_t pd_id, bool resp_requested);
 
     /*!
      * \brief Report a power domain state transition.

--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -1474,51 +1474,7 @@ static int pd_get_domain_parent_id(fwk_id_t pd_id, fwk_id_t *parent_pd_id)
 }
 
 /* Functions specific to the restricted API */
-
-static int pd_set_state(fwk_id_t pd_id, uint32_t state)
-{
-    int status;
-    struct pd_ctx *pd;
-    struct fwk_event req;
-    struct fwk_event resp;
-    struct pd_set_state_request *req_params =
-        (struct pd_set_state_request *)(&req.params);
-    struct pd_set_state_response *resp_params =
-        (struct pd_set_state_response *)(&resp.params);
-
-    pd = &mod_pd_ctx.pd_ctx_table[fwk_id_get_element_idx(pd_id)];
-
-    if (pd->cs_support) {
-        if (!is_valid_composite_state(pd, state)) {
-            return FWK_E_PARAM;
-        }
-    } else {
-        if (!is_valid_state(pd, state)) {
-            return FWK_E_PARAM;
-        }
-    }
-
-    req = (struct fwk_event) {
-        .id = FWK_ID_EVENT(FWK_MODULE_IDX_POWER_DOMAIN,
-                           MOD_PD_PUBLIC_EVENT_IDX_SET_STATE),
-        .source_id = pd->driver_id,
-        .target_id = pd_id,
-    };
-
-    req_params->composite_state = state;
-
-    status = fwk_thread_put_event_and_wait(&req, &resp);
-    if (status != FWK_SUCCESS) {
-        return status;
-    }
-
-    return resp_params->status;
-}
-
-static int pd_set_state_async(
-    fwk_id_t pd_id,
-    bool response_requested,
-    uint32_t state)
+static int pd_set_state(fwk_id_t pd_id, bool response_requested, uint32_t state)
 {
     struct pd_ctx *pd;
     struct fwk_event req;
@@ -1727,7 +1683,6 @@ static const struct mod_pd_restricted_api pd_restricted_api = {
     .get_domain_parent_id = pd_get_domain_parent_id,
 
     .set_state = pd_set_state,
-    .set_state_async = pd_set_state_async,
     .get_state = pd_get_state,
     .reset = pd_reset,
     .system_suspend = pd_system_suspend,
@@ -1735,7 +1690,7 @@ static const struct mod_pd_restricted_api pd_restricted_api = {
 };
 
 static const struct mod_pd_driver_input_api pd_driver_input_api = {
-    .set_state_async = pd_set_state_async,
+    .set_state = pd_set_state,
     .reset_async = pd_reset_async,
     .report_power_state_transition = pd_report_power_state_transition,
     .get_last_core_pd_id = pd_get_last_core_pd_id,

--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -1542,49 +1542,21 @@ static int pd_get_state(fwk_id_t pd_id, unsigned int *state)
     return FWK_SUCCESS;
 }
 
-static int pd_reset(fwk_id_t pd_id)
-{
-    int status;
-    struct fwk_event req;
-    struct fwk_event resp;
-    struct pd_response *resp_params = (struct pd_response *)(&resp.params);
-
-    req = (struct fwk_event) {
-        .id = FWK_ID_EVENT(FWK_MODULE_IDX_POWER_DOMAIN, PD_EVENT_IDX_RESET),
-        .target_id = pd_id,
-    };
-
-    status = fwk_thread_put_event_and_wait(&req, &resp);
-    if (status != FWK_SUCCESS) {
-        return status;
-    }
-
-    return resp_params->status;
-}
-
 static int pd_system_suspend(unsigned int state)
 {
-    int status;
     struct fwk_event req;
-    struct fwk_event resp;
     struct pd_system_suspend_request *req_params =
         (struct pd_system_suspend_request *)(&req.params);
-    struct pd_response *resp_params = (struct pd_response *)(&resp.params);
 
-    req = (struct fwk_event) {
-        .id = FWK_ID_EVENT(FWK_MODULE_IDX_POWER_DOMAIN,
-                           PD_EVENT_IDX_SYSTEM_SUSPEND),
+    req = (struct fwk_event){
+        .id = FWK_ID_EVENT(
+            FWK_MODULE_IDX_POWER_DOMAIN, PD_EVENT_IDX_SYSTEM_SUSPEND),
         .target_id = fwk_module_id_power_domain,
     };
 
     req_params->state = state;
 
-    status = fwk_thread_put_event_and_wait(&req, &resp);
-    if (status != FWK_SUCCESS) {
-        return status;
-    }
-
-    return resp_params->status;
+    return fwk_thread_put_event(&req);
 }
 
 static int pd_system_shutdown(enum mod_pd_system_shutdown system_shutdown)
@@ -1612,14 +1584,14 @@ static int pd_system_shutdown(enum mod_pd_system_shutdown system_shutdown)
 
 /* Functions specific to the driver input API */
 
-static int pd_reset_async(fwk_id_t pd_id, bool response_requested)
+static int pd_reset(fwk_id_t pd_id, bool response_requested)
 {
-    struct fwk_event req;
+    struct fwk_event_light req;
     struct pd_ctx *pd;
 
     pd = &mod_pd_ctx.pd_ctx_table[fwk_id_get_element_idx(pd_id)];
 
-    req = (struct fwk_event) {
+    req = (struct fwk_event_light){
         .id = FWK_ID_EVENT(FWK_MODULE_IDX_POWER_DOMAIN, PD_EVENT_IDX_RESET),
         .source_id = pd->driver_id,
         .target_id = pd_id,
@@ -1691,7 +1663,7 @@ static const struct mod_pd_restricted_api pd_restricted_api = {
 
 static const struct mod_pd_driver_input_api pd_driver_input_api = {
     .set_state = pd_set_state,
-    .reset_async = pd_reset_async,
+    .reset = pd_reset,
     .report_power_state_transition = pd_report_power_state_transition,
     .get_last_core_pd_id = pd_get_last_core_pd_id,
 };

--- a/module/scmi_power_domain/src/mod_scmi_power_domain.c
+++ b/module/scmi_power_domain/src/mod_scmi_power_domain.c
@@ -441,7 +441,7 @@ static int scmi_power_scp_set_core_state(fwk_id_t pd_id,
 {
     int status;
 
-    status = scmi_pd_ctx.pd_api->set_state_async(pd_id, false, composite_state);
+    status = scmi_pd_ctx.pd_api->set_state(pd_id, false, composite_state);
     if (status != FWK_SUCCESS) {
         FWK_LOG_ERR(
             "[SCMI:power] Failed to send core set request (error %s (%d))",
@@ -568,18 +568,19 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
         break;
 
     case MOD_PD_TYPE_CLUSTER:
-        if (!is_sync) {
+        /* sync support is removed */
+        if (is_sync) {
             return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
             goto exit;
         }
 
-        status = scmi_pd_ctx.pd_api->set_state(pd_id, power_state);
+        status = scmi_pd_ctx.pd_api->set_state(pd_id, false, power_state);
         break;
-
 
     case MOD_PD_TYPE_DEVICE_DEBUG:
 #ifdef BUILD_HAS_MOD_DEBUG
-        if (!is_sync) {
+        /* sync support is removed */
+        if (is_sync) {
             return_values.status = SCMI_NOT_SUPPORTED;
             goto exit;
         }
@@ -640,7 +641,7 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
     #endif
 
     case MOD_PD_TYPE_DEVICE:
-        if (!is_sync) {
+        if (is_sync) {
             return_values.status = (int32_t)SCMI_NOT_SUPPORTED;
             goto exit;
         }
@@ -668,7 +669,7 @@ static int scmi_pd_power_state_set_handler(fwk_id_t service_id,
             agent_id,
             power_state);
 
-        status = scmi_pd_ctx.pd_api->set_state(pd_id, pd_power_state);
+        status = scmi_pd_ctx.pd_api->set_state(pd_id, false, pd_power_state);
 
         if (status == FWK_SUCCESS) {
             scmi_pd_power_state_notify(

--- a/module/scmi_system_power/src/mod_scmi_system_power.c
+++ b/module/scmi_system_power/src/mod_scmi_system_power.c
@@ -382,6 +382,7 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
 
         status = scmi_sys_power_ctx.pd_api->set_state(
             scmi_sys_power_ctx.config->wakeup_power_domain_id,
+            false,
             scmi_sys_power_ctx.config->wakeup_composite_state);
         if (status != FWK_SUCCESS) {
             goto exit;

--- a/module/system_power/src/mod_system_power.c
+++ b/module/system_power/src/mod_system_power.c
@@ -339,7 +339,7 @@ static void soc_wakeup_handler(void)
         fwk_trap();
     }
 
-    status = system_power_ctx.mod_pd_restricted_api->set_state_async(
+    status = system_power_ctx.mod_pd_restricted_api->set_state(
         system_power_ctx.last_core_pd_id, false, state);
     fwk_check(status == FWK_SUCCESS);
 }

--- a/product/juno/module/juno_debug/src/mod_juno_debug.c
+++ b/product/juno/module/juno_debug/src/mod_juno_debug.c
@@ -246,7 +246,7 @@ static int turn_on_pd(fwk_id_t pd_id, enum juno_debug_state next_state)
 {
     int status;
 
-    status = dev_ctx.pd_api->set_state(pd_id, MOD_PD_STATE_ON);
+    status = dev_ctx.pd_api->set_state(pd_id, true, MOD_PD_STATE_ON);
     if (status == FWK_PENDING) {
         dev_ctx.state = next_state;
     }

--- a/product/juno/module/juno_debug/src/mod_juno_debug.c
+++ b/product/juno/module/juno_debug/src/mod_juno_debug.c
@@ -246,7 +246,8 @@ static int turn_on_pd(fwk_id_t pd_id, enum juno_debug_state next_state)
 {
     int status;
 
-    status = dev_ctx.pd_api->set_state(pd_id, true, MOD_PD_STATE_ON);
+    status = dev_ctx.pd_api->set_state(
+        pd_id, MOD_PD_SET_STATE_REQ_RESP, MOD_PD_STATE_ON);
     if (status == FWK_PENDING) {
         dev_ctx.state = next_state;
     }

--- a/product/juno/module/juno_ppu/src/mod_juno_ppu.c
+++ b/product/juno/module/juno_ppu/src/mod_juno_ppu.c
@@ -781,7 +781,7 @@ static void core_wakeup_handler(uintptr_t param)
     status = disable_wakeup_irq(dev_config);
     fwk_assert(status == FWK_SUCCESS);
 
-    status = ppu_ctx->pd_api->set_state_async(
+    status = ppu_ctx->pd_api->set_state(
         ppu_ctx->bound_id, false, CPU_WAKEUP_COMPOSITE_STATE);
     fwk_assert(status == FWK_SUCCESS);
 }

--- a/product/morello/module/morello_system/src/mod_morello_system.c
+++ b/product/morello/module/morello_system/src/mod_morello_system.c
@@ -390,7 +390,7 @@ static int morello_system_init_primary_core(void)
             "[MORELLO SYSTEM] Booting primary core at %lu MHz...",
             PIK_CLK_RATE_CLUS0_CPU / FWK_MHZ);
 
-        status = mod_pd_restricted_api->set_state_async(
+        status = mod_pd_restricted_api->set_state(
             FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
             false,
             MOD_PD_COMPOSITE_STATE(
@@ -576,7 +576,7 @@ static int morello_system_start(fwk_id_t id)
     composite_state = MOD_PD_COMPOSITE_STATE(
         MOD_PD_LEVEL_2, 0, MOD_PD_STATE_ON, MOD_PD_STATE_OFF, MOD_PD_STATE_OFF);
 
-    return morello_system_ctx.mod_pd_restricted_api->set_state_async(
+    return morello_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0), false, composite_state);
 }
 

--- a/product/n1sdp/module/n1sdp_c2c/src/mod_n1sdp_c2c_i2c.c
+++ b/product/n1sdp/module/n1sdp_c2c/src/mod_n1sdp_c2c_i2c.c
@@ -730,7 +730,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_CORE:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
-                false,
+                MOD_PD_SET_STATE_NO_RESP,
                 MOD_PD_COMPOSITE_STATE(
                     MOD_PD_LEVEL_0, 0, 0, 0, MOD_PD_STATE_OFF));
             if (status != FWK_SUCCESS) {
@@ -742,7 +742,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_DEVICE_DEBUG:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
-                false,
+                MOD_PD_SET_STATE_NO_RESP,
                 MOD_PD_STATE_OFF);
             if (status != FWK_SUCCESS) {
                 goto error;
@@ -752,7 +752,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_SYSTEM:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
-                false,
+                MOD_PD_SET_STATE_NO_RESP,
                 MOD_PD_STATE_OFF);
             if (status != FWK_SUCCESS) {
                 goto error;
@@ -775,7 +775,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_CORE:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
-                false,
+                MOD_PD_SET_STATE_NO_RESP,
                 MOD_PD_COMPOSITE_STATE(
                     MOD_PD_LEVEL_2,
                     0,
@@ -791,7 +791,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_DEVICE_DEBUG:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
-                false,
+                MOD_PD_SET_STATE_NO_RESP,
                 MOD_PD_STATE_ON);
             if (status != FWK_SUCCESS) {
                 goto error;
@@ -801,7 +801,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_SYSTEM:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
-                false,
+                MOD_PD_SET_STATE_NO_RESP,
                 MOD_PD_STATE_ON);
             if (status != FWK_SUCCESS) {
                 goto error;

--- a/product/n1sdp/module/n1sdp_c2c/src/mod_n1sdp_c2c_i2c.c
+++ b/product/n1sdp/module/n1sdp_c2c/src/mod_n1sdp_c2c_i2c.c
@@ -730,6 +730,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_CORE:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
+                false,
                 MOD_PD_COMPOSITE_STATE(
                     MOD_PD_LEVEL_0, 0, 0, 0, MOD_PD_STATE_OFF));
             if (status != FWK_SUCCESS) {
@@ -741,6 +742,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_DEVICE_DEBUG:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
+                false,
                 MOD_PD_STATE_OFF);
             if (status != FWK_SUCCESS) {
                 goto error;
@@ -750,6 +752,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_SYSTEM:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
+                false,
                 MOD_PD_STATE_OFF);
             if (status != FWK_SUCCESS) {
                 goto error;
@@ -772,6 +775,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_CORE:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
+                false,
                 MOD_PD_COMPOSITE_STATE(
                     MOD_PD_LEVEL_2,
                     0,
@@ -787,6 +791,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_DEVICE_DEBUG:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
+                false,
                 MOD_PD_STATE_ON);
             if (status != FWK_SUCCESS) {
                 goto error;
@@ -796,6 +801,7 @@ static int n1sdp_c2c_process_command(void)
         case MOD_PD_TYPE_SYSTEM:
             status = n1sdp_c2c_ctx.pd_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, rx_data[1]),
+                false,
                 MOD_PD_STATE_ON);
             if (status != FWK_SUCCESS) {
                 goto error;

--- a/product/n1sdp/module/n1sdp_system/src/mod_n1sdp_system.c
+++ b/product/n1sdp/module/n1sdp_system/src/mod_n1sdp_system.c
@@ -457,7 +457,7 @@ static int n1sdp_system_init_primary_core(void)
             "[N1SDP SYSTEM] Booting primary core at %lu MHz...",
             PIK_CLK_RATE_CLUS0_CPU / FWK_MHZ);
 
-        status = mod_pd_restricted_api->set_state_async(
+        status = mod_pd_restricted_api->set_state(
             FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
             false,
             MOD_PD_COMPOSITE_STATE(
@@ -671,7 +671,7 @@ static int n1sdp_system_start(fwk_id_t id)
                                                  MOD_PD_STATE_OFF);
     }
 
-    return n1sdp_system_ctx.mod_pd_restricted_api->set_state_async(
+    return n1sdp_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0), false, composite_state);
 }
 

--- a/product/rcar/module/rcar_pd_pmic_bd9571/src/mod_rcar_pd_pmic_bd9571.c
+++ b/product/rcar/module/rcar_pd_pmic_bd9571/src/mod_rcar_pd_pmic_bd9571.c
@@ -85,7 +85,7 @@ static int pd_pmic_resume(void)
 
     pd_ctx = &rcar_pmic_ctx.pd_ctx_table[
                     RCAR_PD_PMIC_ELEMENT_IDX_PMIC_DDR_BKUP];
-    pd_ctx->pd_driver_input_api->set_state_async(
+    pd_ctx->pd_driver_input_api->set_state(
         pd_ctx->bound_id, false, MOD_PD_STATE_OFF);
 
     return FWK_SUCCESS;

--- a/product/rcar/module/rcar_system_power/src/mod_rcar_system_power.c
+++ b/product/rcar/module/rcar_system_power/src/mod_rcar_system_power.c
@@ -101,8 +101,8 @@ static void soc_wakeup_handler(void)
     uint32_t state = MOD_PD_COMPOSITE_STATE(
         MOD_PD_LEVEL_2, 0, MOD_PD_STATE_ON, MOD_PD_STATE_ON, MOD_PD_STATE_ON);
 
-    status = system_power_ctx.mod_pd_restricted_api->set_state_async(
-        pd_id, false, state);
+    status =
+        system_power_ctx.mod_pd_restricted_api->set_state(pd_id, false, state);
     assert(status == FWK_SUCCESS);
     (void)status;
 }

--- a/product/rdn1e1/module/rdn1e1_system/src/mod_rdn1e1_system.c
+++ b/product/rdn1e1/module/rdn1e1_system/src/mod_rdn1e1_system.c
@@ -303,7 +303,7 @@ static int rdn1e1_system_start(fwk_id_t id)
     if (status != FWK_SUCCESS)
         return status;
 
-    return rdn1e1_system_ctx.mod_pd_restricted_api->set_state_async(
+    return rdn1e1_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
         false,
         MOD_PD_COMPOSITE_STATE(
@@ -377,7 +377,7 @@ int rdn1e1_system_process_notification(const struct fwk_event *event,
 
             mod_pd_restricted_api = rdn1e1_system_ctx.mod_pd_restricted_api;
 
-            status = mod_pd_restricted_api->set_state_async(
+            status = mod_pd_restricted_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
                 false,
                 MOD_PD_COMPOSITE_STATE(

--- a/product/rdn1e1/module/rdn1e1_system/src/mod_rdn1e1_system.c
+++ b/product/rdn1e1/module/rdn1e1_system/src/mod_rdn1e1_system.c
@@ -379,7 +379,7 @@ int rdn1e1_system_process_notification(const struct fwk_event *event,
 
             status = mod_pd_restricted_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
-                false,
+                MOD_PD_SET_STATE_NO_RESP,
                 MOD_PD_COMPOSITE_STATE(
                     MOD_PD_LEVEL_2,
                     0,

--- a/product/rdn2/module/platform_system/src/mod_platform_system.c
+++ b/product/rdn2/module/platform_system/src/mod_platform_system.c
@@ -334,7 +334,7 @@ static int platform_system_start(fwk_id_t id)
 
     status = platform_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
-        false,
+        MOD_PD_SET_STATE_NO_RESP,
         MOD_PD_COMPOSITE_STATE(
             MOD_PD_LEVEL_2,
             0,

--- a/product/rdn2/module/platform_system/src/mod_platform_system.c
+++ b/product/rdn2/module/platform_system/src/mod_platform_system.c
@@ -332,7 +332,7 @@ static int platform_system_start(fwk_id_t id)
         return status;
     }
 
-    status = platform_system_ctx.mod_pd_restricted_api->set_state_async(
+    status = platform_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
         false,
         MOD_PD_COMPOSITE_STATE(
@@ -368,7 +368,7 @@ int platform_system_process_notification(
 
             mod_pd_restricted_api = platform_system_ctx.mod_pd_restricted_api;
 
-            status = mod_pd_restricted_api->set_state_async(
+            status = mod_pd_restricted_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
                 false,
                 MOD_PD_COMPOSITE_STATE(

--- a/product/rdv1/module/platform_system/src/mod_platform_system.c
+++ b/product/rdv1/module/platform_system/src/mod_platform_system.c
@@ -284,7 +284,7 @@ static int platform_system_start(fwk_id_t id)
     if (status != FWK_SUCCESS)
         return status;
 
-    return platform_system_ctx.mod_pd_restricted_api->set_state_async(
+    return platform_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
         false,
         MOD_PD_COMPOSITE_STATE(
@@ -319,7 +319,7 @@ int platform_system_process_notification(
 
             mod_pd_restricted_api = platform_system_ctx.mod_pd_restricted_api;
 
-            status = mod_pd_restricted_api->set_state_async(
+            status = mod_pd_restricted_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
                 false,
                 MOD_PD_COMPOSITE_STATE(

--- a/product/rdv1/module/platform_system/src/mod_platform_system.c
+++ b/product/rdv1/module/platform_system/src/mod_platform_system.c
@@ -321,7 +321,7 @@ int platform_system_process_notification(
 
             status = mod_pd_restricted_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
-                false,
+                MOD_PD_SET_STATE_NO_RESP,
                 MOD_PD_COMPOSITE_STATE(
                     MOD_PD_LEVEL_2,
                     0,

--- a/product/rdv1mc/module/platform_system/src/mod_platform_system.c
+++ b/product/rdv1mc/module/platform_system/src/mod_platform_system.c
@@ -293,7 +293,7 @@ static int platform_system_start(fwk_id_t id)
     if (status != FWK_SUCCESS)
         return status;
 
-    return platform_system_ctx.mod_pd_restricted_api->set_state_async(
+    return platform_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
         false,
         MOD_PD_COMPOSITE_STATE(
@@ -335,7 +335,7 @@ int platform_system_process_notification(
 
             mod_pd_restricted_api = platform_system_ctx.mod_pd_restricted_api;
 
-            status = mod_pd_restricted_api->set_state_async(
+            status = mod_pd_restricted_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
                 false,
                 MOD_PD_COMPOSITE_STATE(

--- a/product/rdv1mc/module/platform_system/src/mod_platform_system.c
+++ b/product/rdv1mc/module/platform_system/src/mod_platform_system.c
@@ -337,7 +337,7 @@ int platform_system_process_notification(
 
             status = mod_pd_restricted_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
-                false,
+                MOD_PD_SET_STATE_NO_RESP,
                 MOD_PD_COMPOSITE_STATE(
                     MOD_PD_LEVEL_2,
                     0,

--- a/product/sgi575/module/sgi575_system/src/mod_sgi575_system.c
+++ b/product/sgi575/module/sgi575_system/src/mod_sgi575_system.c
@@ -321,7 +321,7 @@ int sgi575_system_process_notification(const struct fwk_event *event,
 
             status = mod_pd_restricted_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
-                false,
+                MOD_PD_SET_STATE_NO_RESP,
                 MOD_PD_COMPOSITE_STATE(
                     MOD_PD_LEVEL_2,
                     0,

--- a/product/sgi575/module/sgi575_system/src/mod_sgi575_system.c
+++ b/product/sgi575/module/sgi575_system/src/mod_sgi575_system.c
@@ -285,7 +285,7 @@ static int sgi575_system_start(fwk_id_t id)
         return status;
     }
 
-    return sgi575_system_ctx.mod_pd_restricted_api->set_state_async(
+    return sgi575_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
         false,
         MOD_PD_COMPOSITE_STATE(
@@ -319,7 +319,7 @@ int sgi575_system_process_notification(const struct fwk_event *event,
 
             mod_pd_restricted_api = sgi575_system_ctx.mod_pd_restricted_api;
 
-            status = mod_pd_restricted_api->set_state_async(
+            status = mod_pd_restricted_api->set_state(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
                 false,
                 MOD_PD_COMPOSITE_STATE(

--- a/product/synquacer/module/synquacer_system/src/synquacer_main.c
+++ b/product/synquacer/module/synquacer_system/src/synquacer_main.c
@@ -373,7 +373,7 @@ int synquacer_main(void)
     FWK_LOG_INFO("[SYNQUACER SYSTEM] powering up AP");
     status = synquacer_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
-        false,
+        MOD_PD_SET_STATE_NO_RESP,
         MOD_PD_COMPOSITE_STATE(
             MOD_PD_LEVEL_2,
             0,

--- a/product/synquacer/module/synquacer_system/src/synquacer_main.c
+++ b/product/synquacer/module/synquacer_system/src/synquacer_main.c
@@ -371,7 +371,7 @@ int synquacer_main(void)
     fw_wakeup_ap();
 
     FWK_LOG_INFO("[SYNQUACER SYSTEM] powering up AP");
-    status = synquacer_system_ctx.mod_pd_restricted_api->set_state_async(
+    status = synquacer_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
         false,
         MOD_PD_COMPOSITE_STATE(

--- a/product/tc0/module/tc0_system/src/mod_tc0_system.c
+++ b/product/tc0/module/tc0_system/src/mod_tc0_system.c
@@ -189,7 +189,7 @@ static int tc0_system_start(fwk_id_t id)
 
     return tc0_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
-        false,
+        MOD_PD_SET_STATE_NO_RESP,
         MOD_PD_COMPOSITE_STATE(
             MOD_PD_LEVEL_2,
             0,

--- a/product/tc0/module/tc0_system/src/mod_tc0_system.c
+++ b/product/tc0/module/tc0_system/src/mod_tc0_system.c
@@ -187,7 +187,7 @@ static int tc0_system_start(fwk_id_t id)
         return status;
     }
 
-    return tc0_system_ctx.mod_pd_restricted_api->set_state_async(
+    return tc0_system_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
         false,
         MOD_PD_COMPOSITE_STATE(

--- a/product/tc1/module/tc1_system/src/mod_tc1_system.c
+++ b/product/tc1/module/tc1_system/src/mod_tc1_system.c
@@ -186,7 +186,7 @@ static int tc1_system_start(fwk_id_t id)
 
     return mod_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
-        false,
+        MOD_PD_SET_STATE_NO_RESP,
         MOD_PD_COMPOSITE_STATE(
             MOD_PD_LEVEL_2,
             0,

--- a/product/tc1/module/tc1_system/src/mod_tc1_system.c
+++ b/product/tc1/module/tc1_system/src/mod_tc1_system.c
@@ -184,7 +184,7 @@ static int tc1_system_start(fwk_id_t id)
         return status;
     }
 
-    return mod_ctx.mod_pd_restricted_api->set_state_async(
+    return mod_ctx.mod_pd_restricted_api->set_state(
         FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, 0),
         false,
         MOD_PD_COMPOSITE_STATE(


### PR DESCRIPTION
Now the SCMI Power domain is using the event-response mechanism to handle the synchronous requests.