### PR TITLE
synquacer: Add a make option to select UART port

### DIFF
--- a/product/synquacer/doc/platform_options.md
+++ b/product/synquacer/doc/platform_options.md
@@ -1,0 +1,48 @@
+# SynQuacer Platform Options
+
+## Overview
+
+This documentation describes what options are available and
+how to build example on SynQuacer platform.
+
+## Selecting an UART Port for SCP-firmware console
+
+At SCP-firmware build time for SynQuacer platform,
+the following 3 UART ports are selectable.
+
+    uart0 : A standard UART on the 40 pin expansion connector (used as default)
+    uart1 : A second standard UART on the 40 pin expansion connector
+    debug_uart : A debug UART via the micro-B USB connector
+
+To select UART port,
+set SYNQUACER_UART value as below when executing make commnad.
+
+If SYNQUACER_UART value is not set,
+uart0 is selected as defalut.
+
+In Make build system,
+
+```sh
+make
+    CC=$CC \
+    PRODUCT=synquacer \
+    MODE=<debug,release> \
+    [SYNQUACER_UART=<uart0,uart1,debug_uart>]
+```
+
+e.g.
+make CC=$CC PRODUCT=synquacer MODE=release SYNQUACER_UART=uart1
+
+In CMake build system,
+
+```sh
+make -f Makefile.cmake \
+    CC=$CC \
+    PRODUCT=synquacer \
+    MODE=<debug,release> \
+    [EXTRA_CONFIG_ARGS="-DSYNQUACER_UART=<uart0,uart1,debug_uart>]
+```
+
+e.g.
+make -f Makefile.cmake CC=$CC PRODUCT=synquacer MODE=release EXTRA_CONFIG_ARGS="-DSYNQUACER_UART=uart1"
+

--- a/product/synquacer/include/fmw_io.h
+++ b/product/synquacer/include/fmw_io.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -11,6 +11,18 @@
 #include <fwk_id.h>
 #include <fwk_module_idx.h>
 
+#if defined(CONFIG_SCB_USE_SCP_PL011) || defined(CONFIG_SCB_USE_AP_PL011)
+
+#ifndef BUILD_HAS_MOD_PL011
+#define FMW_IO_STDIN_ID FWK_ID_NONE
+#define FMW_IO_STDOUT_ID FWK_ID_NONE
+#else
+#define FMW_IO_STDIN_ID FWK_ID_NONE
+#define FMW_IO_STDOUT_ID FWK_ID_ELEMENT(FWK_MODULE_IDX_PL011, 0)
+#endif
+
+#else /* defined(CONFIG_SCB_USE_SCP_PL011) || defined(CONFIG_SCB_USE_AP_PL011) */
+
 #ifndef BUILD_HAS_MOD_F_UART3
 #define FMW_IO_STDIN_ID FWK_ID_NONE
 #define FMW_IO_STDOUT_ID FWK_ID_NONE
@@ -18,5 +30,7 @@
 #define FMW_IO_STDIN_ID FWK_ID_NONE
 #define FMW_IO_STDOUT_ID FWK_ID_ELEMENT(FWK_MODULE_IDX_F_UART3, 0)
 #endif
+
+#endif /* defined(CONFIG_SCB_USE_SCP_PL011) || defined(CONFIG_SCB_USE_AP_PL011) */
 
 #endif /* FMW_IO_H */

--- a/product/synquacer/include/system_clock.h
+++ b/product/synquacer/include/system_clock.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -28,12 +28,15 @@
 #define CLOCK_RATE_SYSINCLK (1000UL * FWK_MHZ)
 #define CLOCK_RATE_REFCLK (100UL * FWK_MHZ)
 #define CLOCK_RATE_DDRPLLCLK (1066UL * FWK_MHZ)
+#define CLOCK_RATE_SCP_PL011CLK (100000 * FWK_KHZ)
 #define CLOCK_RATE_AP_PL011CLK (62500 * FWK_KHZ)
 
-#ifdef CONFIG_SCB_USE_AP_PL011
-#define CLOCK_RATE_PL011CLK CLOCK_RATE_AP_PL011CLK
+#if defined(CONFIG_SCB_USE_SCP_PL011)
+#define CLOCK_RATE_UART CLOCK_RATE_SCP_PL011CLK
+#elif defined(CONFIG_SCB_USE_AP_PL011)
+#define CLOCK_RATE_UART CLOCK_RATE_AP_PL011CLK
 #else
