### PR TITLE
Reset domain fixes: HAL type and notification_id

### DIFF
--- a/module/reset_domain/src/mod_reset_domain.c
+++ b/module/reset_domain/src/mod_reset_domain.c
@@ -54,7 +54,7 @@ static int set_reset_state(fwk_id_t reset_dev_id,
 }
 
 /* HAL API */
-static const struct mod_reset_domain_drv_api reset_api = {
+static const struct mod_reset_domain_api reset_api = {
     .set_reset_state = set_reset_state,
 };
 

--- a/product/juno/scp_ramfw/config_reset_domain.c
+++ b/product/juno/scp_ramfw/config_reset_domain.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -14,9 +14,10 @@
 #include <mod_juno_reset_domain.h>
 
 static const struct mod_reset_domain_config reset_domain_config = {
-#ifdef BUILD_HAS_SCMI_NOTIFICATIONS
-    .notification_id = FWK_ID_NOTIFICATION_INIT(FWK_MODULE_IDX_RESET_DOMAIN,
-                            MOD_RESET_DOMAIN_NOTIFICATION_AUTORESET),
+#ifdef BUILD_HAS_NOTIFICATION
+    .notification_id = FWK_ID_NOTIFICATION_INIT(
+        FWK_MODULE_IDX_RESET_DOMAIN,
+        MOD_RESET_DOMAIN_NOTIFICATION_AUTORESET),
 #endif
 };
 


### PR DESCRIPTION
This PR brings two fixes for the reset domain:
- Fix HAL api type for mod_reset_domain
- Fix conditional inclusion of notification_id for juno/reset_domain