### PR TITLE
fix/ci: limit parallize build

### DIFF
--- a/tools/product.py
+++ b/tools/product.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -52,7 +52,6 @@ class Build:
             cmd += Build.__extra_arg__(extra)
         for extra in self.build_type.arguments:
             cmd += Build.__extra_arg__(extra)
-        cmd += ' -j$(nproc) '
         return cmd
 
     @classmethod


### PR DESCRIPTION
This patch limits parallize build features in order to
reduce memory footprint and CPU resources needed to run
this test. It also reduces the number of simultaneous
builds performed. It only builds one product at a time.

Piped stdout stream is removed and stderr stream is
directly printed instead of being piped, this reduces
the memory footprint.

Signed-off-by: Leandro Belli <leandro.belli@arm.com>
Change-Id: I2b0d8b0dc0021b3f554a45f700307b719f212bb0