### PR TITLE
scmi/apcore: permit 32-bit alignment for 64-bit regwidth entrypoints

### DIFF
--- a/module/scmi_apcore/src/mod_scmi_apcore.c
+++ b/module/scmi_apcore/src/mod_scmi_apcore.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -239,13 +239,7 @@ static int scmi_apcore_reset_address_set_handler(fwk_id_t service_id,
     }
 
     /* Check for alignment */
-    if (scmi_apcore_ctx.config->reset_register_width ==
-        MOD_SCMI_APCORE_REG_WIDTH_32) {
-        if ((parameters->reset_address_low % 4) != 0) {
-            return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
-            goto exit;
-        }
-    } else if ((parameters->reset_address_low % 8) != 0) {
+    if ((parameters->reset_address_low % 4) != 0) {
         return_values.status = (int32_t)SCMI_INVALID_PARAMETERS;
         goto exit;
     }


### PR DESCRIPTION
From: Ard Biesheuvel <ardb@google.com>

AArch64 instructions are 32 bits wide, so the distinction between
AArch64 and AArch32 when deciding the minimum alignment of the
entrypoint address is not appropriate.

Signed-off-by: Ard Biesheuvel <ardb@google.com>
Signed-off-by: Masahisa Kojima <masahisa.kojima@linaro.org>
Change-Id: I31197b92ef0307f9ef0f971c23c7cf146032a66e