### PR TITLE
fwk_module: Mark code path as unexpected

### DIFF
--- a/framework/src/fwk_module.c
+++ b/framework/src/fwk_module.c
@@ -652,6 +652,7 @@ const char *fwk_module_get_element_name(fwk_id_t id)
         return fwk_module_get_element_ctx(id)->desc->name;
     }
 
+    fwk_unexpected();
     return NULL;
 }
 
@@ -664,6 +665,7 @@ const void *fwk_module_get_data(fwk_id_t id)
         return fwk_module_get_ctx(id)->config->data;
     }
 
+    fwk_unexpected();
     return NULL;
 }
 


### PR DESCRIPTION
The fwk_module_get_data() and fwk_get_element_name() are not expected
to be called with invalid id. In this scenario, one of the framework
assert functions is used to terminate the program.
This warning was flagged by the static analysis tool.

Signed-off-by: Tarek El-Sherbiny <tarek.el-sherbiny@arm.com>
Change-Id: I6341dede53ab3f8c1ceeaa0a8e5257a08eb1cc13