### PR TITLE
Scmi perf fixes: typo & pointer conversion rule

### DIFF
--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -1687,7 +1687,7 @@ static void scmi_perf_notify_level_updated(
                 get_level =
                     (uint32_t *)((uintptr_t)domain->fast_channels_addr_scp
                                      [MOD_SCMI_PERF_FAST_CHANNEL_LEVEL_GET]);
-                if (get_level != 0x0) { /* note: get_level may not be defined */
+                if (get_level != NULL) { /* get_level may not be defined */
                     *get_level = level;
                 }
             }

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -145,7 +145,7 @@ struct perf_operations {
     fwk_id_t service_id;
 };
 
-struct pref_opp_table {
+struct perf_opp_table {
     /* Pointer to DVFS OPP table */
     struct mod_dvfs_opp *opps;
 
@@ -167,7 +167,7 @@ struct scmi_perf_domain_ctx {
     uint32_t curr_level;
 
     /* Tables of OPPs */
-    struct pref_opp_table *opp_table;
+    struct perf_opp_table *opp_table;
 };
 
 struct mod_scmi_perf_ctx {
@@ -216,7 +216,7 @@ struct mod_scmi_perf_ctx {
 
     struct scmi_perf_domain_ctx *domain_ctx_table;
 
-    struct pref_opp_table *opp_table;
+    struct perf_opp_table *opp_table;
 
     unsigned int dvfs_doms_count;
 };
@@ -294,7 +294,7 @@ static inline uint32_t *get_fc_set_level_addr(
 
 static inline int opp_for_level_found(
     uint32_t *level,
-    struct pref_opp_table *opp_table,
+    struct perf_opp_table *opp_table,
     size_t i)
 {
     *level = opp_table->opps[i].level;
@@ -307,7 +307,7 @@ static int find_opp_for_level(
     uint32_t *level,
     bool use_nearest)
 {
-    struct pref_opp_table *opp_table;
+    struct perf_opp_table *opp_table;
     size_t i;
     uint32_t opp_level, limit_max;
 
@@ -1979,13 +1979,13 @@ static int scmi_perf_start(fwk_id_t id)
     unsigned int i;
 
     const struct mod_dvfs_domain_config *dvfs_config;
-    struct pref_opp_table *opp_table = NULL;
+    struct perf_opp_table *opp_table = NULL;
     const struct mod_scmi_perf_domain_config *domain_cfg;
     unsigned int dom_idx;
     bool has_phy_group;
 
     scmi_perf_ctx.opp_table = fwk_mm_calloc(
-        scmi_perf_ctx.dvfs_doms_count, sizeof(struct pref_opp_table));
+        scmi_perf_ctx.dvfs_doms_count, sizeof(struct perf_opp_table));
 
     for (i = 0; i < scmi_perf_ctx.dvfs_doms_count; i++) {
         opp_table = &scmi_perf_ctx.opp_table[i];


### PR DESCRIPTION
Minor fixes for the scmi_perf module: Fix a typo and fix a MISRAC pointer type conversion rule.