### PR TITLE
FWU: synquacer: Add FWU Multi Bank Update and BL2 boot support

### DIFF
--- a/product/synquacer/include/efi.h
+++ b/product/synquacer/include/efi.h
@@ -1,0 +1,15 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef SYNQUACER_EFI_H
+#define SYNQUACER_EFI_H
+
+typedef struct {
+        uint8_t b[16];
+} efi_guid_t __attribute__((aligned(8)));
+
+#endif /* SYNQUACER_EFI_H */

--- a/product/synquacer/include/fwu_mdata.h
+++ b/product/synquacer/include/fwu_mdata.h
@@ -1,0 +1,74 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FWU_MDATA_H
+#define FWU_MDATA_H
+
+#include <efi.h>
+
+/*!
+ * \brief firmware image information
+ *
+ * \details The structure contains image specific fields which are
+ * used to identify the image and to specify the image's
+ * acceptance status
+ */
+struct fwu_image_bank_info {
+    /*! Guid value of the image in this bank */
+    efi_guid_t  image_uuid;
+
+    /*! Acceptance status of the image */
+    uint32_t accepted;
+
+    /*! Reserved */
+    uint32_t reserved;
+} __attribute__((__packed__));
+
+/*!
+ * \brief information for a particular type of image
+ *
+ * \details This structure contains information on various types of updatable
+ * firmware images. Each image type then contains an array of image
+ * information per bank.
+ */
+struct fwu_image_entry {
+    /*! Guid value for identifying the image type */
+    efi_guid_t image_type_uuid;
+
+    /*! Guid of the storage volume where the image is located */
+    efi_guid_t location_uuid;
+
+    /*! Array containing properties of images */
+    struct fwu_image_bank_info img_bank_info[CONFIG_FWU_NUM_BANKS];
+} __attribute__((__packed__));
+
+/*!
+ * \brief FWU metadata structure for multi-bank updates
+ *
+ * \details This structure is used to store all the needed information for
+ * performing multi bank updates on the platform. This contains info on the
+ * bank being used to boot along with the information needed for
+ * identification of individual images.
+ */
+struct fwu_mdata {
+    /*! crc32 value for the FWU metadata */
+    uint32_t crc32;
+
+    /*! FWU metadata version */
+    uint32_t version;
+
+    /*! Index of the bank currently used for booting images */
+    uint32_t active_index;
+
+    /*! Index of the bank used before the current bank being used for booting */
+    uint32_t previous_active_index;
+
+    /*! Array of information on various firmware images that can be updated */
+    struct fwu_image_entry img_entry[CONFIG_FWU_NUM_IMAGES_PER_BANK];
+} __attribute__((__packed__));
+
+#endif /* FWU_MDATA_H */

--- a/product/synquacer/include/synquacer_mmap.h
+++ b/product/synquacer/include/synquacer_mmap.h
@@ -172,6 +172,17 @@
                                      HSSPI_MEM_BASE)
 #define CONFIG_SCB_UEFI_BASE_ADDR UINT32_C(0xA8200000)
 
+/* FWU and platform metadata address */
+#define CONFIG_SCB_FWU_METADATA_OFFS        UINT32_C(0x500000)
+#define CONFIG_SCB_PLAT_METADATA_OFFS       UINT32_C(0x510000)
+#define CONFIG_SCB_FWU_BANK_SIZE            UINT32_C(0x400000)
+#define CONFIG_FWU_NUM_IMAGES_PER_BANK      1
+#define CONFIG_FWU_NUM_BANKS                2
+#define CONFIG_FWU_MAX_COUNT                3
+
+/* TBBR supported new FIP image offset */
+#define CONFIG_SCB_ARM_BL2_OFFSET           UINT32_C(0x600000)
+
 #define CONFIG_SCB_ARM_TB_BL1_BASE_ADDR UINT32_C(0xA4000000)
 #define CONFIG_SCB_ARM_TB_BL2_BASE_ADDR UINT32_C(0xA4013000)
 #define CONFIG_SCB_ARM_TB_BL3_BASE_ADDR UINT32_C(0xA401F000)


### PR DESCRIPTION
Add FWU Multi Bank Update and boot BL2 from FIP image support for
SynQuacer platform.

When the DSW 3-4 is on, SynQuacer platform will decode FWU metadata
and platform metadata to choose the active bank of the FIP image
and boot BL2 from it.

This also enables the platform trial boot, which count up the boot
counter in the platform metadata, and when it reaches to the limit
(== 3) it switch back to the previous active bank. This counter will
stop when the BL33 (typically U-Boot) clears the counter.

Signed-off-by: Jassi Brar <jaswinder.singh@linaro.org>
Signed-off-by: Masami Hiramatsu <masami.hiramatsu@linaro.org>
Signed-off-by: Masahisa Kojima <masahisa.kojima@linaro.org>
Change-Id: I00b9c932fac5b4a9a231fcf2a050b766abefed61