### PR TITLE
Fix gtimer config in Infra RD platforms mcp ramfw.

### DIFF
--- a/module/gtimer/include/mod_gtimer.h
+++ b/module/gtimer/include/mod_gtimer.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -46,6 +46,9 @@ struct mod_gtimer_dev_config {
 
     /*! Identifier of the clock that this device depends on */
     fwk_id_t clock_id;
+
+    /*! Skip initialisation of CNTCONTROL register */
+    bool skip_cntcontrol_init;
 };
 
 /*!

--- a/module/gtimer/src/mod_gtimer.c
+++ b/module/gtimer/src/mod_gtimer.c
@@ -254,6 +254,10 @@ static int gtimer_start(fwk_id_t id)
 
     ctx = mod_gtimer_ctx.table + fwk_id_get_element_idx(id);
 
+    if (ctx->config->skip_cntcontrol_init) {
+        return FWK_SUCCESS;
+    }
+
     if (!fwk_id_is_type(ctx->config->clock_id, FWK_ID_TYPE_NONE)) {
         /* Register for clock state notifications */
         return fwk_notification_subscribe(

--- a/product/rdn1e1/include/mcp_rdn1e1_mmap.h
+++ b/product/rdn1e1/include/mcp_rdn1e1_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -40,6 +40,11 @@
  * Power control peripherals
  */
 #define MCP_PIK_BASE                  (MCP_POWER_PERIPH_BASE)
+
+/*
+ * System access port 1
+ */
+#define MCP_REFCLK_CNTCONTROL_BASE (MCP_SYS1_BASE + 0x2A430000)
 
 /*
  * Base addresses of MHU devices v2

--- a/product/rdn1e1/mcp_ramfw/config_gtimer.c
+++ b/product/rdn1e1/mcp_ramfw/config_gtimer.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -24,9 +24,10 @@ static const struct fwk_element gtimer_dev_table[] = {
             .data = &((struct mod_gtimer_dev_config){
                 .hw_timer = MCP_REFCLK_CNTBASE0_BASE,
                 .hw_counter = MCP_REFCLK_CNTCTL_BASE,
-                .control = MCP_REFCLK_CNTCTL_BASE,
+                .control = MCP_REFCLK_CNTCONTROL_BASE,
                 .frequency = CLOCK_RATE_REFCLK,
                 .clock_id = FWK_ID_NONE_INIT,
+                .skip_cntcontrol_init = true
         }),
     },
     [1] = { 0 },

--- a/product/rdn2/include/mcp_css_mmap.h
+++ b/product/rdn2/include/mcp_css_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,7 +10,8 @@
 
 #include "mcp_mmap.h"
 
-#define MCP_REFCLK_CNTCTL_BASE   (MCP_PERIPHERAL_BASE + 0x0000)
-#define MCP_REFCLK_CNTBASE0_BASE (MCP_PERIPHERAL_BASE + 0x1000)
+#define MCP_REFCLK_CNTCTL_BASE     (MCP_PERIPHERAL_BASE + 0x0000)
+#define MCP_REFCLK_CNTBASE0_BASE   (MCP_PERIPHERAL_BASE + 0x1000)
+#define MCP_REFCLK_CNTCONTROL_BASE (MCP_SYSTEM_ACCESS_PORT1_BASE + 0x2A430000)
 
 #endif /* MCP_CSS_MMAP_H */

--- a/product/rdn2/include/mcp_mmap.h
+++ b/product/rdn2/include/mcp_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -8,11 +8,12 @@
 #ifndef MCP_MMAP_H
 #define MCP_MMAP_H
 
-#define MCP_BOOT_ROM_BASE       0x00000000
-#define MCP_ITC_RAM_BASE        0x00800000
-#define MCP_SOC_EXPANSION1_BASE 0x01000000
-#define MCP_DTC_RAM_BASE        0x20000000
-#define MCP_UART_BASE           0x4C002000
-#define MCP_PERIPHERAL_BASE     0x4C000000
+#define MCP_BOOT_ROM_BASE            0x00000000
+#define MCP_ITC_RAM_BASE             0x00800000
+#define MCP_SOC_EXPANSION1_BASE      0x01000000
+#define MCP_DTC_RAM_BASE             0x20000000
+#define MCP_UART_BASE                0x4C002000
+#define MCP_PERIPHERAL_BASE          0x4C000000
+#define MCP_SYSTEM_ACCESS_PORT1_BASE 0xA0000000
 
 #endif /* MCP_MMAP_H */

--- a/product/rdn2/mcp_ramfw/config_gtimer.c
+++ b/product/rdn2/mcp_ramfw/config_gtimer.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -24,9 +24,10 @@ static const struct fwk_element gtimer_dev_table[] = {
             .data = &((struct mod_gtimer_dev_config){
                 .hw_timer = MCP_REFCLK_CNTBASE0_BASE,
                 .hw_counter = MCP_REFCLK_CNTCTL_BASE,
-                .control = MCP_REFCLK_CNTCTL_BASE,
+                .control = MCP_REFCLK_CNTCONTROL_BASE,
                 .frequency = CLOCK_RATE_REFCLK,
-                .clock_id = FWK_ID_NONE_INIT }), },
+                .clock_id = FWK_ID_NONE_INIT,
+                .skip_cntcontrol_init = true }), },
     [1] = { 0 },
 };
 

