### PR TITLE
scp: Update firmware version to 2.10.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 
 project(
     SCP
-    VERSION 2.9.0
+    VERSION 2.10.0
     DESCRIPTION "Arm SCP/MCP Software"
     HOMEPAGE_URL
         "https://developer.arm.com/tools-and-software/open-source-software/firmware/scp-firmware"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # Version
 #
 export VERSION_MAJOR := 2
-export VERSION_MINOR := 9
+export VERSION_MINOR := 10
 export VERSION_PATCH := 0
 
 #

--- a/framework/test/CMakeLists.txt
+++ b/framework/test/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.18.3)
 
 project(
     SCP_FWK_TEST
-    VERSION 2.9.0
+    VERSION 2.10.0
     DESCRIPTION "Arm SCP/MCP Software Framework tests"
     HOMEPAGE_URL
         "https://developer.arm.com/tools-and-software/open-source-software/firmware/scp-firmware"

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
-SCP-firmware - version 2.9
-==========================
+SCP-firmware - version 2.10
+===========================
 
-Copyright (c) 2011-2021, Arm Limited. All rights reserved.
+Copyright (c) 2011-2022, Arm Limited. All rights reserved.
 
 References
 ----------


### PR DESCRIPTION
This patch updates the SCP-firmware version to 2.10.0.

Change-Id: Ic2bfe27a17f407a18f98b69154eb97c774a0a288
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>