### PR TITLE
cmn700: fix encoding_bits for mesh size x or y > 8

### DIFF
--- a/module/cmn700/src/cmn700.c
+++ b/module/cmn700/src/cmn700.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -363,7 +363,7 @@ void set_encoding_and_masking_bits(const struct mod_cmn700_config *config)
      * Determine the number of bits used to represent each node coordinate based
      * on the mesh size as per CMN700 specification.
      */
-    if ((mesh_size_x > 8) && (mesh_size_y > 8)) {
+    if ((mesh_size_x > 8) || (mesh_size_y > 8)) {
         encoding_bits = 4;
     } else {
         encoding_bits = ((mesh_size_x > 4) || (mesh_size_y > 4)) ? 3 : 2;


### PR DESCRIPTION
If either the X or Y mesh size values of a CMN-700 mesh is greater than
eight, then the Node ID should be represented using a 11-bit format
with X and Y sizes encoded using 4-bits. So fix the check that
determines X and Y bit encoding size.

Signed-off-by: Tony K Nadackal <tony.nadackal@arm.com>
Change-Id: I76f8fb51953005c6b28aacd91e3ad40c728710b7