### PR TITLE
ci: Print build output/information

### DIFF
--- a/tools/product.py
+++ b/tools/product.py
@@ -38,6 +38,14 @@ class Build:
             build_str += ' - Variant {}'.format(self.variant.name)
         return build_str
 
+    def file_name(self):
+        filename = self.name + "_" + self.toolchain.name + "_" + \
+            self.build_type.name[0]
+        if self.variant:
+            filename += self.variant.name[0]
+        filename += ".txt"
+        return filename
+
     def command(self):
         cmd = 'make -f Makefile.cmake '
         cmd += 'PRODUCT={} TOOLCHAIN={} MODE={} '.format(self.name,


### PR DESCRIPTION
The CI is indicating whether the build failed or passed,
but is not printing the output of the build, which is
making it difficult to debug any problems that arise when
running the cmake-ci tests.

Generate files with the information of each build's output.
Store those files in the path given by the parameter -bod
(build output directory) or under the default folder
/tmp/scp/build-output.

Signed-off-by: Tomás Agustín González Orlando <tomasagustin.gonzalezorlando@arm.com>
Change-Id: I1b45cee047a23e54e4fe2f24414001b583c706bc