### PR TITLE
pd/juno: Simplify get state request

### DIFF
--- a/module/power_domain/include/mod_power_domain.h
+++ b/module/power_domain/include/mod_power_domain.h
@@ -518,11 +518,7 @@ struct mod_pd_restricted_api {
      * \param[out] state The power domain state.
      *
      * \retval ::FWK_SUCCESS The power state was returned.
-     * \retval ::FWK_E_ACCESS Invalid access, the framework has rejected the
-     *      call to the API.
-     * \retval ::FWK_E_HANDLER The function is not called from a thread.
      * \retval ::FWK_E_PARAM An invalid parameter was encountered:
-     *      - The `pd_id` parameter was not a valid system entity identifier.
      *      - The `state` parameter was a null pointer value.
      */
     int (*get_state)(fwk_id_t pd_id, unsigned int *state);
@@ -809,9 +805,6 @@ enum mod_pd_public_event_idx {
     /*! Set state request event */
     MOD_PD_PUBLIC_EVENT_IDX_SET_STATE,
 
-    /*! Get state request event */
-    MOD_PD_PUBLIC_EVENT_IDX_GET_STATE,
-
     /*! Number of public Power Domain events */
     MOD_PD_PUBLIC_EVENT_IDX_COUNT,
 };
@@ -839,24 +832,6 @@ struct pd_set_state_response {
     uint32_t composite_state;
 };
 
-/*! Parameters of the get state response event */
-struct pd_get_state_response {
-    /*! Status of the get state request event processing */
-    int status;
-
-    /*! Copy of the "composite" request parameter */
-    bool composite;
-
-    /*!
-     * \brief Copy of the "state" request parameter
-     *
-     * \details The power state of the power domain target of the request or
-     *      the composite state of the power domain and its ancestors depending
-     *      on the value of the "composite" request parameter.
-     */
-    uint32_t state;
-};
-
 /*!
  * \brief Public Events identifiers.
  */
@@ -866,10 +841,6 @@ static const fwk_id_t mod_pd_public_event_id_set_state =
     FWK_ID_EVENT_INIT(FWK_MODULE_IDX_POWER_DOMAIN,
                       MOD_PD_PUBLIC_EVENT_IDX_SET_STATE);
 
-/*! Identifier of the public event get_state identifier */
-static const fwk_id_t mod_pd_public_event_id_get_state =
-    FWK_ID_EVENT_INIT(FWK_MODULE_IDX_POWER_DOMAIN,
-                      MOD_PD_PUBLIC_EVENT_IDX_GET_STATE);
 #endif
 
 /*!


### PR DESCRIPTION
This patch reduces the overhead of queuing events for retrieving
the power state of a domain. It also removes a call to the
deprecated function fwk_thread_put_event_and_wait().

Signed-off-by: Tarek El-Sherbiny <tarek.el-sherbiny@arm.com>
Change-Id: Id336ce6ccf1023f37970ae562faa5a4ccedb4642