### PR TITLE
product/rdn2: add mapping for cmn700 address space

### DIFF
--- a/product/rdn2/scp_ramfw/config_cmn700.c
+++ b/product/rdn2/scp_ramfw/config_cmn700.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -330,6 +330,16 @@ static const struct mod_cmn700_mem_region_map mmap[] = {
         .node_id = NODE_ID_HNP3,
     },
 #endif
+    {
+        /*
+         * CMN700 GPV
+         * Map: 0x01_4000_0000 - 0x01_7FFF_FFFF (1 GB)
+         */
+        .base = UINT64_C(0x0140000000),
+        .size = UINT64_C(1) * FWK_GIB,
+        .type = MOD_CMN700_MEM_REGION_TYPE_IO,
+        .node_id = NODE_ID_HND,
+    },
     {
         /*
          * Non Secure NOR Flash 0/1


### PR DESCRIPTION
To allow access of the CMN700 register space from Request Nodes, add
CMN700 address space as a RNSAM non-hashed region to route the accesses
for CMN700 configuration registers to the correct destination node i.e
HN-D node instead of DRAM.

Signed-off-by: Aditya Angadi <aditya.angadi@arm.com>
Change-Id: I62986ce0dab12bd6f45c9ef1993bbb15c03b94c7