### PR TITLE
sensor: typedef included to give signed or unsigned value options

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -80,6 +80,7 @@ if(SCP_ENABLE_SCMI_SENSOR_V2)
     target_compile_definitions(framework PUBLIC "BUILD_HAS_SENSOR_TIMESTAMP")
     target_compile_definitions(framework PUBLIC "BUILD_HAS_SENSOR_MULTI_AXIS")
     target_compile_definitions(framework PUBLIC "BUILD_HAS_SENSOR_EXT_ATTRIBS")
+    target_compile_definitions(framework PUBLIC "BUILD_HAS_SENSOR_SIGNED_VALUE")
 endif()
 
 if(SCP_ENABLE_SENSOR_TIMESTAMP)
@@ -92,6 +93,10 @@ endif()
 
 if(SCP_ENABLE_SENSOR_EXT_ATTRIBS)
     target_compile_definitions(framework PUBLIC "BUILD_HAS_SENSOR_EXT_ATTRIBS")
+endif()
+
+if(SCP_ENABLE_SENSOR_SIGNED_VALUE)
+    target_compile_definitions(framework PUBLIC "BUILD_HAS_SENSOR_SIGNED_VALUE")
 endif()
 
 #

--- a/module/mock_sensor/include/mod_mock_sensor.h
+++ b/module/mock_sensor/include/mod_mock_sensor.h
@@ -39,7 +39,7 @@ struct mod_mock_sensor_dev_config {
     fwk_id_t alarm_id;
 
     /*! Sensor read value */
-    uint64_t *read_value;
+    mod_sensor_value_t *read_value;
 
 #ifdef BUILD_HAS_SCMI_SENSOR_V2
     /*! Pointer to sensor axis information */

--- a/module/mock_sensor/src/mod_mock_sensor.c
+++ b/module/mock_sensor/src/mod_mock_sensor.c
@@ -62,8 +62,7 @@ static void mock_sensor_callback(uintptr_t param)
 /*
  * Module API
  */
-
-static int get_value(fwk_id_t id, uint64_t *value)
+static int get_value(fwk_id_t id, mod_sensor_value_t *value)
 {
     struct mock_sensor_dev_ctx *ctx;
     int status;

--- a/module/reg_sensor/src/mod_reg_sensor.c
+++ b/module/reg_sensor/src/mod_reg_sensor.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -22,7 +22,7 @@ static struct mod_reg_sensor_dev_config **config_table;
 /*
  * Module API
  */
-static int get_value(fwk_id_t id, uint64_t *value)
+static int get_value(fwk_id_t id, mod_sensor_value_t *value)
 {
     struct mod_reg_sensor_dev_config *config;
 
@@ -33,7 +33,7 @@ static int get_value(fwk_id_t id, uint64_t *value)
         return FWK_E_PARAM;
     }
 
-    *value = *(uint64_t*)config->reg;
+    *value = *(mod_sensor_value_t *)config->reg;
 
     return FWK_SUCCESS;
 }

--- a/module/sensor/include/mod_sensor.h
+++ b/module/sensor/include/mod_sensor.h
@@ -139,6 +139,15 @@ struct mod_sensor_trip_point_info {
     uint32_t count;
 };
 
+/*!
+ * \brief Sensor value signedness type.
+ */
+#ifdef BUILD_HAS_SENSOR_SIGNED_VALUE
+typedef int64_t mod_sensor_value_t;
+#else
+typedef uint64_t mod_sensor_value_t;
+#endif
+
 #ifdef BUILD_HAS_SENSOR_EXT_ATTRIBS
 
 /*!
@@ -376,9 +385,9 @@ struct mod_sensor_data {
     /*! Sensor value */
     union {
         /*! Sensor N-axis value */
-        uint64_t *axis_value;
+        mod_sensor_value_t *axis_value;
         /*! Sensor scalar value */
-        uint64_t value;
+        mod_sensor_value_t value;
     };
 
 #ifdef BUILD_HAS_SENSOR_TIMESTAMP
@@ -415,14 +424,15 @@ struct mod_sensor_driver_api {
      * \brief Get sensor value.
      *
      * \param id Specific sensor device id.
-     * \param[out] value Sensor value.
+     * \param[out] value Sensor value, which can be either signed or
+     *     unsigned, depending upon the build options.
      *
      * \retval ::FWK_PENDING The request is pending. The driver will provide the
      *      requested value later through the driver response API.
      * \retval ::FWK_SUCCESS Value was read successfully.
      * \return One of the standard framework error codes.
      */
-    int (*get_value)(fwk_id_t id, uint64_t *value);
+    int (*get_value)(fwk_id_t id, mod_sensor_value_t *value);
 
     /*!
      * \brief Get sensor information.
@@ -588,12 +598,12 @@ struct mod_sensor_driver_resp_params {
     /*! Status of the requested operation */
     int status;
 
-    /*! Sensor value requested */
+    /*! Sensor value */
     union {
         /*! Sensor N-axis value */
-        uint64_t *axis_value;
+        mod_sensor_value_t *axis_value;
         /*! Sensor scalar value */
-        uint64_t value;
+        mod_sensor_value_t value;
     };
 };
 

--- a/module/sensor/src/mod_sensor.c
+++ b/module/sensor/src/mod_sensor.c
@@ -54,7 +54,7 @@ static inline void sensor_data_copy(
     const struct mod_sensor_data *origin)
 {
 #ifdef BUILD_HAS_SENSOR_MULTI_AXIS
-    uint64_t *value = dest->axis_value;
+    mod_sensor_value_t *value = dest->axis_value;
 #endif
 
     fwk_str_memcpy(dest, origin, sizeof(struct mod_sensor_data));

--- a/product/juno/module/juno_adc/src/mod_juno_adc.c
+++ b/product/juno/module/juno_adc/src/mod_juno_adc.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2019-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -26,8 +26,12 @@
 /*
  * ADC driver API functions.
  */
-static int get_value(fwk_id_t id, uint64_t *value)
+
+static int get_value(fwk_id_t id, mod_sensor_value_t *value)
 {
+#ifdef BUILD_HAS_SENSOR_SIGNED_VALUE
+    return FWK_E_SUPPORT;
+#else
     uint32_t adc_value;
     uint64_t adc_quantity;
     enum juno_adc_dev_type dev_type;
@@ -36,8 +40,8 @@ static int get_value(fwk_id_t id, uint64_t *value)
 
     switch ((enum juno_adc_sensor_type)fwk_id_get_element_idx(id)) {
     case ADC_TYPE_CURRENT:
-        adc_value = V2M_SYS_REGS->ADC_CURRENT[dev_type] &
-                    JUNO_ADC_SYS_REG_AMPS_MASK;
+        adc_value =
+            V2M_SYS_REGS->ADC_CURRENT[dev_type] & JUNO_ADC_SYS_REG_AMPS_MASK;
 
         adc_quantity = ((uint64_t)adc_value) * JUNO_ADC_AMPS_MULTIPLIER;
 
@@ -52,18 +56,19 @@ static int get_value(fwk_id_t id, uint64_t *value)
         return FWK_SUCCESS;
 
     case ADC_TYPE_VOLT:
-        adc_value = V2M_SYS_REGS->ADC_VOLT[dev_type] &
-                    JUNO_ADC_SYS_REG_VOLT_MASK;
+        adc_value =
+            V2M_SYS_REGS->ADC_VOLT[dev_type] & JUNO_ADC_SYS_REG_VOLT_MASK;
 
-        adc_quantity = (((uint64_t)adc_value) * JUNO_ADC_VOLT_MULTIPLIER)
-                          / ADC_VOLT_CONST;
+        adc_quantity =
+            (((uint64_t)adc_value) * JUNO_ADC_VOLT_MULTIPLIER) / ADC_VOLT_CONST;
+
         *value = adc_quantity;
 
         return FWK_SUCCESS;
 
     case ADC_TYPE_POWER:
-        adc_value = V2M_SYS_REGS->ADC_POWER[dev_type] &
-                    JUNO_ADC_SYS_REG_POWER_MASK;
+        adc_value =
+            V2M_SYS_REGS->ADC_POWER[dev_type] & JUNO_ADC_SYS_REG_POWER_MASK;
 
         adc_quantity = ((uint64_t)adc_value) * JUNO_ADC_WATTS_MULTIPLIER;
 
@@ -78,8 +83,8 @@ static int get_value(fwk_id_t id, uint64_t *value)
         return FWK_SUCCESS;
 
     case ADC_TYPE_ENERGY:
-        adc_quantity = V2M_SYS_REGS->ADC_ENERGY[dev_type] *
-            JUNO_ADC_JOULE_MULTIPLIER;
+        adc_quantity =
+            V2M_SYS_REGS->ADC_ENERGY[dev_type] * JUNO_ADC_JOULE_MULTIPLIER;
 
         if ((dev_type == ADC_DEV_BIG) || (dev_type == ADC_DEV_GPU)) {
             adc_quantity /= ADC_ENERGY_CONST1;
@@ -94,6 +99,7 @@ static int get_value(fwk_id_t id, uint64_t *value)
     default:
         return FWK_E_PARAM;
     }
+#endif
 }
 
 static int get_info(fwk_id_t id, struct mod_sensor_info *info)

--- a/product/juno/module/juno_pvt/src/mod_juno_pvt.c
+++ b/product/juno/module/juno_pvt/src/mod_juno_pvt.c
@@ -390,8 +390,11 @@ static int get_info(fwk_id_t id, struct mod_sensor_info *info)
     return FWK_SUCCESS;
 }
 
-static int get_value(fwk_id_t id, uint64_t *value)
+static int get_value(fwk_id_t id, mod_sensor_value_t *value)
 {
+#ifdef BUILD_HAS_SENSOR_SIGNED_VALUE
+    return FWK_E_SUPPORT;
+#else
     uint8_t elt_idx;
     struct pvt_dev_ctx *group_ctx;
     struct fwk_event read_req;
@@ -430,6 +433,7 @@ static int get_value(fwk_id_t id, uint64_t *value)
     }
 
     return status;
+#endif
 }
 
 static const struct mod_sensor_driver_api pvt_sensor_api = {

--- a/product/juno/module/juno_xrp7724/src/mod_juno_xrp7724.c
+++ b/product/juno/module/juno_xrp7724/src/mod_juno_xrp7724.c
@@ -283,8 +283,11 @@ static const struct mod_juno_xrp7724_api_system_mode system_mode_api = {
 /*
  * Driver functions for the sensor API
  */
-static int juno_xrp7724_sensor_get_value(fwk_id_t id, uint64_t *value)
+static int juno_xrp7724_sensor_get_value(fwk_id_t id, mod_sensor_value_t *value)
 {
+#ifdef BUILD_HAS_SENSOR_SIGNED_VALUE
+    return FWK_E_SUPPORT;
+#else
     int status;
     struct fwk_event event;
 
@@ -306,6 +309,7 @@ static int juno_xrp7724_sensor_get_value(fwk_id_t id, uint64_t *value)
     }
 
     return FWK_PENDING;
+#endif
 }
 
 static int juno_xrp7724_sensor_get_info(fwk_id_t id,

--- a/product/morello/module/morello_sensor/src/mod_morello_sensor.c
+++ b/product/morello/module/morello_sensor/src/mod_morello_sensor.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -105,8 +105,11 @@ static void morello_sensor_timer_callback(uintptr_t unused)
 /*
  * Module API
  */
-static int get_value(fwk_id_t element_id, uint64_t *value)
+static int get_value(fwk_id_t element_id, mod_sensor_value_t *value)
 {
+#ifdef BUILD_HAS_SENSOR_SIGNED_VALUE
+    return FWK_E_SUPPORT;
+#else
     struct morello_temp_sensor_ctx *t_dev_ctx;
     struct morello_volt_sensor_ctx *v_dev_ctx;
     unsigned int el_idx;
@@ -145,6 +148,7 @@ static int get_value(fwk_id_t element_id, uint64_t *value)
     *value = (uint64_t)buf_value;
 
     return FWK_SUCCESS;
+#endif
 }
 
 static const struct mod_sensor_driver_api morello_sensor_api = {

--- a/product/n1sdp/module/n1sdp_sensor/src/mod_n1sdp_sensor.c
+++ b/product/n1sdp/module/n1sdp_sensor/src/mod_n1sdp_sensor.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -87,8 +87,11 @@ static void n1sdp_sensor_timer_callback(uintptr_t unused)
 /*
  * Module API
  */
-static int get_value(fwk_id_t element_id, uint64_t *value)
+static int get_value(fwk_id_t element_id, mod_sensor_value_t *value)
 {
+#ifdef BUILD_HAS_SENSOR_SIGNED_VALUE
+    return FWK_E_SUPPORT;
+#else
     struct n1sdp_temp_sensor_ctx *t_dev_ctx;
     struct n1sdp_volt_sensor_ctx *v_dev_ctx;
     unsigned int id;
@@ -125,6 +128,7 @@ static int get_value(fwk_id_t element_id, uint64_t *value)
     *value = (uint64_t)buf_value;
 
     return FWK_SUCCESS;
+#endif
 }
 
 static int get_info(fwk_id_t element_id, struct mod_sensor_info *info)

--- a/product/rcar/module/rcar_reg_sensor/src/mod_rcar_reg_sensor.c
+++ b/product/rcar/module/rcar_reg_sensor/src/mod_rcar_reg_sensor.c
@@ -1,6 +1,6 @@
 /*
  * Renesas SCP/MCP Software
- * Copyright (c) 2020-2021, Renesas Electronics Corporation. All rights
+ * Copyright (c) 2020-2022, Renesas Electronics Corporation. All rights
  * reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
@@ -111,8 +111,11 @@ static int rcar_gen3_thermal_get_temp(void *devdata, int *temp)
 /*
  * Module API
  */
-static int get_value(fwk_id_t id, uint64_t *value)
+static int get_value(fwk_id_t id, mod_sensor_value_t *value)
 {
+#ifdef BUILD_HAS_SENSOR_SIGNED_VALUE
+    return FWK_E_SUPPORT;
+#else
     int tmp = 0;
     int64_t *ivalue;
 
@@ -128,6 +131,7 @@ static int get_value(fwk_id_t id, uint64_t *value)
     *ivalue = (int64_t)tmp;
 
     return FWK_SUCCESS;
+#endif
 }
 
 static int get_info(fwk_id_t id, struct mod_sensor_info *info)

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -59,7 +59,7 @@ memleak:*framework/test/fwk_test.c:145
 // dereference can only occur if the check succeeds
 nullPointerRedundantCheck:*framework/src/fwk_io.c
 nullPointerRedundantCheck:*product/sgm775/module/sgm775_dmc500/src/mod_sgm775_dmc500.c:78
-nullPointerRedundantCheck:*product/rcar/module/rcar_reg_sensor/src/mod_rcar_reg_sensor.c:143
+nullPointerRedundantCheck:*product/rcar/module/rcar_reg_sensor/src/mod_rcar_reg_sensor.c:147
 nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:60
 nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:61
 nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:65


### PR DESCRIPTION
The changes in this patch are to introduce a typedef, which will
allow either signed or unsigned sensor values. This new typedef is
used to be able to conditionally support int64, allowing the
introduction of negative value sensors.

It will be automatically enabled with SCMI-sensor-v2, however it
can also be enabled on its own using with the cmake tag
SCP_ENABLE_SENSOR_SIGNED_VALUE.

Existing platforms that cannot handle signed values will return
FWK_E_SUPPORT when the above build options are set.

Signed-off-by: Katherine Vincent <katherine.vincent@arm.com>
Change-Id: I0f24e31d4bc3861b1724d814e866ef97f09c4b88