### PR TITLE
clock: Fix wrong async driver assertions

### DIFF
--- a/module/clock/src/clock_tree_management.c
+++ b/module/clock/src/clock_tree_management.c
@@ -158,7 +158,7 @@ int clock_management_process_state(const struct fwk_event *event)
                  * This should not be reached because. asynchronous drivers
                  * are not supported.
                  */
-                fwk_assert(status == FWK_E_SUPPORT);
+                fwk_assert(status != FWK_E_SUPPORT);
 
                 if (status == FWK_E_SUPPORT) {
                     return status;
@@ -185,7 +185,7 @@ int clock_management_process_state(const struct fwk_event *event)
                  * This should not be reached because. asynchronous drivers
                  * are not supported.
                  */
-                fwk_assert(status == FWK_E_SUPPORT);
+                fwk_assert(status != FWK_E_SUPPORT);
 
                 if (status == FWK_E_SUPPORT) {
                     return status;
@@ -241,7 +241,7 @@ int clock_management_process_state(const struct fwk_event *event)
              * This should not be reached because. asynchronous drivers
              * are not supported.
              */
-            fwk_assert(status == FWK_E_SUPPORT);
+            fwk_assert(status != FWK_E_SUPPORT);
 
             if (status == FWK_E_SUPPORT) {
                 return status;


### PR DESCRIPTION
The assertions were checking that the status _is_ FWK_E_SUPPORT
instead of checking that it is _not_ FWK_E_SUPPORT
