### PR TITLE
morello: move MHU mailbox to AP non-trusted RAM for FVP

### DIFF
--- a/product/morello/scp_ramfw_fvp/config_armv7m_mpu.c
+++ b/product/morello/scp_ramfw_fvp/config_armv7m_mpu.c
@@ -82,8 +82,8 @@ static const ARM_MPU_Region_t regions[] = {
             ARM_MPU_REGION_SIZE_256B),
     },
     {
-        /* 0x6520_0000 - 0x6520_FFFF */
-        .RBAR = ARM_MPU_RBAR(5, SCP_AP_SHARED_NONSECURE_RAM),
+        /* 0xA600_0000 - 0xA600_FFFF */
+        .RBAR = ARM_MPU_RBAR(5, SCP_AP_BASE_NS_MAILBOX_SRAM),
         .RASR = ARM_MPU_RASR(
             1,
             ARM_MPU_AP_PRIV,

--- a/product/morello/scp_ramfw_fvp/config_smt.c
+++ b/product/morello/scp_ramfw_fvp/config_smt.c
@@ -21,58 +21,53 @@
 
 #include <stdint.h>
 
-static const struct fwk_element smt_element_table[] = {
-    [SCP_MORELLO_SCMI_SERVICE_IDX_PSCI] =
-        {
+static const struct fwk_element
+    smt_element_table[SCP_MORELLO_SCMI_SERVICE_IDX_COUNT + 1] = {
+        [SCP_MORELLO_SCMI_SERVICE_IDX_PSCI] = {
             .name = "PSCI",
-            .data =
-                &(struct mod_smt_channel_config){
-                    .type = MOD_SMT_CHANNEL_TYPE_SLAVE,
-                    .policies =
-                        MOD_SMT_POLICY_INIT_MAILBOX | MOD_SMT_POLICY_SECURE,
-                    .mailbox_address = SCP_AP_SHARED_SECURE_RAM,
-                    .mailbox_size = SCP_SCMI_PAYLOAD_SIZE,
-                    .driver_id = FWK_ID_SUB_ELEMENT_INIT(
-                        FWK_MODULE_IDX_MHU,
-                        MORELLO_MHU_DEVICE_IDX_S_CLUS0,
-                        0),
-                    .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_MHU, 0),
-                },
+            .data = &(struct mod_smt_channel_config){
+                .type = MOD_SMT_CHANNEL_TYPE_SLAVE,
+                .policies =
+                    MOD_SMT_POLICY_INIT_MAILBOX | MOD_SMT_POLICY_SECURE,
+                .mailbox_address = SCP_AP_SHARED_SECURE_RAM,
+                .mailbox_size = SCP_SCMI_PAYLOAD_SIZE,
+                .driver_id = FWK_ID_SUB_ELEMENT_INIT(
+                    FWK_MODULE_IDX_MHU,
+                    MORELLO_MHU_DEVICE_IDX_S_CLUS0,
+                    0),
+                .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_MHU, 0),
+            },
         },
-    [SCP_MORELLO_SCMI_SERVICE_IDX_OSPM] =
-        {
+        [SCP_MORELLO_SCMI_SERVICE_IDX_OSPM] = {
             .name = "OSPM",
-            .data =
-                &(struct mod_smt_channel_config){
-                    .type = MOD_SMT_CHANNEL_TYPE_SLAVE,
-                    .policies = MOD_SMT_POLICY_INIT_MAILBOX,
-                    .mailbox_address = SCP_AP_SHARED_NONSECURE_RAM,
-                    .mailbox_size = SCP_SCMI_PAYLOAD_SIZE,
-                    .driver_id = FWK_ID_SUB_ELEMENT_INIT(
-                        FWK_MODULE_IDX_MHU,
-                        MORELLO_MHU_DEVICE_IDX_NS_CLUS0,
-                        0),
-                    .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_MHU, 0),
-                },
+            .data = &(struct mod_smt_channel_config){
+                .type = MOD_SMT_CHANNEL_TYPE_SLAVE,
+                .policies = MOD_SMT_POLICY_INIT_MAILBOX,
+                .mailbox_address = SCP_AP_BASE_NS_MAILBOX_SRAM,
+                .mailbox_size = SCP_SCMI_PAYLOAD_SIZE,
+                .driver_id = FWK_ID_SUB_ELEMENT_INIT(
+                    FWK_MODULE_IDX_MHU,
+                    MORELLO_MHU_DEVICE_IDX_NS_CLUS0,
+                    0),
+                .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_MHU, 0),
+            },
         },
-    [SCP_MORELLO_SCMI_SERVICE_IDX_MCP] =
-        {
+        [SCP_MORELLO_SCMI_SERVICE_IDX_MCP] = {
             .name = "MCP",
-            .data =
-                &(struct mod_smt_channel_config){
-                    .type = MOD_SMT_CHANNEL_TYPE_SLAVE,
-                    .policies =
-                        MOD_SMT_POLICY_INIT_MAILBOX | MOD_SMT_POLICY_SECURE,
-                    .mailbox_address = SCP_MCP_SHARED_SECURE_RAM,
-                    .mailbox_size = SCP_SCMI_PAYLOAD_SIZE,
-                    .driver_id = FWK_ID_SUB_ELEMENT_INIT(
-                        FWK_MODULE_IDX_MHU,
-                        MORELLO_MHU_DEVICE_IDX_S_MCP,
-                        0),
-                    .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_MHU, 0),
-                },
+            .data = &(struct mod_smt_channel_config){
+                .type = MOD_SMT_CHANNEL_TYPE_SLAVE,
+                .policies =
+                    MOD_SMT_POLICY_INIT_MAILBOX | MOD_SMT_POLICY_SECURE,
+                .mailbox_address = SCP_MCP_SHARED_SECURE_RAM,
+                .mailbox_size = SCP_SCMI_PAYLOAD_SIZE,
+                .driver_id = FWK_ID_SUB_ELEMENT_INIT(
+                    FWK_MODULE_IDX_MHU,
+                    MORELLO_MHU_DEVICE_IDX_S_MCP,
+                    0),
+                .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_MHU, 0),
+            },
         },
-    [SCP_MORELLO_SCMI_SERVICE_IDX_COUNT] = { 0 },
+        [SCP_MORELLO_SCMI_SERVICE_IDX_COUNT] = { 0 },
 };
 
 static const struct fwk_element *smt_get_element_table(fwk_id_t module_id)


### PR DESCRIPTION
As per https://github.com/ARM-software/SCP-firmware/commit/9488bc401bb4e9289264368b7bb3ba702da276be#
the AP-SCP MHU mailbox memory region was moved from
SRAM to AP Non-trusted RAM for “scp_ramfw_soc” due
to the issue with unaligned accesses with MHU SRAM.

This patch is to align the same mailbox memory region
change for “scp_ramfw_fvp”.

Signed-off-by: Himanshu Sharma <Himanshu.Sharma@arm.com>
Change-Id: I8b63afc919ad83f77a47a629961659d4586aca01