### PR TITLE
thermal_mgmt: Fix undefined error for fwk_thread_put_event

### DIFF
--- a/module/thermal_mgmt/src/mod_thermal_mgmt.c
+++ b/module/thermal_mgmt/src/mod_thermal_mgmt.c
@@ -14,13 +14,13 @@
 #include <mod_sensor.h>
 #include <mod_thermal_mgmt.h>
 
+#include <fwk_core.h>
 #include <fwk_event.h>
 #include <fwk_id.h>
 #include <fwk_log.h>
 #include <fwk_mm.h>
 #include <fwk_module.h>
 #include <fwk_status.h>
-#include <fwk_thread.h>
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -372,7 +372,7 @@ static int read_temperature(void)
         .id = mod_thermal_event_id_read_temp,
     };
 
-    return fwk_thread_put_event(&event);
+    return fwk_put_event(&event);
 #else
     int status;
     uint64_t value;


### PR DESCRIPTION
Recently fwk_thread_put_event function is been renamed to
fwk_put_event. However one instance of this is not updated
in mod_thermal_mgmt.c. This commit fixes this.

Change-Id: I81ce475b3e0b54abcaf8e7b1177733cb0e22b16f
Signed-off-by: Girish Pathak <girish.pathak@arm.com>