### PR TITLE
morello: Enforce strict ordering for mailbox memory

### DIFF
--- a/product/morello/scp_ramfw_fvp/config_armv7m_mpu.c
+++ b/product/morello/scp_ramfw_fvp/config_armv7m_mpu.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -88,9 +88,10 @@ static const ARM_MPU_Region_t regions[] = {
             1,
             ARM_MPU_AP_PRIV,
             0,
+            /* Shared memory, Strongly Ordered */
             1,
-            1,
-            1,
+            0,
+            0,
             0,
             ARM_MPU_REGION_SIZE_64KB),
     },

--- a/product/morello/scp_ramfw_soc/config_armv7m_mpu.c
+++ b/product/morello/scp_ramfw_soc/config_armv7m_mpu.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -86,9 +86,10 @@ static const ARM_MPU_Region_t regions[] = {
             1,
             ARM_MPU_AP_PRIV,
             0,
+            /* Shared memory, Strongly Ordered */
             1,
-            1,
-            1,
+            0,
+            0,
             0,
             ARM_MPU_REGION_SIZE_64KB),
     },


### PR DESCRIPTION
The mailbox memory is shared between the SCP and the
OSPM agent, and is used for SCMI communication between
the two. The underlying memory region, which the
mailbox memory is mapped to, is currently configured as
Normal Memory (weak ordering) via the SCP MPU attributes.

This has been traced down to be the origin of the occasional
mailbox channel ownership errors as seen in the SCP FW logs -
the root cause being that on some occasions, the firmware
ends up reading the stale value of the channel ownership status
bit (as opposed to the reading value updated by the SCMI agent
during the SCMI comms) because of the reordering/buffering at
the interconnect.

Configuring the memory region to Strongly Ordered enforces a
strict ordering and gets rid of the mailbox channel ownership
errors.

Signed-off-by: Anurag Koul <anurag.koul@arm.com>
Change-Id: I69b2f74e111dde1b7d1e0a22ba85f101366eb86d