### PR TITLE
morello: fix timestamp in debug logs

### DIFF
--- a/product/morello/scp_ramfw_soc/config_timer.c
+++ b/product/morello/scp_ramfw_soc/config_timer.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -17,6 +17,7 @@
 #include <fwk_id.h>
 #include <fwk_module.h>
 #include <fwk_module_idx.h>
+#include <fwk_time.h>
 
 #include <fmw_cmsis.h>
 
@@ -38,14 +39,14 @@ static const struct fwk_element gtimer_dev_table[2] = {
     [1] = { 0 },
 };
 
-static const struct fwk_element *gtimer_get_dev_table(fwk_id_t module_id)
-{
-    return gtimer_dev_table;
-}
-
 const struct fwk_module_config config_gtimer = {
-    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(gtimer_get_dev_table),
+    .elements = FWK_MODULE_STATIC_ELEMENTS_PTR(gtimer_dev_table),
 };
+
+struct fwk_time_driver fmw_time_driver(const void **ctx)
+{
+    return mod_gtimer_driver(ctx, config_gtimer.elements.table[0].data);
+}
 
 /*
  * Timer HAL config


### PR DESCRIPTION
The generic timer instance is not hooked to the framework time driver
which makes the timestamp to be printed as zeros all the time.

This patch fixes the gap to let framework print correct timestamps
during debug logs.

Signed-off-by: Manoj Kumar <manoj.kumar3@arm.com>
Change-Id: Iacab58a01999be8f71358d13e48c1517dba02b64