### PR TITLE
clock: Fix call to get_state to use driver id instead of clock id

### DIFF
--- a/module/clock/src/clock_tree_management.c
+++ b/module/clock/src/clock_tree_management.c
@@ -337,7 +337,7 @@ int clock_connect_tree(struct clock_ctx *module_ctx)
 
         fwk_list_push_tail(&parent->children_list, &clk->child_node);
 
-        status = clk->api->get_state(clk->id, &current_state);
+        status = clk->api->get_state(clk->config->driver_id, &current_state);
         if (status == FWK_PENDING) {
             FWK_LOG_WARN(
                 "[CLOCK] Async drivers not supported with clock tree mgmt");


### PR DESCRIPTION
When calling the clock driver's get_state API, the provied id should be
the driver element id, and not the clock's element id.
Fixed a call to get_state that was using the clock id.
