### PR TITLE
cmake: Fix ArmClang generated images

### DIFF
--- a/cmake/Toolchain/ArmClang-Baremetal.cmake
+++ b/cmake/Toolchain/ArmClang-Baremetal.cmake
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -12,8 +12,10 @@ foreach(language IN ITEMS ASM C CXX)
     string(APPEND CMAKE_${language}_FLAGS_INIT "-ffunction-sections ")
     string(APPEND CMAKE_${language}_FLAGS_INIT "-fdata-sections ")
     string(APPEND CMAKE_${language}_FLAGS_INIT "-fshort-enums ")
+    string(APPEND CMAKE_${language}_FLAGS_INIT "-mfloat-abi=soft ")
 
     string(APPEND CMAKE_${language}_FLAGS_DEBUG_INIT "-Og ")
 endforeach()
 
 string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT "--remove ")
+string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT "--fpu=SoftVFP ")


### PR DESCRIPTION
Images generated for cortex-m7 targets are not booting.
This is because hardware floating point initialization modules
are added by ArmClang linker. These modules add floating point
instructions that cause exceptions.

This patch adds the linker option to omit including the floating
point initialization modules and the compiler option to avoid
using floating point instructions.

Signed-off-by: Ahmed Gadallah <ahmed.gadallah@arm.com>
Change-Id: I7e0f868227587c0a167d29974608ddb2a21b018f