### PR TITLE
system_power: accept the product does not support soc_wakeup_irq

### DIFF
--- a/module/system_power/src/mod_system_power.c
+++ b/module/system_power/src/mod_system_power.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -178,11 +178,13 @@ static int shutdown_system_power_ppus(
 
 static int disable_all_irqs(void)
 {
-    int status;
+    int status = FWK_SUCCESS;
 
-    status = fwk_interrupt_disable(system_power_ctx.config->soc_wakeup_irq);
-    if (status != FWK_SUCCESS) {
-        return FWK_E_DEVICE;
+    if (system_power_ctx.config->soc_wakeup_irq != FWK_INTERRUPT_NONE) {
+        status = fwk_interrupt_disable(system_power_ctx.config->soc_wakeup_irq);
+        if (status != FWK_SUCCESS) {
+            return FWK_E_DEVICE;
+        }
     }
 
     if (system_power_ctx.driver_api->platform_interrupts != NULL) {


### PR DESCRIPTION
The product does not support or intend to use soc_wakeup_irq specifies
FWK_INTERRUPT_NONE to mod_system_power_config.soc_wakeup_irq field.
This commit checks that soc_wakeup_irq is valid before calling
fwk_interrupt_disable(). Without this change, system shutdown
fails because disable_all_irqs() returns FWK_E_DEVICE.

Signed-off-by: Masahisa Kojima <masahisa.kojima@linaro.org>
Change-Id: I8b318649eec5da98093880360c3dd27f02205902