### PR TITLE
llvm/morello: Add support for soc build images

### DIFF
--- a/product/morello/mcp_ramfw_soc/Toolchain-Clang.cmake
+++ b/product/morello/mcp_ramfw_soc/Toolchain-Clang.cmake
@@ -1,0 +1,17 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/Clang-Baremetal.cmake")

--- a/product/morello/scp_ramfw_soc/Toolchain-Clang.cmake
+++ b/product/morello/scp_ramfw_soc/Toolchain-Clang.cmake
@@ -1,0 +1,17 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+set(CMAKE_SYSTEM_PROCESSOR "cortex-m7")
+
+set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")
+set(CMAKE_CXX_COMPILER_TARGET "arm-arm-none-eabi")
+
+include(
+    "${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Toolchain/Clang-Baremetal.cmake")


### PR DESCRIPTION
This patch adds LLVM support for soc build images.

Signed-off-by: Leandro Belli <leandro.belli@arm.com>
Change-Id: I06c3e996e8a6bafaa74f2ea7985af3de48bdae2f