### PR TITLE
fwk: SCP suspend execution until an interrupt occurs

### DIFF
--- a/arch/arm/armv7-m/include/arch_helpers.h
+++ b/arch/arm/armv7-m/include/arch_helpers.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -28,6 +28,17 @@ inline static void arch_interrupts_enable(void)
 inline static void arch_interrupts_disable(void)
 {
     __asm volatile("cpsid i" : : : "memory");
+}
+
+/*!
+ * \brief Suspend execution of current CPU.
+
+ * \note CPU will be woken up by receiving interrupts.
+ *
+ */
+inline static void arch_suspend(void)
+{
+    __asm volatile("wfe");
 }
 
 #endif /* ARCH_HELPERS_H */

--- a/arch/arm/armv8-a/include/arch_helpers.h
+++ b/arch/arm/armv8-a/include/arch_helpers.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2013-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -569,6 +569,17 @@ inline static void arch_interrupts_enable()
 inline static void arch_interrupts_disable()
 {
     disable_irq();
+}
+
+/*!
+ * \brief Suspend execution of current CPU.
+
+ * \note CPU will be woken up by receiving interrupts.
+ *
+ */
+inline static void arch_suspend(void)
+{
+    wfe();
 }
 
 #endif /* ARCH_HELPERS_H */

--- a/arch/none/host/include/arch_helpers.h
+++ b/arch/none/host/include/arch_helpers.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -21,6 +21,14 @@ inline static void arch_interrupts_enable(void)
  *
  */
 inline static void arch_interrupts_disable(void)
+{
+}
+
+/*!
+ * \brief Suspend execution of current CPU.
+ *
+ */
+inline static void arch_suspend(void)
 {
 }
 

--- a/framework/include/fwk_arch.h
+++ b/framework/include/fwk_arch.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -213,6 +213,12 @@ struct fwk_arch_init_driver {
  * \retval ::FWK_E_PANIC Unrecoverable initialization error.
  */
 int fwk_arch_init(const struct fwk_arch_init_driver *driver);
+
+/*!
+ * \brief Architecture defined suspend, will wakup on receiving interrupt
+ *
+ */
+void fwk_arch_suspend(void);
 
 /*!
  * \}

--- a/framework/src/fwk_arch.c
+++ b/framework/src/fwk_arch.c
@@ -1,17 +1,23 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Description:
  *     Framework API for the architecture layer.
  */
-
 #include <internal/fwk_module.h>
 
 #include <fwk_arch.h>
 #include <fwk_assert.h>
+
+#include <arch_helpers.h>
+
+#if FWK_HAS_INCLUDE(<fmw_arch.h>)
+#    include <fmw_arch.h>
+#endif
+
 #include <fwk_io.h>
 #include <fwk_log.h>
 #include <fwk_module.h>
@@ -82,4 +88,15 @@ int fwk_arch_init(const struct fwk_arch_init_driver *driver)
     }
 
     return FWK_SUCCESS;
+}
+
+void fwk_arch_suspend(void)
+{
+    /* On some arm plaforms, wfe is supported architecturally, however
+     * implementation is erroneous. In such platforms FMW_DISABLE_ARCH_SUSPEND
+     * needs to be defined
+     */
+#if !defined(FMW_DISABLE_ARCH_SUSPEND)
+    arch_suspend();
+#endif
 }

--- a/framework/src/fwk_core.c
+++ b/framework/src/fwk_core.c
@@ -306,6 +306,7 @@ noreturn void __fwk_run(void)
         }
 
         (void)fwk_log_unbuffer();
+        fwk_arch_suspend();
     }
 }
 

--- a/framework/test/arch_helpers.h
+++ b/framework/test/arch_helpers.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -21,6 +21,14 @@ inline static void arch_interrupts_enable(void)
  *
  */
 inline static void arch_interrupts_disable(void)
+{
+}
+
+/*!
+ * \brief Suspend execution of current CPU.
+ *
+ */
+inline static void arch_suspend(void)
 {
 }
 

--- a/tools/build_system/doc.md
+++ b/tools/build_system/doc.md
@@ -264,6 +264,18 @@ Clock Tree Management                           {#section_clock_tree_management}
 When building a firmware and its dependencies, the BUILD_HAS_CLOCK_TREE_MGMT
 parameter controls if Clock Tree Management is enabled.
 
+Core Idle Suspend (WFE)                               {#section_idle_management}
+===============================
+
+WFE on ARM architecture makes processor suspends it's execution until it
+receives any interrupt. SCP firmware will execute this instruction when SCP
+firmware is in idle state, that is, when it has finished responding to all the
+internal events and external interrupts.
+
+Use FMW_DISABLE_ARCH_SUSPEND option to disable this execution of WFE. It
+can be defined in a platform specific fmw_arch.h file and adding this file
+in product/*/include directory.
+
 Performance Plugin Handler
 ==========================
 


### PR DESCRIPTION
Currently, the firmware is busy looping forever while
waiting for any interrupts. This behaviour consumes power
unnecessarily. To avoid the busy loop scenario the firmware
will enter suspend state using WFE (Wait For Event)
instruction. Any interrupt will wake up the CPU to handle
new events.

Signed-off-by: Tarek El-Sherbiny <tarek.el-sherbiny@arm.com>
Signed-off-by: Girish Pathak <girish.pathak@arm.com>
Change-Id: I83508dcce721a6d3fb93fa598d03a4bb01331f00