### PR TITLE
SCP SCMI Initiator Patches

### DIFF
--- a/module/scmi/include/internal/mod_scmi.h
+++ b/module/scmi/include/internal/mod_scmi.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -41,8 +41,12 @@ struct scmi_service_ctx {
     /*
      * Copy of the pointer to the 'transmit' function within the transport API.
      */
-    int (*transmit)(fwk_id_t transport_id, uint32_t message_header,
-        const void *payload, size_t size);
+    int (*transmit)(
+        fwk_id_t transport_id,
+        uint32_t message_header,
+        const void *payload,
+        size_t size,
+        bool request_ack_by_interrupt);
 
     /* SCMI message token, used by the agent to identify individual messages */
     uint16_t scmi_token;

--- a/module/scmi/include/mod_scmi.h
+++ b/module/scmi/include/mod_scmi.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -290,6 +290,8 @@ struct mod_scmi_to_transport_api {
      * \param message_header Message ID.
      * \param payload Payload data to write.
      * \param size Size of the payload source.
+     * \param request_ack_by_interrupt flag to select whether acknowledgement
+     * interrupt is required for this message.
      *
      * \retval ::FWK_SUCCESS The operation succeeded.
      * \retval ::FWK_E_PARAM An invalid parameter was encountered:
@@ -299,8 +301,12 @@ struct mod_scmi_to_transport_api {
      * \return One of the standard error codes for implementation-defined
      *      errors.
      */
-    int (*transmit)(fwk_id_t channel_id, uint32_t message_header,
-        const void *payload, size_t size);
+    int (*transmit)(
+        fwk_id_t channel_id,
+        uint32_t message_header,
+        const void *payload,
+        size_t size,
+        bool request_ack_by_interrupt);
 };
 
 /*!
@@ -583,6 +589,27 @@ struct mod_scmi_from_protocol_api {
      */
     void (*notify)(fwk_id_t service_id, int protocol_id, int message_id,
         const void *payload, size_t size);
+
+    /*!
+     * \brief Send an SCMI message
+     *
+     * \param scmi_message_id SCMI message identifier.
+     * \param scmi_protocol_id SCMI message protocol identifier.
+     * \param token SCMI message token.
+     * \param service_id SCMI service identifier.
+     * \param payload Payload data to write
+     * \param payload_size size of the payload in bytes.
+     * \param request_ack_by_interrupt flag to select whether acknowledgement
+     * interrupt is required for this message.
+     */
+    int (*scmi_send_message)(
+        uint8_t scmi_message_id,
+        uint8_t scmi_protocol_id,
+        uint8_t token,
+        fwk_id_t service_id,
+        const void *payload,
+        size_t payload_size,
+        bool request_ack_by_interrupt);
 };
 
 /*!

--- a/module/scmi/include/mod_scmi.h
+++ b/module/scmi/include/mod_scmi.h
@@ -619,6 +619,15 @@ struct mod_scmi_from_protocol_api {
         const void *payload,
         size_t payload_size,
         bool request_ack_by_interrupt);
+
+    /*!
+     * \brief Handle response SCMI message
+     *
+     * \param service_id Service identifier.
+     *
+     * \retval ::FWK_SUCCESS The operation succeeded.
+     */
+    int (*response_message_handler)(fwk_id_t service_id);
 };
 
 /*!

--- a/module/scmi/include/mod_scmi.h
+++ b/module/scmi/include/mod_scmi.h
@@ -307,6 +307,15 @@ struct mod_scmi_to_transport_api {
         const void *payload,
         size_t size,
         bool request_ack_by_interrupt);
+
+    /*!
+     * \brief Release the transport channel context lock.
+     *
+     * \param channel_id Transport channel identifier.
+     *
+     * \retval ::FWK_SUCCESS The operation succeeded.
+     */
+    int (*release_transport_channel_lock)(fwk_id_t channel_id);
 };
 
 /*!

--- a/module/scmi/src/mod_scmi.c
+++ b/module/scmi/src/mod_scmi.c
@@ -522,6 +522,20 @@ int scmi_send_message(
         request_ack_by_interrupt);
 };
 
+int response_message_handler(fwk_id_t service_id)
+{
+    int status;
+    const struct scmi_service_ctx *ctx;
+
+    ctx = &scmi_ctx.service_ctx_table[fwk_id_get_element_idx(service_id)];
+
+    /* release the tranport channel lock */
+    status =
+        ctx->transport_api->release_transport_channel_lock(ctx->transport_id);
+
+    return status;
+}
+
 static const struct mod_scmi_from_protocol_api scmi_from_protocol_api = {
     .get_agent_count = get_agent_count,
     .get_agent_id = get_agent_id,
@@ -531,6 +545,7 @@ static const struct mod_scmi_from_protocol_api scmi_from_protocol_api = {
     .respond = respond,
     .notify = scmi_notify,
     .scmi_send_message = scmi_send_message,
+    .response_message_handler = response_message_handler,
 };
 
 #ifdef BUILD_HAS_SCMI_NOTIFICATIONS

--- a/module/smt/src/mod_smt.c
+++ b/module/smt/src/mod_smt.c
@@ -279,6 +279,23 @@ static int smt_transmit(
     return channel_ctx->driver_api->raise_interrupt(channel_ctx->driver_id);
 }
 
+static int smt_release_channel_lock(fwk_id_t channel_id)
+{
+    /* This function will be called by the scmi module after handling a
+     * response message in order to release the channel context lock
+     * without having to call the smt_respond() function.
+     */
+    struct smt_channel_ctx *channel_ctx;
+
+    channel_ctx =
+        &smt_ctx.channel_ctx_table[fwk_id_get_element_idx(channel_id)];
+
+    /* Release the channel lock so that we can process the next message */
+    channel_ctx->locked = false;
+
+    return FWK_SUCCESS;
+}
+
 static const struct mod_scmi_to_transport_api smt_mod_scmi_to_transport_api = {
     .get_secure = smt_get_secure,
     .get_max_payload_size = smt_get_max_payload_size,
@@ -287,6 +304,7 @@ static const struct mod_scmi_to_transport_api smt_mod_scmi_to_transport_api = {
     .write_payload = smt_write_payload,
     .respond = smt_respond,
     .transmit = smt_transmit,
+    .release_transport_channel_lock = smt_release_channel_lock,
 };
 
 /*


### PR DESCRIPTION
This patch series enables the SCP to initiate SCMI messages and also adds support for requester type SMT channel message handler.