### PR TITLE
Performance Plugins Handler & Thermal Management

### DIFF
--- a/framework/src/fwk_string.c
+++ b/framework/src/fwk_string.c
@@ -17,6 +17,10 @@ void fwk_str_memset(void *dest, int ch, size_t count)
 {
     void *ret;
 
+    if (dest == NULL) {
+        fwk_trap();
+    }
+
     ret = memset(dest, ch, count);
     if (ret != dest) {
         fwk_trap();
@@ -27,6 +31,10 @@ void fwk_str_memcpy(void *dest, const void *src, size_t count)
 {
     void *ret;
 
+    if ((dest == NULL) || (src == NULL)) {
+        fwk_trap();
+    }
+
     ret = memcpy(dest, src, count);
     if (ret != dest) {
         fwk_trap();
@@ -36,6 +44,10 @@ void fwk_str_memcpy(void *dest, const void *src, size_t count)
 void fwk_str_strncpy(char *dest, const char *src, size_t count)
 {
     char *ch;
+
+    if ((dest == NULL) || (src == NULL)) {
+        fwk_trap();
+    }
 
     ch = strncpy(dest, src, count);
     if (ch != dest) {

--- a/framework/src/fwk_string.c
+++ b/framework/src/fwk_string.c
@@ -1,11 +1,11 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Description:
- *     Memory management.
+ *     String management.
  */
 
 #include <fwk_assert.h>

--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -70,9 +70,9 @@ list(APPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/scmi_reset_domain")
 list(APPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/mock_clock")
 list(APPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/voltage_domain")
 list(APPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/mock_voltage_domain")
-list(APPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/mpmm")
 list(APPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/traffic_cop")
-
+list(APPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/mpmm")
+list(APPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/thermal_mgmt")
 
 foreach(source_dir IN LISTS SCP_MODULE_PATHS)
     unset(SCP_MODULE)

--- a/module/scmi_perf/doc/perf_plugins_handler.md
+++ b/module/scmi_perf/doc/perf_plugins_handler.md
@@ -168,7 +168,6 @@ SCP_ENABLE_PLUGIN_HANDLER_INIT (CMake).
 implemented (and enabled).
 - This entire mechanism for adding/removing plugins is not supported with the
 traditional SCMI SMT/doorbell transport.
-- Only one performance plugin is supported, for now.
 
 ## Configuration Example 1 (plugin with physical/DVFS domains view)
 
@@ -255,3 +254,31 @@ Note that a plugin in this case can choose either logical or physical view.
 
 This example is for cases when only the logical domains aggregation policy is
 required.
+
+## Configuration Example 4 (2 plugins with physical domain view)
+
+    static const struct mod_scmi_perf_domain_config domains[] = {
+        [DVFS_DOMAIN_0] = {
+            .fast_channels_addr_scp = (uint64_t[]) { ... },
+            .fast_channels_addr_ap = (uint64_t[]) { ... },
+        },
+    };
+
+    static const struct mod_scmi_plugin_config plugins_table[] = {
+        [0] = {
+            .id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_<PLUGIN>),
+            .dom_type = PERF_PLUGIN_DOM_TYPE_PHYSICAL,
+        },
+        [1] = {
+            .id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_<PLUGIN>),
+            .dom_type = PERF_PLUGIN_DOM_TYPE_PHYSICAL,
+        },
+    };
+
+    struct fwk_module_config config_scmi_perf = {
+        .data = &((struct mod_scmi_perf_config){
+            ...
+            .plugins = plugins_table,
+            .plugins_count = FWK_ARRAY_SIZE(plugins_table)
+        }),
+    };

--- a/module/scmi_perf/include/mod_scmi_perf.h
+++ b/module/scmi_perf/include/mod_scmi_perf.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -431,6 +431,28 @@ struct perf_plugins_api {
      *
      * \details This function is called periodically to inform the plugin with
      *      the latest performance requests coming from SCMI.
+     *
+     * \details This callback serves the following purposes:
+     *      - periodic tick: the plugins is called at determined time intervals
+     *      that can be specified in the configuration and corresponds to the
+     *      periodicity of the FastChannels sampling.
+     *      - last performance level: the plugin has visibility of the last
+     *      updated performance level that is taken from the FastChannels.
+     *      - last performance limits: the plugin has visibility of the last
+     *      updated performance limits that are taken from the FastChannels.
+     *      - adjusted performance limits: the plugin has the opportunity to
+     *      affect the final performance limits by writing a performance limit
+     *      back to the SCMI Performance.
+     *      All the above are put together along with an identifier of the
+     *      performance domain being controlled.
+     *
+     *      A typical scenario for a plugin would be that upon every callback,
+     *      the plugin runs its own algorithm which can take advantage of the
+     *      periodicity. In this algorithm the plugin can - if required - read
+     *      the current performance level and limits for the given domain and,
+     *      when necessary, can apply (write) new limits in the `adjusted`
+     *      fields. This is expected to be done for each of the relevant
+     *      performance domains that the plugin is concerned.
      *
      * \param data Performance data
      * \retval ::FWK_SUCCESS or one of FWK_E_* error codes.

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -242,6 +242,27 @@ static const fwk_id_t scmi_perf_get_level =
  * SCMI PERF Helpers
  */
 
+/* This identifier is either:
+ * - the element type version of the one built by the perf-plugins-handler
+ *      (sub-element type)
+ * - or the DVFS domain
+ */
+static inline fwk_id_t get_dvfs_dependency_id(unsigned int el_idx)
+{
+#ifdef BUILD_HAS_SCMI_PERF_PLUGIN_HANDLER
+    fwk_id_t id;
+
+    id = perf_plugins_get_dependency_id(el_idx);
+    return fwk_id_build_element_id(id, el_idx);
+#else
+    return FWK_ID_ELEMENT(FWK_MODULE_IDX_DVFS, el_idx);
+#endif
+}
+
+/* This identifier is either:
+ * - exactly the one built by the perf-plugins-handler (sub-element type)
+ * - or the DVFS domain
+ */
 static inline fwk_id_t get_dependency_id(unsigned int el_idx)
 {
 #ifdef BUILD_HAS_SCMI_PERF_PLUGIN_HANDLER
@@ -654,7 +675,7 @@ static int scmi_perf_domain_attributes_handler(fwk_id_t service_id,
     }
 #endif
 
-    domain_id = get_dependency_id(parameters->domain_id);
+    domain_id = get_dvfs_dependency_id(parameters->domain_id);
     status = scmi_perf_ctx.dvfs_api->get_sustained_opp(domain_id, &opp);
     if (status != FWK_SUCCESS) {
         goto exit;

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -1836,7 +1836,7 @@ static int scmi_perf_process_bind_request(fwk_id_t source_id,
 
     case MOD_SCMI_PERF_PLUGINS_API:
 #ifdef BUILD_HAS_SCMI_PERF_PLUGIN_HANDLER
-        return perf_plugins_handler_bind_request(
+        return perf_plugins_handler_process_bind_request(
             source_id, target_id, api_id, api);
 #else
         return FWK_E_ACCESS;

--- a/module/scmi_perf/src/perf_plugins_handler.c
+++ b/module/scmi_perf/src/perf_plugins_handler.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -506,7 +506,7 @@ int perf_plugins_handler_bind(void)
         &perf_plugins_ctx.plugins_api);
 }
 
-int perf_plugins_handler_bind_request(
+int perf_plugins_handler_process_bind_request(
     fwk_id_t source_id,
     fwk_id_t target_id,
     fwk_id_t api_id,

--- a/module/scmi_perf/src/perf_plugins_handler.h
+++ b/module/scmi_perf/src/perf_plugins_handler.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -24,7 +24,7 @@
 
 int perf_plugins_handler_bind(void);
 
-int perf_plugins_handler_bind_request(
+int perf_plugins_handler_process_bind_request(
     fwk_id_t source_id,
     fwk_id_t target_id,
     fwk_id_t api_id,
@@ -32,15 +32,31 @@ int perf_plugins_handler_bind_request(
 
 /*!
  * \brief FastChannel Performance Update data container
+ *
+ * \note This data structure is passed between the plugins handler and the SCMI
+ *      performance module. It contains:
+ *      - limits that SCMI-Perf provides to the plugins handler for its logic.
+ *      - adjusted limits that the plugins handler returns to SCMI-Perf ready
+ *          for the DVFS module.
+ *      These values come from the FastChannels and the plugins handler executes
+ *      its logic in order to aggregate them before they can be forwarded to the
+ *      DVFS module.
  */
 struct fc_perf_update {
+    /*! DVFS domain identifier */
     fwk_id_t domain_id;
 
+    /*! Performance level */
     uint32_t level;
 
+    /*! Performance limit max to the plugins handler */
     uint32_t max_limit;
+    /*! Performance limit min to the plugins handler */
     uint32_t min_limit;
+
+    /*! Adjusted (by the plugins hanlder) performance limit max */
     uint32_t adj_max_limit;
+    /*! Adjusted (by the plugins hanlder) performance limit min */
     uint32_t adj_min_limit;
 };
 

--- a/module/scmi_perf/src/perf_plugins_handler.h
+++ b/module/scmi_perf/src/perf_plugins_handler.h
@@ -60,7 +60,52 @@ struct fc_perf_update {
     uint32_t adj_min_limit;
 };
 
-void perf_plugins_handler_update(struct fc_perf_update *freq_update);
+/*!
+ * \brief FastChannel mirror
+ *
+ * \details Fastchannels addresses in memory are not necessarily contiguous,
+ *      thus copy them into a temporary area for easy handling. Also for the
+ *      purpose of managing performance requests, get_ are not required.
+ */
+struct fast_channels_mirror {
+    uint32_t level;
+    struct mod_scmi_perf_fast_channel_limit limits;
+};
+
+/*!
+ * \brief Performance Plugins Handler Update
+ *
+ * \details Call the update logic for the Plugins Handler. This logic will take
+ *      care of the aggregation of values for all the domains and all the
+ *      plugins.
+ *
+ * \param perf_dom_idx Performance domain index
+ * \param fc_update FastChannel data. The Plugins Handler expects to receive the
+ *      latest FastChannels values for the above particular performance domain
+ *      and runst its internal logic of storing and aggregating. This is an
+ *      input to the Plugins Handler.
+ */
+void perf_plugins_handler_update(
+    unsigned int perf_dom_idx,
+    struct fc_perf_update *fc_update);
+
+/*!
+ * \brief Performance Plugins Handler Get
+ *
+ * \details Get the performance update for a performance domain. For a given
+ *      domain, the final aggregated values are provided in the fc_perf_update
+ *      container. It is meant to be called after all the updates have run.
+ *
+ * \param perf_dom_idx Performance domain index
+ * \param fc_update FastChannel data. The Plugins Handler expects to receive
+ *      the latest FastChannels values for the above particular performance
+ *      domain and runst its internal logic of storing and aggregating. This is
+ *      an input and an output to/from the Plugins Handler.
+ */
+void perf_plugins_handler_get(
+    unsigned int perf_dom_idx,
+    struct fc_perf_update *fc_update);
+
 void perf_plugins_handler_report(struct perf_plugins_perf_report *data);
 
 fwk_id_t perf_plugins_get_dependency_id(unsigned int dom_idx);

--- a/module/thermal_mgmt/CMakeLists.txt
+++ b/module/thermal_mgmt/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_thermal_mgmt.c")
+
+target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-dvfs
+                                                   module-scmi-perf
+                                                   module-sensor)

--- a/module/thermal_mgmt/Module.cmake
+++ b/module/thermal_mgmt/Module.cmake
@@ -1,0 +1,9 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "thermal-mgmt")
+set(SCP_MODULE_TARGET "module-thermal-mgmt")

--- a/module/thermal_mgmt/doc/thermal_mgmt.md
+++ b/module/thermal_mgmt/doc/thermal_mgmt.md
@@ -1,0 +1,258 @@
+\ingroup GroupModules Modules
+\defgroup GroupThermal Thermal Management
+
+# Thermal Management Architecture
+
+Copyright (c) 2022, Arm Limited. All rights reserved.
+
+
+## Overview
+
+Thermal Management is a basic closed-loop temperature controller which
+dynamically controls the platform performance in a thermal envelope.
+
+With a closed control loop and by intelligently dividing the power among actors,
+Thermal Management can efficiently distribute the power within the thermal
+constraints.
+
+The power delivered to each actor (CPU, GPU, etc) is controlled by adjusting the
+frequency and the voltage provided to such actors (performance limits).
+Each actor can be assigned with its own power model, which defines the equations
+for converting power into performance levels and vice-versa.
+
+By allocating the correct performance level, this is reflected to the correct
+power consumed and thus the temperature is maintained at the desired level.
+
+
+## Architecture
+
+The main two blocks composing Thermal Mgmt are the PI (Proportional and
+Integral) control loop and the power divider.
+
+                               Thermal Design
+    current temp                Power (TDP)      weight (config)
+         |                           |             |   |
+         |                           |             |   |
+         |                           |             |   |
+         v                           v             v   v
+       +-+-+     +---------+       +-+-+        +--+---+--+
+       |   +---->+ PI Ctrl +------>+   +------->+  power  +----> power granted
+       +-+-+     +---------+       +---+   +--->+ divider +---->
+         ^                                 |    +--+---+--+
+         |                                 |       ^   ^
+         |    performance request ---------+       |   |
+         |                                   +-----+   +-----+
+    control temp                             |               |
+                                             v               v
+                                         +---+---+       +---+---+
+                                         | power |       | power |
+                                         | model |       | model |
+                                         +-------+       +-------+
+
+
+The control loop reacts to temperature deviations from the control settings and
+provides a (proportional and integral) signal which is then converted into
+allocatable power offset.
+This available power is then distributed across the actors by a basic weighted
+bias mechanism. Each actor will get a fraction of the available power
+proportionally to the bias.
+
+Thermal Management runs internally on two loops: fast loop and slow loop.
+The fast loop is required to provide a fast adjustment of the performance
+requests, while the slow loop is meant to update the PI control (which in turns
+provides an updated allocatable power). The temperature is
+sampled at slow loop cadence.
+
+Thermal Management is taking advantage of the plugin-handler extension to get a
+synchronous tick with the performance requests coming from SCMI. This way the
+fast loop is directly sync'ed with the performance chain to adjust the
+performance limits. This tick imposes the fast loop periodicity.
+The slow loop is derived internally from the fast loop cadence by a configurable
+multiplication factor. This will allow custom tuning of the PI control timings.
+
+An additional module plays an important role in the entire algorithm for
+translating the power to performance and vice-versa. It is required that each
+actor has got their own power model which will be implemented as an additional
+platform-specific module to achieve best modularity and flexibility.
+
+The interface for the power model is defined by Thermal Management
+(mod_thermal_power_model_api).
+
+
+## Algorithm
+
+At each regular tick (fast loop), the Thermal Management will:
+- convert the requested performance level into power
+- attempt to distribute the power across actors based on their request and
+  weights. Any spare power is collected or any shortages kept track of.
+- re-distribute any available spare power across actors based on their shortage
+- convert the granted power into requested performance level
+- apply a performance limit on the actor's corresponding domain if the power
+  requested could not be met
+
+The above conversions power<->performance are performed within the
+platform-specific power model module.
+
+With a slower periodicity (slow loop), the Thermal Management will:
+- initiate a temperature reading
+- run the PI control and update the total available power
+
+
+## Use
+
+To use the Thermal Management the following dependencies are required:
+- performance plugin handler enabled (BS_FIRMWARE_HAS_PERF_PLUGIN_HANDLER)
+- Power Model in product/<product-name>/module/product_power_model
+
+
+## Limitations
+
+There is a single loop for reading the temperature and evaluating the PI
+control, therefore only one temperature sensor can be monitored and only one PI
+control can run.
+Currently the implementation is in "prototype" stage and limited tests have been
+carried out.
+
+
+## Tunings & Settings
+
+### Global PI control tunings
+
+`slow_loop_mult`
+Multiplier applied to the the base tick via the ->update callback.
+For example: if the tick period is 5ms, then a value of 20 will give the PI
+control a refresh rate at 100ms (= 5 * 20).
+
+`tdp (thermal design power)`
+The thermal design power for all the actors monitored. This can be an abstract
+value as long as the power model can work with it.
+
+`switch_on_temperature`
+The temperature above which the Thermal Mgmt algorithm will run. The unit needs
+to be consistent with the value provided by the targeted temperature sensor.
+
+`control_temperature`
+The control temperature for the platform. Above this temperature the Thermal
+Mgmt will limit the power/performance.
+
+`integral_cutoff`
+The error threshold below which the errors are accumulated. This may be useful
+to avoid accumulating errors when the error is positive i.e the temperature is
+below the control.
+
+`integral_max`
+The maximum value of accumulated errors. This may be useful to limit the
+positive accumulation of error which, in turn, will affect the overshooting
+operation.
+
+`k_p_undershoot`
+The proportional coefficient used when the error is positive (actual temperature
+below control temperature)
+
+`k_p_overshoot`
+The proportional coefficient used when the error is negative (actual temperature
+above control temperature)
+
+`k_integral`
+The integral coefficient used when multiplying with the accumulated error.
+
+
+### Per-actor tunings
+
+`weight`
+The coefficient used as an allocation factor for a specific actor. Its value can
+be "any" and expresses the corresponding weight an actor has over the others.
+
+
+## Power models
+
+The power model is a platform-specific module that needs to be implemented by
+each platform in order to perform power-to-performance level conversions and
+vice-versa.
+This allows separation from Thermal Management common-code to platform-specific
+characteristics.
+When implementing the APIs, the Power Model module should also allow incoming
+bind requests from Thermal Mgmt.
+
+
+## Configuration Example (2 actors)
+
+```C
+static const struct fwk_element thermal_mgmt_element_table[] = {
+    [0] = {
+        .name = "ACTOR-0",
+        .data = &((const struct mod_thermal_mgmt_dev_config) {
+            .power_model_id =
+                FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_PLAT_POWER_MODEL, 0),
+            .driver_id =
+                FWK_ID_API_INIT(FWK_MODULE_IDX_PLAT_POWER_MODEL, 0),
+            .dvfs_domain_id =
+                FWK_ID_ELEMENT_INIT(
+                    FWK_MODULE_IDX_DVFS, DVFS_ELEMENT_IDX_ACTOR0),
+            .weight = 100,
+        }),
+    },
+    [1] = {
+        .name = "ACTOR-1",
+        .data = &((const struct mod_thermal_mgmt_dev_config) {
+            .power_model_id =
+                FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_PLAT_POWER_MODEL, 1),
+            .driver_id =
+                FWK_ID_API_INIT(FWK_MODULE_IDX_PLAT_POWER_MODEL, 0),
+            .dvfs_domain_id =
+                FWK_ID_ELEMENT_INIT(
+                    FWK_MODULE_IDX_DVFS, DVFS_ELEMENT_IDX_ACTOR1),
+            .weight = 200,
+        }),
+    },
+    [2] = { 0 }, /* Termination description */
+};
+
+static const struct fwk_element *get_thermal_mgmt_element_table(
+    fwk_id_t module_id)
+{
+    return thermal_mgmt_element_table;
+}
+
+struct fwk_module_config config_thermal_mgmt = {
+    .data = &((struct mod_thermal_mgmt_config){
+        .slow_loop_mult = 20,
+
+        .tdp = 5000,
+        .switch_on_temperature = 60,
+        .control_temperature = 75,
+        .integral_cutoff = 5,
+        .integral_max = 20,
+
+        .k_p_undershoot = 1,
+        .k_p_overshoot = 1,
+        .k_integral = 1,
+
+        .sensor_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_SENSOR, 0),
+    }),
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_thermal_mgmt_element_table),
+};
+```
+
+And the power model should implement the following API:
+
+```C
+
+uint32_t plat_level_to_power(fwk_id_t domain_id, const uint32_t level)
+{
+    /* compute the power for this actor/domain at this level */
+    return power;
+}
+
+uint32_t plat_power_to_level(fwk_id_t domain_id, const uint32_t power)
+{
+    /* compute the performance level for this actor/domain for this power */
+    return perf_level;
+}
+
+struct mod_thermal_mgmt_power_model_api power_model_api = {
+    .level_to_power = plat_level_to_power,
+    .power_to_level = plat_power_to_level,
+};
+
+```

--- a/module/thermal_mgmt/doc/thermal_mgmt.md
+++ b/module/thermal_mgmt/doc/thermal_mgmt.md
@@ -85,7 +85,10 @@ At each regular tick (fast loop), the Thermal Management will:
 - convert the requested performance level into power
 - attempt to distribute the power across actors based on their request and
   weights. Any spare power is collected or any shortages kept track of.
+- any carry-over power not consumed in the previous cycle is added onto the
+  available spare power
 - re-distribute any available spare power across actors based on their shortage
+- any spare power left becomes the carry-over power for the next cycle
 - convert the granted power into requested performance level
 - apply a performance limit on the actor's corresponding domain if the power
   requested could not be met

--- a/module/thermal_mgmt/include/mod_thermal_mgmt.h
+++ b/module/thermal_mgmt/include/mod_thermal_mgmt.h
@@ -1,0 +1,168 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef MOD_THERMAL_MGMT_H
+#define MOD_THERMAL_MGMT_H
+
+#include <fwk_element.h>
+#include <fwk_id.h>
+#include <fwk_module_idx.h>
+
+#include <stdint.h>
+
+/*!
+ * \ingroup GroupModules
+ * \defgroup GroupThermal Thermal Management
+ *
+ * \details Module for controlling/limiting the Performance of a platform based
+ *      on thermal input.
+ *
+ * \{
+ */
+
+/*!
+ * \brief Number of defined APIs for Thermal Management Module.
+ */
+enum mod_thermal_api_idx {
+    /*!
+     * \brief Performance Update API index.
+     *
+     * \note This API implements the ::perf_plugins_api interface.
+     */
+    MOD_THERMAL_API_PERF_UPDATE_IDX,
+
+    MOD_THERMAL_API_COUNT,
+};
+
+/*!
+ * \brief Thermal Mgmt device configuration.
+ *
+ * \details Configuration structure for individual thermal devices.
+ *      Please refer to the doc section for further details.
+ */
+struct mod_thermal_mgmt_dev_config {
+    /*! Element identifier of the corresponding power model */
+    fwk_id_t driver_id;
+
+    /*! Power Model API identifier */
+    fwk_id_t driver_api_id;
+
+    /*! Corresponding DVFS Element identifier for this device */
+    fwk_id_t dvfs_domain_id;
+
+    /*!
+     * \brief Weight coefficient for power distribution.
+     *
+     * \details Its value can be any. It expresses the relative weight to other
+     *      devices.
+     */
+    uint16_t weight;
+};
+
+/*!
+ * \brief Thermal Mgmt configuration.
+ *
+ * \details Configuration structure for the whole thermal management.
+ *      Please refer to the doc section for further details.
+ */
+struct mod_thermal_mgmt_config {
+    /*!
+     * \brief Slow loop multiplier.
+     *
+     * \details The slow loop time interval is derived as follow:
+     *      slow_loop_period = slow_loop_mult * perf_update_period.
+     */
+    unsigned int slow_loop_mult;
+
+    /*! The thermal design power (TDP) for all the devices being controlled */
+    uint16_t tdp;
+
+    /*!
+     * \brief Switch-on temperature threshold.
+     *
+     * \details The temperature above which the PI loop runs. Below this
+     *      threshold the power is allocated only on bias coefficients.
+     */
+    uint32_t switch_on_temperature;
+
+    /*!
+     * \brief Control temperature
+     *
+     * \details The temperature that the system will achive once stabilised.
+     *      Due to the PI nature of the controller, some overshoot/undershoot
+     *      may occur.
+     *      Note that the controller can only limit the temperature by placing a
+     *      limit to the power to the heat source. It has no direct control on
+     *      the heat source itself and therefore only the upper limit can be
+     *      controlled.
+     */
+    uint32_t control_temperature;
+
+    /*!
+     * \brief Integral cut-off threshold.
+     *
+     * \details Below this value the errors are accumulated. This is useful to
+     *      avoid accumulating errors when the temperature is below the target.
+     */
+    int32_t integral_cutoff;
+
+    /*!
+     * \brief Integral maximum.
+     *
+     * \details This is the upper limit the accumulated errors.
+     */
+    int32_t integral_max;
+
+    /*! Proportional term when undershooting (PI loop)*/
+    int32_t k_p_undershoot;
+
+    /*! Proportional term when overhooting (PI loop) */
+    int32_t k_p_overshoot;
+
+    /*! Integral term (PI loop) */
+    int32_t k_integral;
+
+    /*! Temperature sensor identifier */
+    fwk_id_t sensor_id;
+};
+
+/*!
+ * \brief Power Model API.
+ *
+ * \ details This API must be implemented by the platform.
+ */
+struct mod_thermal_mgmt_driver_api {
+    /*!
+     * \brief Performance Level to Power conversion.
+     *
+     * \details Convert a performance level into its corresponding power usage.
+     *
+     * \param domain_id Specific power model device id.
+     * \param level Performance level
+     *
+     * \retval power The corresponding power for a given performance level.
+     */
+    uint32_t (*level_to_power)(fwk_id_t domain_id, const uint32_t level);
+
+    /*!
+     * \brief Power to Performance Level conversion.
+     *
+     * \details Convert a power usage into its corresponding performance level.
+     *
+     * \param domain_id Specific power model device id.
+     * \param power Power
+     *
+     * \retval level The corresponding performance level for a given power.
+     */
+    uint32_t (*power_to_level)(fwk_id_t domain_id, const uint32_t power);
+};
+
+/*!
+ * \}
+ */
+
+#endif /* MOD_THERMAL_MGMT_H */

--- a/module/thermal_mgmt/src/Makefile
+++ b/module/thermal_mgmt/src/Makefile
@@ -1,0 +1,11 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BS_LIB_NAME := Thermal Management
+BS_LIB_SOURCES := mod_thermal_mgmt.c
+
+include $(BS_DIR)/lib.mk

--- a/module/thermal_mgmt/src/mod_thermal_mgmt.c
+++ b/module/thermal_mgmt/src/mod_thermal_mgmt.c
@@ -1,0 +1,594 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *  Thermal Management.
+ *  This module implements a basic power allocator based on the temperature.
+ *  It is meant to work as a performance plugin.
+ */
+
+#include <mod_scmi_perf.h>
+#include <mod_sensor.h>
+#include <mod_thermal_mgmt.h>
+
+#include <fwk_event.h>
+#include <fwk_id.h>
+#include <fwk_log.h>
+#include <fwk_mm.h>
+#include <fwk_module.h>
+#include <fwk_status.h>
+#include <fwk_thread.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#define THERMAL_HAS_ASYNC_SENSORS 1
+
+enum mod_thermal_mgmt_event_idx {
+    MOD_THERMAL_EVENT_IDX_READ_TEMP,
+
+    MOD_THERMAL_EVENT_IDX_COUNT,
+};
+
+struct mod_thermal_mgmt_dev_ctx {
+    /* Thermal device configuration */
+    struct mod_thermal_mgmt_dev_config *config;
+
+    /* Driver API */
+    struct mod_thermal_mgmt_driver_api *driver_api;
+
+    /* When the power allocated for this actor is less than what it requested */
+    uint32_t power_deficit;
+
+    /* What the demand power is for this actor */
+    uint32_t demand_power;
+
+    /* The power granted to an actor */
+    uint32_t granted_power;
+
+    /* The excess of power (initially) granted vs the demand power */
+    uint32_t spare_power;
+};
+
+struct mod_thermal_mgmt_ctx {
+    /* Tick counter for the slow loop */
+    unsigned int tick_counter;
+
+    /* Thermal module configuration */
+    struct mod_thermal_mgmt_config *config;
+
+    /* Current temperature */
+    uint32_t cur_temp;
+
+    /* Does the PI loop need update */
+    bool pi_control_needs_update;
+
+    /* Sensor API */
+    const struct mod_sensor_api *sensor_api;
+
+    /* The total power that can be re-distributed */
+    uint32_t tot_spare_power;
+
+    /* The total power that actors could still take */
+    uint32_t tot_power_deficit;
+
+    /*
+     * The power as: SUM(weight_actor * demand_power_actor)
+     * Use to distribute power according to actors' weight.
+     */
+    uint32_t tot_weighted_demand_power;
+
+    /* Total power budget */
+    uint32_t allocatable_power;
+
+    /* Integral (accumulated) error */
+    int32_t integral_error;
+
+    /* Number of DVFS domains */
+    unsigned int dvfs_doms_count;
+
+    /* Number of Thermal domains */
+    unsigned int domain_count;
+
+    /* Table of thermal actors */
+    struct mod_thermal_mgmt_dev_ctx *dev_ctx_table;
+};
+
+#if THERMAL_HAS_ASYNC_SENSORS
+static const fwk_id_t mod_thermal_event_id_read_temp = FWK_ID_EVENT_INIT(
+    FWK_MODULE_IDX_THERMAL_MGMT,
+    MOD_THERMAL_EVENT_IDX_READ_TEMP);
+#endif
+
+static struct mod_thermal_mgmt_ctx mod_ctx;
+
+/*
+ * Forward declarations.
+ */
+static void get_actor_power(
+    struct mod_thermal_mgmt_dev_ctx *dev_ctx,
+    uint32_t req_level);
+
+static void pi_control(void)
+{
+    int32_t err, terr, pi_power;
+    int32_t k_p, k_i;
+
+    if (mod_ctx.cur_temp < mod_ctx.config->switch_on_temperature) {
+        /* The PI loop is not activated */
+        mod_ctx.integral_error = 0;
+        mod_ctx.allocatable_power = (uint32_t)mod_ctx.config->tdp;
+
+        return;
+    }
+
+    k_i = mod_ctx.config->k_integral;
+
+    err = (int32_t)mod_ctx.config->control_temperature -
+        (int32_t)mod_ctx.cur_temp;
+
+    k_p = (err < 0) ? mod_ctx.config->k_p_overshoot :
+                      mod_ctx.config->k_p_undershoot;
+
+    /* Evaluate the integral term */
+    if (((err > 0) && (mod_ctx.integral_error < (INT32_MAX - err))) ||
+        ((err < 0) && (mod_ctx.integral_error > (INT32_MIN - err)))) {
+        terr = mod_ctx.integral_error + err;
+
+        if ((err < mod_ctx.config->integral_cutoff) &&
+            (terr < mod_ctx.config->integral_max)) {
+            /*
+             * The error is below the cutoff value and,
+             * the accumulated error is still within the maximum permissible
+             * value, thus continue integration.
+             */
+            mod_ctx.integral_error = terr;
+        }
+    }
+
+    pi_power = (k_p * err) + (k_i * mod_ctx.integral_error);
+
+    if (pi_power + (int32_t)mod_ctx.config->tdp > 0) {
+        mod_ctx.allocatable_power = pi_power + (uint32_t)mod_ctx.config->tdp;
+    } else {
+        mod_ctx.allocatable_power = 0;
+    }
+}
+
+static inline struct mod_thermal_mgmt_dev_ctx *get_dev_ctx(unsigned int dom)
+{
+    return &mod_ctx.dev_ctx_table[dom];
+}
+
+static struct mod_thermal_mgmt_dev_ctx *get_thermal_dev_ctx(
+    unsigned int dvfs_dom_idx)
+{
+    unsigned int domain_idx;
+    fwk_id_t dvfs_id =
+        fwk_id_build_element_id(fwk_module_id_dvfs, dvfs_dom_idx);
+
+    /* Attempt to find the thermal domain relevant to the given dvfs domain */
+    for (domain_idx = 0; domain_idx < mod_ctx.domain_count; domain_idx++) {
+        if (fwk_id_is_equal(
+                mod_ctx.dev_ctx_table[domain_idx].config->dvfs_domain_id,
+                dvfs_id)) {
+            break;
+        }
+    }
+
+    if (domain_idx == mod_ctx.domain_count) {
+        /* There is no thermal domain corresponding to any DVFS domain */
+        return NULL;
+    }
+
+    return get_dev_ctx(domain_idx);
+}
+/*
+ * Perform the first round of power distribution.
+ * An actor gets at most the power requested. Some actors may get less than
+ * their demand power.
+ */
+static void allocate_power(struct mod_thermal_mgmt_dev_ctx *dev_ctx)
+{
+    dev_ctx->granted_power =
+        ((dev_ctx->config->weight * dev_ctx->demand_power) *
+         mod_ctx.allocatable_power) /
+        mod_ctx.tot_weighted_demand_power;
+
+    if (dev_ctx->granted_power > dev_ctx->demand_power) {
+        dev_ctx->spare_power = dev_ctx->granted_power - dev_ctx->demand_power;
+        dev_ctx->power_deficit = 0;
+
+        dev_ctx->granted_power = dev_ctx->demand_power;
+    } else {
+        dev_ctx->spare_power = 0;
+        dev_ctx->power_deficit = dev_ctx->demand_power - dev_ctx->granted_power;
+    }
+
+    mod_ctx.tot_spare_power += dev_ctx->spare_power;
+    mod_ctx.tot_power_deficit += dev_ctx->power_deficit;
+}
+
+/*
+ * Perform the second round of power distribution.
+ * If an actor has received less than its demand power and there's a reserve of
+ * power not allocated, it may get a fraction of that.
+ */
+static void re_allocate_power(struct mod_thermal_mgmt_dev_ctx *dev_ctx)
+{
+    if (mod_ctx.tot_spare_power == 0) {
+        return;
+    }
+
+    if (dev_ctx->power_deficit > 0) {
+        /*
+         * The actor has been given less than requested, and it may still take
+         * some power
+         */
+        dev_ctx->granted_power +=
+            (dev_ctx->power_deficit * mod_ctx.tot_spare_power) /
+            mod_ctx.tot_power_deficit;
+    }
+}
+
+static void get_actor_power(
+    struct mod_thermal_mgmt_dev_ctx *dev_ctx,
+    uint32_t req_level)
+{
+    struct mod_thermal_mgmt_driver_api *driver;
+    fwk_id_t driver_id;
+
+    driver = dev_ctx->driver_api;
+    driver_id = dev_ctx->config->driver_id;
+
+    dev_ctx->demand_power = driver->level_to_power(driver_id, req_level);
+}
+
+static void get_actor_level(
+    struct mod_thermal_mgmt_dev_ctx *dev_ctx,
+    uint32_t *level)
+{
+    struct mod_thermal_mgmt_driver_api *driver;
+    fwk_id_t driver_id;
+
+    driver = dev_ctx->driver_api;
+    driver_id = dev_ctx->config->driver_id;
+
+    *level = driver->power_to_level(driver_id, dev_ctx->granted_power);
+}
+
+static void distribute_power(uint32_t *perf_request, uint32_t *perf_limit)
+{
+    struct mod_thermal_mgmt_dev_ctx *dev_ctx;
+    unsigned int dvfs_doms_count, dom;
+    uint32_t new_perf_limit, dev_perf_request;
+
+    dvfs_doms_count = mod_ctx.dvfs_doms_count;
+
+    mod_ctx.tot_weighted_demand_power = 0;
+    mod_ctx.tot_spare_power = 0;
+    mod_ctx.tot_power_deficit = 0;
+
+    /*
+     * STEP 0:
+     * Initialise the actors' demand power.
+     */
+    for (dom = 0; dom < dvfs_doms_count; dom++) {
+        dev_ctx = get_thermal_dev_ctx(dom);
+        if (dev_ctx == NULL) {
+            continue;
+        }
+
+        /* Here we take into account limits already placed by other plugins */
+        if (perf_request[dom] > perf_limit[dom]) {
+            dev_perf_request = perf_limit[dom];
+        } else {
+            dev_perf_request = perf_request[dom];
+        }
+
+        get_actor_power(dev_ctx, dev_perf_request);
+
+        mod_ctx.tot_weighted_demand_power +=
+            dev_ctx->config->weight * dev_ctx->demand_power;
+    }
+
+    /*
+     * STEP 1:
+     * The power available is allocated in proportion to the actors' weight and
+     * their power demand.
+     */
+    for (dom = 0; dom < dvfs_doms_count; dom++) {
+        dev_ctx = get_thermal_dev_ctx(dom);
+        if (dev_ctx == NULL) {
+            continue;
+        }
+
+        allocate_power(dev_ctx);
+    }
+
+    /*
+     * STEP 2:
+     * A further allocation based on actors' power deficit, if any spare power
+     * left.
+     * Finally, get the corresponding performance level and place a new limit.
+     */
+    for (dom = 0; dom < dvfs_doms_count; dom++) {
+        dev_ctx = get_thermal_dev_ctx(dom);
+        if (dev_ctx == NULL) {
+            continue;
+        }
+
+        re_allocate_power(dev_ctx);
+
+        get_actor_level(dev_ctx, &new_perf_limit);
+
+        /*
+         * If we have been granted the power we requested (which is at most the
+         * limit already placed by other plugins), then there's no need to limit
+         * further.
+         */
+        if (new_perf_limit < perf_limit[dom]) {
+            perf_limit[dom] = new_perf_limit;
+        }
+    }
+}
+
+static int read_temperature(void)
+{
+#if THERMAL_HAS_ASYNC_SENSORS
+    /* Initiate the temperature reading sequence */
+    struct fwk_event event = {
+        .source_id = FWK_ID_MODULE(FWK_MODULE_IDX_THERMAL_MGMT),
+        .target_id = FWK_ID_MODULE(FWK_MODULE_IDX_THERMAL_MGMT),
+        .id = mod_thermal_event_id_read_temp,
+    };
+
+    return fwk_thread_put_event(&event);
+#else
+    int status;
+    uint64_t value;
+
+    status = mod_ctx.sensor_api->get_value(mod_ctx.config->sensor_id, &value);
+    if (status == FWK_SUCCESS) {
+        mod_ctx.cur_temp = (uint32_t)value;
+
+        mod_ctx.pi_control_needs_update = true;
+    }
+
+    return status;
+#endif
+}
+
+static int pi_control_update(void)
+{
+    int status;
+
+    mod_ctx.tick_counter++;
+    if (mod_ctx.tick_counter > mod_ctx.config->slow_loop_mult) {
+        mod_ctx.tick_counter = 0;
+
+        if (mod_ctx.pi_control_needs_update) {
+            /* The last reading was not processed */
+            FWK_LOG_WARN("[TPM] Failed to process last reading\n");
+
+            return FWK_E_PANIC;
+        }
+
+        /*
+         * ASYNC: The new temperature is not yet available but should be ready
+         * by next fast-loop tick.
+         * SYNC: The new temperature is ready.
+         *
+         * Either way we need to attempt to continue to process the loop.
+         */
+        status = read_temperature();
+        if (status != FWK_SUCCESS) {
+            return FWK_E_DEVICE;
+        }
+    }
+
+    if (mod_ctx.pi_control_needs_update) {
+        mod_ctx.pi_control_needs_update = false;
+
+        pi_control();
+    }
+
+    return FWK_SUCCESS;
+}
+
+/*
+ * Thermal Management should be configured in such a way that this callback
+ * is called once every performance update via the plugins handler and the data
+ * contains all the performance domains info (see _TYPE_FULL view).
+ */
+static int thermal_update(struct perf_plugins_perf_update *data)
+{
+    int status;
+
+    status = pi_control_update();
+    if (status != FWK_SUCCESS) {
+        return status;
+    }
+
+    distribute_power(data->level, data->adj_max_limit);
+
+    return FWK_SUCCESS;
+}
+
+struct perf_plugins_api perf_plugins_api = {
+    .update = thermal_update,
+};
+
+/*
+ * Framework handler functions.
+ */
+
+static int thermal_mgmt_init(
+    fwk_id_t module_id,
+    unsigned int element_count,
+    const void *data)
+{
+    int dvfs_doms_count;
+
+    mod_ctx.config = (struct mod_thermal_mgmt_config *)data;
+
+    /* Assume TDP until PI loop is updated */
+    mod_ctx.allocatable_power = (uint32_t)mod_ctx.config->tdp;
+
+    dvfs_doms_count =
+        fwk_module_get_element_count(FWK_ID_MODULE(FWK_MODULE_IDX_DVFS));
+    if (dvfs_doms_count <= 0) {
+        return FWK_E_SUPPORT;
+    }
+
+    mod_ctx.dvfs_doms_count = (unsigned int)dvfs_doms_count;
+
+    mod_ctx.dev_ctx_table =
+        fwk_mm_calloc(element_count, sizeof(*mod_ctx.dev_ctx_table));
+
+    mod_ctx.domain_count = element_count;
+
+    return FWK_SUCCESS;
+}
+
+static int thermal_mgmt_dev_init(
+    fwk_id_t element_id,
+    unsigned int sub_element_count,
+    const void *data)
+{
+    struct mod_thermal_mgmt_dev_config *config;
+    struct mod_thermal_mgmt_dev_ctx *dev_ctx;
+    uint64_t sum_weights;
+
+    if (data == NULL) {
+        return FWK_E_PARAM;
+    }
+
+    config = (struct mod_thermal_mgmt_dev_config *)data;
+
+    if (!fwk_module_is_valid_element_id(config->dvfs_domain_id)) {
+        return FWK_E_PARAM;
+    }
+
+    dev_ctx = get_dev_ctx(fwk_id_get_element_idx(element_id));
+
+    if (!fwk_id_type_is_valid(config->driver_id) ||
+        fwk_id_is_equal(config->driver_id, FWK_ID_NONE)) {
+        return FWK_E_PARAM;
+    }
+
+    dev_ctx->config = config;
+
+    sum_weights =
+        dev_ctx->config->weight * mod_ctx.config->tdp * mod_ctx.config->tdp;
+    if (sum_weights > UINT32_MAX) {
+        FWK_LOG_WARN(
+            "[THERMAL] WARN: Possible overflow for device %u",
+            fwk_id_get_element_idx(element_id));
+    }
+
+    return FWK_SUCCESS;
+}
+
+static int thermal_mgmt_bind(fwk_id_t id, unsigned int round)
+{
+    int status;
+    struct mod_thermal_mgmt_dev_ctx *dev_ctx;
+
+    if (round > 0) {
+        return FWK_SUCCESS;
+    }
+
+    if (fwk_id_is_type(id, FWK_ID_TYPE_MODULE)) {
+        /* Bind to sensor */
+        status = fwk_module_bind(
+            mod_ctx.config->sensor_id,
+            mod_sensor_api_id_sensor,
+            &mod_ctx.sensor_api);
+        if (status != FWK_SUCCESS) {
+            return FWK_E_PANIC;
+        }
+
+        return FWK_SUCCESS;
+    }
+
+    dev_ctx = get_dev_ctx(fwk_id_get_element_idx(id));
+
+    /* Bind to a respective thermal driver */
+    status = fwk_module_bind(
+        dev_ctx->config->driver_id,
+        dev_ctx->config->driver_api_id,
+        &dev_ctx->driver_api);
+    if (status != FWK_SUCCESS) {
+        return FWK_E_PANIC;
+    }
+
+    return FWK_SUCCESS;
+}
+
+static int thermal_mgmt_process_bind_request(
+    fwk_id_t source_id,
+    fwk_id_t target_id,
+    fwk_id_t api_id,
+    const void **api)
+{
+    *api = &perf_plugins_api;
+
+    return FWK_SUCCESS;
+}
+
+#if THERMAL_HAS_ASYNC_SENSORS
+static int thermal_mgmt_process_event(
+    const struct fwk_event *event,
+    struct fwk_event *resp_event)
+{
+    struct mod_sensor_event_params *params;
+    uint64_t value;
+    int status;
+
+    if (fwk_id_is_equal(event->id, mod_thermal_event_id_read_temp)) {
+        /* Temperature-reading event */
+        status =
+            mod_ctx.sensor_api->get_value(mod_ctx.config->sensor_id, &value);
+        if (status == FWK_SUCCESS) {
+            mod_ctx.cur_temp = (uint32_t)value;
+        }
+    } else if (fwk_id_is_equal(event->id, mod_sensor_event_id_read_request)) {
+        /* Response event from Sensor HAL */
+        params = (struct mod_sensor_event_params *)event->params;
+
+        if (params->status == FWK_SUCCESS) {
+            mod_ctx.cur_temp = (uint32_t)params->value;
+            status = FWK_SUCCESS;
+        } else {
+            status = FWK_E_DEVICE;
+        }
+    } else {
+        status = FWK_E_PARAM;
+    }
+
+    if (status == FWK_SUCCESS) {
+        mod_ctx.pi_control_needs_update = true;
+    } else if (status == FWK_PENDING) {
+        status = FWK_SUCCESS;
+    }
+
+    return status;
+}
+#endif
+
+const struct fwk_module module_thermal_mgmt = {
+    .type = FWK_MODULE_TYPE_SERVICE,
+    .api_count = (unsigned int)MOD_THERMAL_API_COUNT,
+    .event_count = (unsigned int)MOD_THERMAL_EVENT_IDX_COUNT,
+    .init = thermal_mgmt_init,
+    .element_init = thermal_mgmt_dev_init,
+    .bind = thermal_mgmt_bind,
+    .process_bind_request = thermal_mgmt_process_bind_request,
+#if THERMAL_HAS_ASYNC_SENSORS
+    .process_event = thermal_mgmt_process_event,
+#endif
+};

--- a/product/tc0/doc/variants.md
+++ b/product/tc0/doc/variants.md
@@ -1,0 +1,71 @@
+# TC0 Platform Variants
+
+Copyright (c) 2022, Arm Limited. All rights reserved.
+
+
+## Overview
+
+Documentation for TC0 platform can be found at [1].
+
+For the purpose of experimenting some of the software features that have been
+introduced in SCP-firmware a new variant of TC0 has been created.
+The variant(s) can be chosen at build time by adding:
+
+```sh
+
+make -f Makefile.cmake \
+    PRODUCT=tc0 \
+    MODE=<debug,release> \
+    EXTRA_CONFIG_ARGS+=-DSCP_PLATFORM_VARIANT=<0,1>
+
+```
+
+
+### Variant 0 (Standard build)
+
+The standard build provides all the features described in [1].
+For this default variant, it's not required to provide any extra parameters in
+the build commands.
+
+
+### Variant 1 (Power/Performance testing)
+
+This variant adds support for the following software features:
+- Traffic Cop
+- MPMM (Maximum Power Mitigation Mechanism)
+- Thermal Management
+and to have the above fully working, the following dependencies are also added:
+- Sensor support
+- SCMI Performance FastChannels
+- Performance Plugins Handler
+
+Since all the above work on power and performance, to ease evaluating the
+features, and to show the configurability options, we split the features among
+some of the DVFS domains.
+
+Once built, the features above will act as:
+
++-----------------+-------------------+
+| DVFS domain     | Controlled by (*) |
++-----------------+-------------------+
+| KLEIN           | TRAFFIC COP       |
+|                 | THERMAL MGMT      |
++-----------------+-------------------+
+| MATTERHORN      | TRAFFIC COP       |
+|                 | THERMAL MGMT      |
++-----------------+-------------------+
+| MATTERHORN ELP  | MPMM              |
+|                 | THERMAL MGMT      |
++-----------------+-------------------+
+
+(*) This is in addition to the standard SCMI Performance interface commands.
+
+
+## Limitations
+
+- The "variant" option is available only with the CMake build.
+- The Thermal functionality is limited at this time cause the constant
+  temperature being sampled.
+
+References:
+[1] https://developer.arm.com/tools-and-software/open-source-software/arm-platforms-software/total-compute-solution

--- a/product/tc0/module/tc0_power_model/CMakeLists.txt
+++ b/product/tc0/module/tc0_power_model/CMakeLists.txt
@@ -1,0 +1,16 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+add_library(${SCP_MODULE_TARGET} SCP_MODULE)
+
+target_include_directories(${SCP_MODULE_TARGET}
+                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+target_sources(${SCP_MODULE_TARGET}
+               PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_tc0_power_model.c")
+
+target_link_libraries(${SCP_MODULE_TARGET}
+    PRIVATE module-thermal-mgmt module-scmi-perf)

--- a/product/tc0/module/tc0_power_model/Module.cmake
+++ b/product/tc0/module/tc0_power_model/Module.cmake
@@ -1,0 +1,10 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(SCP_MODULE "tc0-power-model")
+
+set(SCP_MODULE_TARGET "module-tc0-power-model")

--- a/product/tc0/module/tc0_power_model/include/mod_tc0_power_model.h
+++ b/product/tc0/module/tc0_power_model/include/mod_tc0_power_model.h
@@ -1,0 +1,59 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     TC0 Power Model (Thermal Management Driver)
+ */
+
+#ifndef MOD_TC0_POWER_MODEL_H
+#define MOD_TC0_POWER_MODEL_H
+
+//#include <mod_power_domain.h>
+
+/*!
+ * \addtogroup GroupTC0Module TC0 Product Modules
+ * \{
+ */
+
+/*!
+ * \defgroup GroupTC0PowerModel TC0 Power Model
+ * \{
+ */
+
+/*!
+ * \brief TC0 Power Model element configuration
+ */
+struct mod_tc0_power_model_dev_config {
+    /*!
+     * \brief Coefficient to compute the power from level and viceversa.
+     *
+     * \details This is an oversimplified example of element configuration. For
+     *      the purpose of code reference, we assume that power and level are
+     *      tied each other by a simple coefficient.
+     */
+    unsigned int coeff;
+};
+
+/*!
+ * \brief Number of defined APIs for Power Model.
+ */
+enum mod_tc0_power_model_api_idx {
+    /*! API index for the driver interface of the Thermal Management module */
+    MOD_TC0_POWER_MODEL_THERMAL_DRIVER_API_IDX,
+
+    /*! Number of exposed interfaces */
+    MOD_TC0_POWER_MODEL_API_COUNT,
+};
+
+/*!
+ * \}
+ */
+
+/*!
+ * \}
+ */
+
+#endif /* MOD_TC0_POWER_MODEL_H */

--- a/product/tc0/module/tc0_power_model/src/Makefile
+++ b/product/tc0/module/tc0_power_model/src/Makefile
@@ -1,0 +1,11 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BS_LIB_NAME := TC0 POWER MODEL
+BS_LIB_SOURCES = mod_tc0_power_model.c
+
+include $(BS_DIR)/lib.mk

--- a/product/tc0/module/tc0_power_model/src/mod_tc0_power_model.c
+++ b/product/tc0/module/tc0_power_model/src/mod_tc0_power_model.c
@@ -1,0 +1,92 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     TC0 Power Model.
+ */
+
+#include <mod_tc0_power_model.h>
+#include <mod_thermal_mgmt.h>
+
+#include <fwk_id.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+
+#include <stdint.h>
+
+uint32_t tc0_pm_level_to_power(fwk_id_t pm_id, const uint32_t level)
+{
+    const struct mod_tc0_power_model_dev_config *config;
+
+    config = fwk_module_get_data(pm_id);
+    return (config->coeff * level);
+}
+
+uint32_t tc0_pm_power_to_level(fwk_id_t pm_id, const uint32_t power)
+{
+    const struct mod_tc0_power_model_dev_config *config;
+
+    config = fwk_module_get_data(pm_id);
+    return (power / config->coeff);
+}
+
+static const struct mod_thermal_mgmt_driver_api tc0_thermal_mgmt_driver_api = {
+    .level_to_power = tc0_pm_level_to_power,
+    .power_to_level = tc0_pm_power_to_level,
+};
+
+/*
+ * Framework handlers.
+ */
+
+static int tc0_power_model_mod_init(
+    fwk_id_t module_id,
+    unsigned int unused,
+    const void *data)
+{
+    return FWK_SUCCESS;
+}
+
+static int tc0_power_model_elem_init(
+    fwk_id_t element_id,
+    unsigned int sub_element_count,
+    const void *data)
+{
+    return FWK_SUCCESS;
+}
+
+static int tc0_power_model_bind(fwk_id_t id, unsigned int round)
+{
+    return FWK_SUCCESS;
+}
+
+static int tc0_power_model_process_bind_request(
+    fwk_id_t requester_id,
+    fwk_id_t pd_id,
+    fwk_id_t api_id,
+    const void **api)
+{
+    fwk_id_t power_model_api_id = FWK_ID_API(
+        FWK_MODULE_IDX_TC0_POWER_MODEL,
+        MOD_TC0_POWER_MODEL_THERMAL_DRIVER_API_IDX);
+
+    if (fwk_id_is_equal(api_id, power_model_api_id)) {
+        *api = &tc0_thermal_mgmt_driver_api;
+
+        return FWK_SUCCESS;
+    }
+
+    return FWK_E_ACCESS;
+}
+
+const struct fwk_module module_tc0_power_model = {
+    .type = FWK_MODULE_TYPE_DRIVER,
+    .api_count = 1,
+    .init = tc0_power_model_mod_init,
+    .element_init = tc0_power_model_elem_init,
+    .bind = tc0_power_model_bind,
+    .process_bind_request = tc0_power_model_process_bind_request,
+};

--- a/product/tc0/scp_ramfw/CMakeLists.txt
+++ b/product/tc0/scp_ramfw/CMakeLists.txt
@@ -43,6 +43,12 @@ if (SCP_PLATFORM_VARIANT STREQUAL "1")
     list(APPEND SCP_MODULES "mpmm")
     target_sources(tc0-bl2 PRIVATE "config_mpmm.c")
 
+    list(APPEND SCP_MODULES "sensor")
+    target_sources(tc0-bl2 PRIVATE "config_sensor.c")
+
+    list(APPEND SCP_MODULES "reg-sensor")
+    target_sources(tc0-bl2 PRIVATE "config_reg_sensor.c")
+
 else()
     message(NOTICE "SCP_PLATFORM_VARIANT set to STANDARD (tc0-bl2)\n")
 

--- a/product/tc0/scp_ramfw/CMakeLists.txt
+++ b/product/tc0/scp_ramfw/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -10,6 +10,43 @@
 #
 
 add_executable(tc0-bl2)
+
+
+# SCP_PLATFORM_VARIANT options:
+# - 'TC0_VARIANT_STD' for TC0 standard build
+# - 'TC0_VAR_EXPERIMENT_POWER' for TC0 with power/performance plugins used for
+#   evaluation purposes
+
+
+target_compile_definitions(tc0-bl2 PUBLIC -DTC0_VARIANT_STD=0)
+target_compile_definitions(tc0-bl2 PUBLIC -DTC0_VAR_EXPERIMENT_POWER=1)
+
+
+set(SCP_PLATFORM_VARIANT ${SCP_PLATFORM_VARIANT_INIT} CACHE STRING "1")
+
+
+if (SCP_PLATFORM_VARIANT STREQUAL "1")
+    message(NOTICE "SCP_PLATFORM_VARIANT set to EXPERIMENT_POWER (tc0-bl2)\n")
+
+    target_compile_definitions(tc0-bl2
+        PUBLIC -DPLATFORM_VARIANT=TC0_VAR_EXPERIMENT_POWER)
+
+    set(SCP_ENABLE_PLUGIN_HANDLER TRUE PARENT_SCOPE)
+    set(SCP_ENABLE_FAST_CHANNELS TRUE PARENT_SCOPE)
+
+# The order of the modules in the following list is appended on the list of
+# modules defined in Firmware.cmake.
+
+    list(APPEND SCP_MODULES "traffic-cop")
+    target_sources(tc0-bl2 PRIVATE "config_traffic_cop.c")
+
+else()
+    message(NOTICE "SCP_PLATFORM_VARIANT set to STANDARD (tc0-bl2)\n")
+
+    target_compile_definitions(tc0-bl2
+        PUBLIC -DPLATFORM_VARIANT=TC0_VARIANT_STD)
+endif()
+
 
 target_include_directories(
     tc0-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
@@ -48,6 +85,7 @@ target_sources(
 if(SCP_ENABLE_RESOURCE_PERMISSIONS)
     target_sources(tc0-bl2 PRIVATE "config_resource_perms.c")
 endif()
+
 
 #
 # Some of our firmware includes require CMSIS.

--- a/product/tc0/scp_ramfw/CMakeLists.txt
+++ b/product/tc0/scp_ramfw/CMakeLists.txt
@@ -49,6 +49,14 @@ if (SCP_PLATFORM_VARIANT STREQUAL "1")
     list(APPEND SCP_MODULES "reg-sensor")
     target_sources(tc0-bl2 PRIVATE "config_reg_sensor.c")
 
+    list(APPEND SCP_MODULES "thermal-mgmt")
+    target_sources(tc0-bl2 PRIVATE "config_thermal_mgmt.c")
+
+    list(APPEND SCP_MODULES "tc0-power-model")
+    list(PREPEND SCP_MODULE_PATHS
+        "${CMAKE_CURRENT_LIST_DIR}/../module/tc0_power_model")
+    target_sources(tc0-bl2 PRIVATE "config_tc0_power_model.c")
+
 else()
     message(NOTICE "SCP_PLATFORM_VARIANT set to STANDARD (tc0-bl2)\n")
 

--- a/product/tc0/scp_ramfw/CMakeLists.txt
+++ b/product/tc0/scp_ramfw/CMakeLists.txt
@@ -40,6 +40,9 @@ if (SCP_PLATFORM_VARIANT STREQUAL "1")
     list(APPEND SCP_MODULES "traffic-cop")
     target_sources(tc0-bl2 PRIVATE "config_traffic_cop.c")
 
+    list(APPEND SCP_MODULES "mpmm")
+    target_sources(tc0-bl2 PRIVATE "config_mpmm.c")
+
 else()
     message(NOTICE "SCP_PLATFORM_VARIANT set to STANDARD (tc0-bl2)\n")
 

--- a/product/tc0/scp_ramfw/Firmware.cmake
+++ b/product/tc0/scp_ramfw/Firmware.cmake
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -26,6 +26,8 @@ set(SCP_ENABLE_IPO_INIT FALSE)
 set(SCP_ENABLE_FAST_CHANNELS_INIT FALSE)
 
 set(SCP_ENABLE_PLUGIN_HANDLER_INIT FALSE)
+
+set(SCP_PLATFORM_VARIANT_INIT 0)
 
 set(SCP_ARCHITECTURE "armv7-m")
 

--- a/product/tc0/scp_ramfw/config_mpmm.c
+++ b/product/tc0/scp_ramfw/config_mpmm.c
@@ -27,6 +27,7 @@ enum core_pd_idx {
     CORE7_IDX
 };
 
+#if defined(PLATFORM_VARIANT) && (PLATFORM_VARIANT == TC0_VARIANT_STD)
 static struct mod_mpmm_pct_table k_pct[] = {
     { .cores_online = 4,
       .default_perf_limit = 1153 * 1000000UL,
@@ -114,6 +115,7 @@ static struct mod_mpmm_pct_table m_pct[] = {
                           },
                         } },
 };
+#endif
 
 static struct mod_mpmm_pct_table m_elp_pct[] = {
     { .cores_online = 1,
@@ -130,6 +132,7 @@ static struct mod_mpmm_pct_table m_elp_pct[] = {
                         } },
 };
 
+#if defined(PLATFORM_VARIANT) && (PLATFORM_VARIANT == TC0_VARIANT_STD)
 static const struct mod_mpmm_core_config k_core_config[] = {
     [0] = {
         .pd_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_POWER_DOMAIN, CORE0_IDX),
@@ -177,6 +180,7 @@ static const struct mod_mpmm_core_config m_core_config[] = {
         .core_starts_online = false,
         },
 };
+#endif
 
 static const struct mod_mpmm_core_config m_elp_core_config[] = {
     [0] = {
@@ -187,6 +191,7 @@ static const struct mod_mpmm_core_config m_elp_core_config[] = {
         },
 };
 
+#if defined(PLATFORM_VARIANT) && (PLATFORM_VARIANT == TC0_VARIANT_STD)
 static const struct mod_mpmm_domain_config k_domain_conf[] = {
     [0] = {
         .perf_id = FWK_ID_ELEMENT_INIT(
@@ -214,6 +219,7 @@ static const struct mod_mpmm_domain_config m_domain_conf[] = {
     },
     [1] = {0},
 };
+#endif
 
 static const struct mod_mpmm_domain_config m_elp_domain_conf[] = {
     [0] = {
@@ -230,6 +236,14 @@ static const struct mod_mpmm_domain_config m_elp_domain_conf[] = {
 };
 
 static const struct fwk_element element_table[] = {
+#if defined(PLATFORM_VARIANT) && (PLATFORM_VARIANT == TC0_VAR_EXPERIMENT_POWER)
+    [0] = {
+        .name = "MPMM_MATTERHORN_ELP_ARM_ELEM",
+        .sub_element_count = 1,
+        .data = m_elp_domain_conf,
+    },
+    [1] = { 0 },
+#else
     [0] = {
         .name = "MPMM_KLEIN_ELEM",
         .sub_element_count = 4,
@@ -246,6 +260,7 @@ static const struct fwk_element element_table[] = {
         .data = m_elp_domain_conf,
     },
     [3] = { 0 },
+#endif
 };
 
 static const struct fwk_element *mpmm_get_element_table(fwk_id_t module_id)

--- a/product/tc0/scp_ramfw/config_reg_sensor.c
+++ b/product/tc0/scp_ramfw/config_reg_sensor.c
@@ -1,0 +1,49 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <mod_reg_sensor.h>
+#include <mod_sensor.h>
+
+#include <fwk_element.h>
+#include <fwk_id.h>
+#include <fwk_module.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+static uint64_t fake_sensor_register = UINT64_C(0x0);
+
+/*
+ * Register Sensor driver config
+ */
+static struct mod_sensor_info info_fake_temperature = {
+    .type = MOD_SENSOR_TYPE_DEGREES_C,
+    .update_interval = 0,
+    .update_interval_multiplier = 0,
+    .unit_multiplier = 0,
+};
+
+static const struct fwk_element reg_sensor_element_table[] = {
+    [0] = {
+        .name = "TC0 Fake Temperature Sensor Register",
+        .data = &((struct mod_reg_sensor_dev_config) {
+            .reg = (uintptr_t)(&fake_sensor_register),
+            .info = &info_fake_temperature,
+        }),
+    },
+
+    [1] = { 0 }, /* Termination description */
+};
+
+static const struct fwk_element *get_reg_sensor_element_table(fwk_id_t id)
+{
+    return reg_sensor_element_table;
+}
+
+struct fwk_module_config config_reg_sensor = {
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_reg_sensor_element_table),
+};

--- a/product/tc0/scp_ramfw/config_scmi_perf.c
+++ b/product/tc0/scp_ramfw/config_scmi_perf.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -129,7 +129,7 @@ static const struct mod_scmi_perf_domain_config domains[] = {
     },
 };
 
-#ifdef BUILD_HAS_SCMI_PERF_PLUGIN_HANDLER
+#if defined(PLATFORM_VARIANT) && (PLATFORM_VARIANT == TC0_VAR_EXPERIMENT_POWER)
 static const struct mod_scmi_plugin_config plugins_table[] = {
     [0] = {
         .id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_TRAFFIC_COP),
@@ -138,19 +138,16 @@ static const struct mod_scmi_plugin_config plugins_table[] = {
 };
 #endif
 const struct fwk_module_config config_scmi_perf = {
-    .data = &((struct mod_scmi_perf_config){
-        .domains = &domains,
-        .perf_doms_count = FWK_ARRAY_SIZE(domains),
+    .data = &((struct mod_scmi_perf_config) {
+        .domains = &domains, .perf_doms_count = FWK_ARRAY_SIZE(domains),
 #ifdef BUILD_HAS_FAST_CHANNELS
         .fast_channels_alarm_id = FWK_ID_SUB_ELEMENT_INIT(
-            FWK_MODULE_IDX_TIMER,
-            0,
-            CONFIG_TIMER_FAST_CHANNEL_TIMER_IDX),
+            FWK_MODULE_IDX_TIMER, 0, CONFIG_TIMER_FAST_CHANNEL_TIMER_IDX),
         .fast_channels_rate_limit = (2 * 1000),
 #else
         .fast_channels_alarm_id = FWK_ID_NONE_INIT,
 #endif
-#ifdef BUILD_HAS_SCMI_PERF_PLUGIN_HANDLER
+#if defined(PLATFORM_VARIANT) && (PLATFORM_VARIANT == TC0_VAR_EXPERIMENT_POWER)
         .plugins = plugins_table,
         .plugins_count = FWK_ARRAY_SIZE(plugins_table),
 #endif

--- a/product/tc0/scp_ramfw/config_scmi_perf.c
+++ b/product/tc0/scp_ramfw/config_scmi_perf.c
@@ -135,6 +135,10 @@ static const struct mod_scmi_plugin_config plugins_table[] = {
         .id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_TRAFFIC_COP),
         .dom_type = PERF_PLUGIN_DOM_TYPE_PHYSICAL,
     },
+    [1] = {
+        .id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_MPMM),
+        .dom_type = PERF_PLUGIN_DOM_TYPE_PHYSICAL,
+    },
 };
 #endif
 const struct fwk_module_config config_scmi_perf = {

--- a/product/tc0/scp_ramfw/config_scmi_perf.c
+++ b/product/tc0/scp_ramfw/config_scmi_perf.c
@@ -139,8 +139,13 @@ static const struct mod_scmi_plugin_config plugins_table[] = {
         .id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_MPMM),
         .dom_type = PERF_PLUGIN_DOM_TYPE_PHYSICAL,
     },
+    [2] = {
+        .id = FWK_ID_MODULE_INIT(FWK_MODULE_IDX_THERMAL_MGMT),
+        .dom_type = PERF_PLUGIN_DOM_TYPE_FULL,
+    },
 };
 #endif
+
 const struct fwk_module_config config_scmi_perf = {
     .data = &((struct mod_scmi_perf_config) {
         .domains = &domains, .perf_doms_count = FWK_ARRAY_SIZE(domains),

--- a/product/tc0/scp_ramfw/config_sensor.c
+++ b/product/tc0/scp_ramfw/config_sensor.c
@@ -1,0 +1,44 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <mod_sensor.h>
+
+#include <fwk_assert.h>
+#include <fwk_element.h>
+#include <fwk_id.h>
+#include <fwk_macros.h>
+#include <fwk_mm.h>
+#include <fwk_module.h>
+#include <fwk_module_idx.h>
+#include <fwk_status.h>
+
+#include <string.h>
+
+/*
+ * When running on a model at least one fake sensor is required to in order to
+ * properly initialize the entire sensor support.
+ */
+static const struct fwk_element sensor_element_table_fvp[] = {
+    [0] = {
+        .name = "Fake sensor",
+        .data = &((struct mod_sensor_dev_config) {
+            .driver_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_REG_SENSOR, 0),
+            .driver_api_id = FWK_ID_API_INIT(FWK_MODULE_IDX_REG_SENSOR, 0),
+        }),
+    },
+
+    [1] = { 0 } /* Termination description */
+};
+
+static const struct fwk_element *get_sensor_element_table(fwk_id_t module_id)
+{
+    return sensor_element_table_fvp;
+}
+
+struct fwk_module_config config_sensor = {
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_sensor_element_table),
+};

--- a/product/tc0/scp_ramfw/config_tc0_power_model.c
+++ b/product/tc0/scp_ramfw/config_tc0_power_model.c
@@ -1,0 +1,42 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <mod_tc0_power_model.h>
+
+#include <fwk_module.h>
+
+static const struct fwk_element pm_elem_table[] = {
+    [0] = {
+        .name = "Power Model 0",
+        .data = &(struct mod_tc0_power_model_dev_config){
+            .coeff = 1,
+        },
+    },
+    [1] = {
+        .name = "Power Model 1",
+        .data = &(struct mod_tc0_power_model_dev_config){
+            .coeff = 1,
+        },
+    },
+    [2] = {
+        .name = "Power Model 2",
+        .data = &(struct mod_tc0_power_model_dev_config){
+            .coeff = 1,
+        },
+    },
+    [3] = { 0 } /* Termination description */
+};
+
+static const struct fwk_element *get_element_table(fwk_id_t module_id)
+{
+    return pm_elem_table;
+};
+
+const struct fwk_module_config config_tc0_power_model = {
+    .data = NULL,
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
+};

--- a/product/tc0/scp_ramfw/config_thermal_mgmt.c
+++ b/product/tc0/scp_ramfw/config_thermal_mgmt.c
@@ -1,0 +1,87 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <tc0_dvfs.h>
+
+#include <mod_tc0_power_model.h>
+#include <mod_thermal_mgmt.h>
+
+#include <fwk_element.h>
+#include <fwk_id.h>
+#include <fwk_module.h>
+
+#include <stddef.h>
+#include <stdint.h>
+
+static const struct fwk_element thermal_mgmt_elem_table[] = {
+    [0] = {
+        .name = "Thermal Actor 0",
+        .data = &((struct mod_thermal_mgmt_dev_config) {
+            .driver_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TC0_POWER_MODEL, 0),
+            .driver_api_id =
+                FWK_ID_API_INIT(
+                    FWK_MODULE_IDX_TC0_POWER_MODEL,
+                    MOD_TC0_POWER_MODEL_THERMAL_DRIVER_API_IDX),
+            .dvfs_domain_id =
+                FWK_ID_ELEMENT_INIT(
+                    FWK_MODULE_IDX_DVFS, DVFS_ELEMENT_IDX_KLEIN),
+            .weight = 100,
+        }),
+    },
+    [1] = {
+        .name = "Thermal Actor 1",
+        .data = &((struct mod_thermal_mgmt_dev_config) {
+            .driver_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TC0_POWER_MODEL, 1),
+            .driver_api_id =
+                FWK_ID_API_INIT(
+                    FWK_MODULE_IDX_TC0_POWER_MODEL,
+                    MOD_TC0_POWER_MODEL_THERMAL_DRIVER_API_IDX),
+            .dvfs_domain_id =
+                FWK_ID_ELEMENT_INIT(
+                    FWK_MODULE_IDX_DVFS, DVFS_ELEMENT_IDX_MATTERHORN),
+            .weight = 100,
+        }),
+    },
+    [2] = {
+        .name = "Thermal Actor 2",
+        .data = &((struct mod_thermal_mgmt_dev_config) {
+            .driver_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_TC0_POWER_MODEL, 2),
+            .driver_api_id =
+                FWK_ID_API_INIT(
+                    FWK_MODULE_IDX_TC0_POWER_MODEL,
+                    MOD_TC0_POWER_MODEL_THERMAL_DRIVER_API_IDX),
+            .dvfs_domain_id =
+                FWK_ID_ELEMENT_INIT(
+                    FWK_MODULE_IDX_DVFS, DVFS_ELEMENT_IDX_MATTERHORN_ELP_ARM),
+            .weight = 100,
+        }),
+    },
+
+    [3] = { 0 } /* Termination description */
+};
+
+static const struct fwk_element *get_element_table(fwk_id_t module_id)
+{
+    return thermal_mgmt_elem_table;
+}
+
+struct fwk_module_config config_thermal_mgmt = {
+    .data =
+        &(struct mod_thermal_mgmt_config){
+            .slow_loop_mult = 25,
+            .tdp = 10,
+            .switch_on_temperature = 50,
+            .control_temperature = 60,
+            .integral_cutoff = 0,
+            .integral_max = 100,
+            .k_p_undershoot = 1,
+            .k_p_overshoot = 1,
+            .k_integral = 1,
+            .sensor_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_SENSOR, 0),
+        },
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
+};

--- a/product/tc0/scp_romfw/CMakeLists.txt
+++ b/product/tc0/scp_romfw/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -46,3 +46,8 @@ target_link_libraries(tc0-bl1 PUBLIC cmsis::core-m)
 
 target_include_directories(tc0-bl1
     PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)
+
+cmake_dependent_option(
+    SCP_PLATFORM_VARIANT "Choose platform software variant?"
+    "${SCP_PLATFORM_VARIANT_INIT}" "DEFINED SCP_PLATFORM_VARIANT_INIT"
+    "${SCP_PLATFORM_VARIANT}")

--- a/product/tc0/scp_romfw/Firmware.cmake
+++ b/product/tc0/scp_romfw/Firmware.cmake
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -20,6 +20,8 @@ set(SCP_GENERATE_FLAT_BINARY_INIT TRUE)
 set(SCP_ENABLE_NOTIFICATIONS_INIT TRUE)
 
 set(SCP_ENABLE_IPO_INIT FALSE)
+
+set(SCP_PLATFORM_VARIANT_INIT 0)
 
 set(SCP_ARCHITECTURE "armv7-m")
 


### PR DESCRIPTION
This PR brings a number of improvements and additions that are related together.

In particular:
- some fixes/improvements for fwk_string
- scmi_perf module: Fix for the plugins-handler dependency identifier
- performance plugins handler: additions to handle more than one plugin and support for full domains snapshot
- thermal management: add thermal management module to distribute power/performance across DVFS domains according to the thermal status of the platform
- TC0 software variant: TC0 is chosen as a reference platform to test three power/performance features available in firmware: MPMM, Traffic-cop and Thermal management.