### PR TITLE
Code-rules/Check-copyright: Minor fixes - Jan 22

### DIFF
--- a/doc/code_rules.md
+++ b/doc/code_rules.md
@@ -52,8 +52,9 @@ checks can be found [here](../tools/cppcheck_suppress_list.txt).
 
 ## Static analysis using `cmake`
 
-When this project is build using `cmake`, `cppcheck` is performed automatically for the current build using the list of suppressed checks
-mentioned in the previous section.
+When this project is built using `cmake`, `cppcheck` is performed automatically
+for the current build using the list of suppressed checks mentioned in the
+previous section.
 `cppcheck` can be run standalone with the current build configuration using
 the following commands:
 

--- a/tools/check_copyright.py
+++ b/tools/check_copyright.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2015-2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -147,7 +147,7 @@ def main():
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
     except subprocess.CalledProcessError as e:
-        print("ERROR " + e.returncode + ": Failed to get last changed files - ")
+        print("ERROR " + e.returncode + ": Failed to get last changed files")
         return 1
 
     for line in result.stdout:


### PR DESCRIPTION
Minor fixes for:
- indentation on code rules
- max line length in check_copyright script