### PR TITLE
pd/juno: Simplify get state request

### DIFF
--- a/module/power_domain/include/mod_power_domain.h
+++ b/module/power_domain/include/mod_power_domain.h
@@ -518,11 +518,7 @@ struct mod_pd_restricted_api {
      * \param[out] state The power domain state.
      *
      * \retval ::FWK_SUCCESS The power state was returned.
-     * \retval ::FWK_E_ACCESS Invalid access, the framework has rejected the
-     *      call to the API.
-     * \retval ::FWK_E_HANDLER The function is not called from a thread.
      * \retval ::FWK_E_PARAM An invalid parameter was encountered:
-     *      - The `pd_id` parameter was not a valid system entity identifier.
      *      - The `state` parameter was a null pointer value.
      */
     int (*get_state)(fwk_id_t pd_id, unsigned int *state);
@@ -809,9 +805,6 @@ enum mod_pd_public_event_idx {
     /*! Set state request event */
     MOD_PD_PUBLIC_EVENT_IDX_SET_STATE,
 
-    /*! Get state request event */
-    MOD_PD_PUBLIC_EVENT_IDX_GET_STATE,
-
     /*! Number of public Power Domain events */
     MOD_PD_PUBLIC_EVENT_IDX_COUNT,
 };
@@ -866,10 +859,6 @@ static const fwk_id_t mod_pd_public_event_id_set_state =
     FWK_ID_EVENT_INIT(FWK_MODULE_IDX_POWER_DOMAIN,
                       MOD_PD_PUBLIC_EVENT_IDX_SET_STATE);
 
-/*! Identifier of the public event get_state identifier */
-static const fwk_id_t mod_pd_public_event_id_get_state =
-    FWK_ID_EVENT_INIT(FWK_MODULE_IDX_POWER_DOMAIN,
-                      MOD_PD_PUBLIC_EVENT_IDX_GET_STATE);
 #endif
 
 /*!

--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -245,8 +245,7 @@ struct pd_set_state_request {
 };
 
 /*
- * MOD_PD_PUBLIC_EVENT_IDX_GET_STATE
- * Parameters of the get state request event
+ * Parameters of the get state request
  */
 struct pd_get_state_request {
     /*
@@ -1014,15 +1013,12 @@ static int complete_system_suspend(struct pd_ctx *target_pd)
 }
 
 /*
- * Process a 'get composite state' request.
+ * Process a 'get state' request.
  *
  * pd Description of the target of the 'get state' request
- * req_params Parameters of the 'get state' request
- * resp_params Parameters of the 'get state' request response to be filled in
+ * state the required state to be filled in
  */
-static void process_get_state_request(struct pd_ctx *pd,
-    const struct pd_get_state_request *req_params,
-    struct pd_get_state_response *resp_params)
+static void process_get_state_request(struct pd_ctx *pd, unsigned int *state)
 {
     unsigned int level = 0U;
     struct pd_ctx *const base_pd = pd;
@@ -1032,7 +1028,7 @@ static void process_get_state_request(struct pd_ctx *pd,
     int table_size, cs_idx = 0;
 
     if (!pd->cs_support) {
-        resp_params->state = pd->current_state;
+        *state = pd->current_state;
     } else {
         state_mask_table = pd->composite_state_mask_table;
         table_size = (int)pd->composite_state_mask_table_size;
@@ -1060,10 +1056,8 @@ static void process_get_state_request(struct pd_ctx *pd,
             composite_state |= (--level) << shift;
         }
 
-        resp_params->state = composite_state;
+        *state = composite_state;
     }
-
-    resp_params->status = FWK_SUCCESS;
 }
 
 /*
@@ -1535,36 +1529,15 @@ static int pd_set_state(fwk_id_t pd_id, bool response_requested, uint32_t state)
 
 static int pd_get_state(fwk_id_t pd_id, unsigned int *state)
 {
-    int status;
-    struct fwk_event req;
-    struct fwk_event resp;
-    struct pd_get_state_request *req_params =
-        (struct pd_get_state_request *)(&req.params);
-    struct pd_get_state_response *resp_params =
-        (struct pd_get_state_response *)(&resp.params);
+    struct pd_ctx *pd = NULL;
 
     if (state == NULL) {
         return FWK_E_PARAM;
     }
 
-    req = (struct fwk_event) {
-        .id = FWK_ID_EVENT(FWK_MODULE_IDX_POWER_DOMAIN,
-                           MOD_PD_PUBLIC_EVENT_IDX_GET_STATE),
-        .target_id = pd_id,
-    };
+    pd = &mod_pd_ctx.pd_ctx_table[fwk_id_get_element_idx(pd_id)];
 
-    req_params->composite = false;
-
-    status = fwk_thread_put_event_and_wait(&req, &resp);
-    if (status != FWK_SUCCESS) {
-        return status;
-    }
-
-    if (resp_params->status != FWK_SUCCESS) {
-        return resp_params->status;
-    }
-
-    *state = resp_params->state;
+    process_get_state_request(pd, state);
 
     return FWK_SUCCESS;
 }
@@ -1951,15 +1924,6 @@ static int pd_process_event(const struct fwk_event *event,
         fwk_assert(pd != NULL);
 
         process_set_state_request(pd, event, resp);
-
-        return FWK_SUCCESS;
-
-    case (unsigned int)MOD_PD_PUBLIC_EVENT_IDX_GET_STATE:
-        fwk_assert(pd != NULL);
-
-        process_get_state_request(pd,
-            (struct pd_get_state_request *)event->params,
-            (struct pd_get_state_response *)resp->params);
 
         return FWK_SUCCESS;
 

--- a/product/juno/module/juno_debug/src/mod_juno_debug.c
+++ b/product/juno/module/juno_debug/src/mod_juno_debug.c
@@ -541,7 +541,6 @@ static int juno_debug_process_event(const struct fwk_event *event,
 
         switch (fwk_id_get_event_idx(event->id)) {
         /* Response event from PD */
-        case MOD_PD_PUBLIC_EVENT_IDX_GET_STATE:
         case MOD_PD_PUBLIC_EVENT_IDX_SET_STATE:
             pd_set_resp_params = (struct pd_set_state_response *)event->params;
 


### PR DESCRIPTION
This patch reduces the overhead of queuing events for retrieving
the power state of a domain. It also removes a call to the
deprecated function fwk_thread_put_event_and_wait().

Signed-off-by: Tarek El-Sherbiny <tarek.el-sherbiny@arm.com>
Change-Id: Id336ce6ccf1023f37970ae562faa5a4ccedb4642