### PR TITLE
readme: Update SCMI reference to v3.1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ References
 [1] Power Control System Architecture - DEN0050C (Please contact Arm directly to
 obtain a copy of this document)
 
-[2] [System Control and Management Interface - DEN0056A](https://developer.arm.com/documentation/den0056/a/)
+[2] [System Control and Management Interface - DEN0056A](https://developer.arm.com/documentation/den0056/d/)
 
 [3] Power Policy Unit - DEN0051C (Please contact Arm directly to obtain a copy
 of this document)


### PR DESCRIPTION
Update readme.md so that the reference to SCMI points to v3.1 instead of v1.0.

Signed-off-by: Chuyue Luo <Chuyue.Luo@arm.com>
Change-Id: I85d04d53b1da3c45f58c15f1524c6e9e4ad07a03