--- a/product/rdv1/include/mcp_css_mmap.h
+++ b/product/rdv1/include/mcp_css_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,7 +10,8 @@
 
 #include "mcp_mmap.h"
 
-#define MCP_REFCLK_CNTCTL_BASE   (MCP_PERIPHERAL_BASE + 0x0000)
-#define MCP_REFCLK_CNTBASE0_BASE (MCP_PERIPHERAL_BASE + 0x1000)
+#define MCP_REFCLK_CNTCTL_BASE     (MCP_PERIPHERAL_BASE + 0x0000)
+#define MCP_REFCLK_CNTBASE0_BASE   (MCP_PERIPHERAL_BASE + 0x1000)
+#define MCP_REFCLK_CNTCONTROL_BASE (MCP_SYSTEM_ACCESS_PORT1_BASE + 0x2A430000)
 
 #endif /* MCP_CSS_MMAP_H */

--- a/product/rdv1/include/mcp_mmap.h
+++ b/product/rdv1/include/mcp_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -8,12 +8,13 @@
 #ifndef MCP_MMAP_H
 #define MCP_MMAP_H
 
-#define MCP_BOOT_ROM_BASE       0x00000000
-#define MCP_ITC_RAM_BASE        0x00800000
-#define MCP_SOC_EXPANSION1_BASE 0x01000000
-#define MCP_DTC_RAM_BASE        0x20000000
-#define MCP_UART1_BASE          0x4C002000
-#define MCP_UART2_BASE          0x4C003000
-#define MCP_PERIPHERAL_BASE     0x4C000000
+#define MCP_BOOT_ROM_BASE            0x00000000
+#define MCP_ITC_RAM_BASE             0x00800000
+#define MCP_SOC_EXPANSION1_BASE      0x01000000
+#define MCP_DTC_RAM_BASE             0x20000000
+#define MCP_UART1_BASE               0x4C002000
+#define MCP_UART2_BASE               0x4C003000
+#define MCP_PERIPHERAL_BASE          0x4C000000
+#define MCP_SYSTEM_ACCESS_PORT1_BASE 0xA0000000
 
 #endif /* MCP_MMAP_H */

--- a/product/rdv1/mcp_ramfw/config_gtimer.c
+++ b/product/rdv1/mcp_ramfw/config_gtimer.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -24,9 +24,10 @@ static const struct fwk_element gtimer_dev_table[] = {
             .data = &((struct mod_gtimer_dev_config){
                 .hw_timer = MCP_REFCLK_CNTBASE0_BASE,
                 .hw_counter = MCP_REFCLK_CNTCTL_BASE,
-                .control = MCP_REFCLK_CNTCTL_BASE,
+                .control = MCP_REFCLK_CNTCONTROL_BASE,
                 .frequency = CLOCK_RATE_REFCLK,
                 .clock_id = FWK_ID_NONE_INIT,
+                .skip_cntcontrol_init = true,
         }),
     },
     [1] = { 0 },

--- a/product/rdv1mc/include/mcp_css_mmap.h
+++ b/product/rdv1mc/include/mcp_css_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,7 +10,8 @@
 
 #include "mcp_mmap.h"
 