-#define CLOCK_RATE_PL011CLK (100000 * FWK_KHZ)
+#define CLOCK_RATE_UART (100000 * FWK_KHZ)
 #endif
 
 #endif /* SYSTEM_CLOCK_H */

--- a/product/synquacer/scp_ramfw/CMakeLists.txt
+++ b/product/synquacer/scp_ramfw/CMakeLists.txt
@@ -29,7 +29,6 @@ target_sources(
             "${CMAKE_CURRENT_SOURCE_DIR}/config_f_i2c.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_hsspi.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_nor.c"
-            "${CMAKE_CURRENT_SOURCE_DIR}/config_f_uart3.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_mhu.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_pik_clock.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_power_domain.c"
@@ -42,6 +41,20 @@ target_sources(
             "${CMAKE_CURRENT_SOURCE_DIR}/config_system_power.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_timer.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c")
+
+if(SYNQUACER_UART MATCHES "uart0")
+    target_sources(synquacer-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_f_uart3.c")
+elseif(SYNQUACER_UART MATCHES "uart1")
+    target_sources(synquacer-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c")
+elseif(SYNQUACER_UART MATCHES "debug_uart")
+    target_sources(synquacer-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c")
+else()
+    target_sources(synquacer-bl2
+                   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_f_uart3.c")
+endif()
 
 #
 # Some of our firmware includes require CMSIS.

--- a/product/synquacer/scp_ramfw/Firmware.cmake
+++ b/product/synquacer/scp_ramfw/Firmware.cmake
@@ -28,7 +28,6 @@ list(PREPEND SCP_MODULE_PATHS
 list(PREPEND SCP_MODULE_PATHS
      "${CMAKE_CURRENT_LIST_DIR}/../module/synquacer_memc")
 list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/f_i2c")
-list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/f_uart3")
 list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/hsspi")
 list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/nor")
 list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/ccn512")
@@ -42,7 +41,6 @@ list(PREPEND SCP_MODULE_PATHS
 # any change in the order will cause firmware initialization errors.
 
 list(APPEND SCP_MODULES "armv7m-mpu")
-list(APPEND SCP_MODULES "f-uart3")
 list(APPEND SCP_MODULES "gtimer")
 list(APPEND SCP_MODULES "timer")
 list(APPEND SCP_MODULES "ppu-v0-synquacer")
@@ -64,6 +62,23 @@ list(APPEND SCP_MODULES "scmi-power-domain")
 list(APPEND SCP_MODULES "scmi-system-power")
 list(APPEND SCP_MODULES "scmi-apcore")
 list(APPEND SCP_MODULES "scmi-vendor-ext")
+
+if(SYNQUACER_UART MATCHES "uart0")
+    add_definitions(-DCA53_USE_F_UART)
+    list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/f_uart3")
+    list(APPEND SCP_MODULES "f-uart3")
+elseif(SYNQUACER_UART MATCHES "uart1")
+    add_definitions(-DCONFIG_SCB_USE_SCP_PL011)
+    list(APPEND SCP_MODULES "pl011")
+elseif(SYNQUACER_UART MATCHES "debug_uart")
+    add_definitions(-DCONFIG_SCB_USE_AP_PL011)
+    list(APPEND SCP_MODULES "pl011")
+else()
+    # default
+    add_definitions(-DCA53_USE_F_UART)
+    list(PREPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_LIST_DIR}/../module/f_uart3")
+    list(APPEND SCP_MODULES "f-uart3")
+endif()
 
 add_compile_definitions(PUBLIC PCIE_FILTER_BUS0_TYPE0_CONFIG
                         ENABLE_OPTEE SET_PCIE_NON_SECURE)

--- a/product/synquacer/scp_ramfw/config_pl011.c
+++ b/product/synquacer/scp_ramfw/config_pl011.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -13,6 +13,7 @@
 #include <fwk_log.h>
 #include <fwk_macros.h>
 #include <fwk_module.h>
+#include <system_clock.h>
 
 struct fwk_module_config config_pl011 = {
     .elements = FWK_MODULE_STATIC_ELEMENTS({
@@ -22,7 +23,7 @@ struct fwk_module_config config_pl011 = {
                 &(struct mod_pl011_element_cfg){
                     .reg_base = SCP_UART_BASE,
                     .baud_rate_bps = 115200,
-                    .clock_rate_hz = 62500 * FWK_KHZ,
+                    .clock_rate_hz = CLOCK_RATE_UART,
                     .clock_id = FWK_ID_NONE_INIT,
                     .pd_id = FWK_ID_NONE_INIT,
                 },

--- a/product/synquacer/scp_ramfw/firmware.mk
+++ b/product/synquacer/scp_ramfw/firmware.mk
@@ -12,11 +12,9 @@ BS_FIRMWARE_USE_NEWLIB_NANO_SPECS := yes
 DEFINES += PCIE_FILTER_BUS0_TYPE0_CONFIG
 DEFINES += ENABLE_OPTEE
 DEFINES += SET_PCIE_NON_SECURE
-#DEFINES += CA53_USE_F_UART
 
 BS_FIRMWARE_MODULES := \
     armv7m_mpu \
-    f_uart3 \
     gtimer \
     timer \
     ppu_v0_synquacer \
@@ -47,7 +45,6 @@ BS_FIRMWARE_SOURCES := \
     config_css_clock.c \
     config_f_i2c.c \
     config_hsspi.c \
-    config_f_uart3.c \
     config_mhu.c \
     config_pik_clock.c \
     config_power_domain.c \
@@ -61,6 +58,29 @@ BS_FIRMWARE_SOURCES := \
     config_timer.c \
     config_nor.c \
     config_scmi_power_domain.c
+
+ifeq ($(SYNQUACER_UART),uart0)
+    DEFINES += CA53_USE_F_UART
+    BS_FIRMWARE_MODULES += f_uart3
+    BS_FIRMWARE_SOURCES += config_f_uart3.c
+else
+ifeq ($(SYNQUACER_UART),uart1)
+    DEFINES += CONFIG_SCB_USE_SCP_PL011
+    BS_FIRMWARE_MODULES += pl011
+    BS_FIRMWARE_SOURCES += config_pl011.c
+else
+ifeq ($(SYNQUACER_UART),debug_uart)
+    DEFINES += CONFIG_SCB_USE_AP_PL011
+    BS_FIRMWARE_MODULES += pl011
+    BS_FIRMWARE_SOURCES += config_pl011.c
+else
+    # Default
+    DEFINES += CA53_USE_F_UART
+    BS_FIRMWARE_MODULES += f_uart3
+    BS_FIRMWARE_SOURCES += config_f_uart3.c
+endif
+endif
+endif
 
 include $(PRODUCT_DIR)/src/device.mk
 


### PR DESCRIPTION
This patch adds a new make option to select UART port
in make and CMake build on SynQuacer platform.

The following 3 UART ports are selectable.
uart0 : A standard UART on the 40 pin expansion connector
        (used as default for SCP console)
uart1 : A second standard UART on the 40 pin expansion connector
debug_uart : A debug UART via the micro-B USB connector

To select UART port, set SYNQUACER_UART value as below
when executing make commnad.

In make build system,
make CC=$CC PRODUCT=synquacer MODE=$MODE \
 [SYNQUACER_UART=uart0|uart1|debug_uart]
e.g.
make CC=$CC PRODUCT=synquacer MODE=$MODE SYNQUACER_UART=uart1

In CMake build system,
make -f Makefile.cmake CC=$CC PRODUCT=synquacer MODE=$MODE \
 [EXTRA_CONFIG_ARGS="-DSYNQUACER_UART=uart0|uart1|debug_uart"]
e.g.
make -f Makefile.cmake CC=$CC PRODUCT=synquacer MODE=$MODE \
 EXTRA_CONFIG_ARGS="-DSYNQUACER_UART=uart1"

If SYNQUACER_UART value is not set, uart0 is selected as defalut.

Change-Id: I9390a178c4685d5e4aa88d1eb1174aa9a26fd00f
Signed-off-by: Masahisa Kojima <masahisa.kojima@linaro.org>
Signed-off-by: Masanobu Morikawa <morikawa.masanobu@socionext.com>