### PR TITLE
Sensor SCMI V3 Changes

### DIFF
--- a/module/scmi_sensor/include/internal/scmi_sensor.h
+++ b/module/scmi_sensor/include/internal/scmi_sensor.h
@@ -79,13 +79,14 @@ struct scmi_sensor_protocol_reading_get_a2p {
     uint32_t sensor_id;
     uint32_t flags;
 };
-
+#ifdef BUILD_HAS_SCMI_SENSOR_V2
 struct scmi_sensor_protocol_reading_get_data {
-    uint32_t sensor_value_low;
-    uint32_t sensor_value_high;
+    int32_t sensor_value_low;
+    int32_t sensor_value_high;
     uint32_t timestamp_low;
     uint32_t timestamp_high;
 };
+#endif
 
 struct scmi_sensor_protocol_reading_get_p2a {
     int32_t status;

--- a/module/scmi_sensor/src/mod_scmi_sensor.c
+++ b/module/scmi_sensor/src/mod_scmi_sensor.c
@@ -198,16 +198,16 @@ static int scmi_sensor_reading_respond(
          ++axis_idx, payload_size += sizeof(axis_value)) {
         if (sensor_data->axis_count == 1) {
             axis_value = (struct scmi_sensor_protocol_reading_get_data){
-                .sensor_value_low = (uint32_t)sensor_data->value,
-                .sensor_value_high = (uint32_t)(sensor_data->value >> 32),
+                .sensor_value_low = (int32_t)sensor_data->value,
+                .sensor_value_high = (int32_t)(sensor_data->value >> 32),
                 .timestamp_low = (uint32_t)sensor_data->timestamp,
                 .timestamp_high = (uint32_t)(sensor_data->timestamp >> 32),
             };
         } else {
             axis_value = (struct scmi_sensor_protocol_reading_get_data){
-                .sensor_value_low = (uint32_t)sensor_data->axis_value[axis_idx],
+                .sensor_value_low = (int32_t)sensor_data->axis_value[axis_idx],
                 .sensor_value_high =
-                    (uint32_t)(sensor_data->axis_value[axis_idx] >> 32),
+                    (int32_t)(sensor_data->axis_value[axis_idx] >> 32),
                 .timestamp_low = (uint32_t)sensor_data->timestamp,
                 .timestamp_high = (uint32_t)(sensor_data->timestamp >> 32),
             };

--- a/module/scmi_sensor/src/mod_scmi_sensor.c
+++ b/module/scmi_sensor/src/mod_scmi_sensor.c
@@ -584,8 +584,10 @@ static int scmi_sensor_trip_point_config_handler(
         goto exit;
     }
 
-    trip_point_param.high_value = parameters->sensor_value_high;
-    trip_point_param.low_value = parameters->sensor_value_low;
+    trip_point_param.tp_value =
+        (((uint64_t)parameters->sensor_value_high << 32) & ~0U) |
+        (((uint64_t)parameters->sensor_value_low) & ~0U);
+
     trip_point_param.mode =
         (parameters->flags & SCMI_SENSOR_TRIP_POINT_FLAGS_EV_CTRL_MASK) >>
         SCMI_SENSOR_TRIP_POINT_FLAGS_EV_CTRL_POS;

--- a/module/sensor/include/mod_sensor.h
+++ b/module/sensor/include/mod_sensor.h
@@ -329,11 +329,8 @@ enum mod_sensor_trip_point_mode {
  *     a trip point value.
  */
 struct mod_sensor_trip_point_params {
-    /*! Sensor trip point low valuer */
-    uint32_t low_value;
-
-    /*! Sensor trip point high value */
-    uint32_t high_value;
+    /*! Sensor trip point value */
+    uint64_t tp_value;
 
     /*! Sensor trip point mode */
     enum mod_sensor_trip_point_mode mode;

--- a/module/sensor/src/mod_sensor.c
+++ b/module/sensor/src/mod_sensor.c
@@ -78,8 +78,7 @@ static bool trip_point_evaluate(
     uint64_t threshold;
     bool new_above_threshold, trigger = false;
 
-    threshold = (((uint64_t)ctx->params.high_value << 32) & ~0U) |
-        (((uint64_t)ctx->params.low_value) & ~0U);
+    threshold = ctx->params.tp_value;
     new_above_threshold = value > threshold;
 
     switch (ctx->params.mode) {
@@ -102,6 +101,7 @@ static bool trip_point_evaluate(
     default:
         break;
     }
+
     ctx->above_threshold = new_above_threshold;
     return trigger;
 }


### PR DESCRIPTION
The modifications included in these patches are for changing the sign for the value returned from get value from unsigned to signed and to simplify the trip point with a single 64 bit value. 