-#define MCP_REFCLK_CNTCTL_BASE   (MCP_PERIPHERAL_BASE + 0x0000)
-#define MCP_REFCLK_CNTBASE0_BASE (MCP_PERIPHERAL_BASE + 0x1000)
+#define MCP_REFCLK_CNTCTL_BASE     (MCP_PERIPHERAL_BASE + 0x0000)
+#define MCP_REFCLK_CNTBASE0_BASE   (MCP_PERIPHERAL_BASE + 0x1000)
+#define MCP_REFCLK_CNTCONTROL_BASE (MCP_SYSTEM_ACCESS_PORT1_BASE + 0x2A430000)
 
 #endif /* MCP_CSS_MMAP_H */

--- a/product/rdv1mc/include/mcp_mmap.h
+++ b/product/rdv1mc/include/mcp_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -8,12 +8,13 @@
 #ifndef MCP_MMAP_H
 #define MCP_MMAP_H
 
-#define MCP_BOOT_ROM_BASE       0x00000000
-#define MCP_ITC_RAM_BASE        0x00800000
-#define MCP_SOC_EXPANSION1_BASE 0x01000000
-#define MCP_DTC_RAM_BASE        0x20000000
-#define MCP_UART1_BASE          0x4C002000
-#define MCP_UART2_BASE          0x4C003000
-#define MCP_PERIPHERAL_BASE     0x4C000000
+#define MCP_BOOT_ROM_BASE            0x00000000
+#define MCP_ITC_RAM_BASE             0x00800000
+#define MCP_SOC_EXPANSION1_BASE      0x01000000
+#define MCP_DTC_RAM_BASE             0x20000000
+#define MCP_UART1_BASE               0x4C002000
+#define MCP_UART2_BASE               0x4C003000
+#define MCP_PERIPHERAL_BASE          0x4C000000
+#define MCP_SYSTEM_ACCESS_PORT1_BASE 0xA0000000
 
 #endif /* MCP_MMAP_H */

--- a/product/rdv1mc/mcp_ramfw/config_gtimer.c
+++ b/product/rdv1mc/mcp_ramfw/config_gtimer.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -24,9 +24,10 @@ static const struct fwk_element gtimer_dev_table[] = {
             .data = &((struct mod_gtimer_dev_config){
                 .hw_timer = MCP_REFCLK_CNTBASE0_BASE,
                 .hw_counter = MCP_REFCLK_CNTCTL_BASE,
-                .control = MCP_REFCLK_CNTCTL_BASE,
+                .control = MCP_REFCLK_CNTCONTROL_BASE,
                 .frequency = CLOCK_RATE_REFCLK,
                 .clock_id = FWK_ID_NONE_INIT,
+                .skip_cntcontrol_init = true,
         }),
     },
     [1] = { 0 },

--- a/product/sgi575/include/mcp_sgi575_mmap.h
+++ b/product/sgi575/include/mcp_sgi575_mmap.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -40,6 +40,11 @@
  * Power control peripherals
  */
 #define MCP_PIK_BASE                  (MCP_POWER_PERIPH_BASE)
+
+/*
+ * System access port 1
+ */
+#define MCP_REFCLK_CNTCONTROL_BASE (MCP_SYS1_BASE + 0x2A430000)
 
 /*
  * Base addresses of MHU devices

--- a/product/sgi575/mcp_ramfw/config_gtimer.c
+++ b/product/sgi575/mcp_ramfw/config_gtimer.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -24,9 +24,10 @@ static const struct fwk_element gtimer_dev_table[] = {
             .data = &((struct mod_gtimer_dev_config){
                 .hw_timer = MCP_REFCLK_CNTBASE0_BASE,
                 .hw_counter = MCP_REFCLK_CNTCTL_BASE,
-                .control = MCP_REFCLK_CNTCTL_BASE,
+                .control = MCP_REFCLK_CNTCONTROL_BASE,
                 .frequency = CLOCK_RATE_REFCLK,
                 .clock_id = FWK_ID_NONE_INIT,
+                .skip_cntcontrol_init = true,
         }),
     },
     [1] = { 0 },


### PR DESCRIPTION
- This patch-set fixes the the gtimer config in mcp ramfw for Infra RD platforms. 
- It also introduces a new flag in the gtimer module to make the CNTCONTROL register initialization optional.