### PR TITLE
fwk: Return a value from a non-void function

### DIFF
--- a/arch/none/host/include/arch_helpers.h
+++ b/arch/none/host/include/arch_helpers.h
@@ -22,6 +22,7 @@ inline static void arch_interrupts_enable(unsigned int not_used)
  */
 inline static unsigned int arch_interrupts_disable(void)
 {
+    return 0;
 }
 
 /*!


### PR DESCRIPTION
Some compilers complain the return type error as below.

 | arch/none/host/include/arch_helpers.h: In function ‘arch_interrupts_disable’:
 | arch/none/host/include/arch_helpers.h:25:1: error: no return statement in
 |	function returning non-void [-Werror=return-type]

Fix the same.

Change-Id: Ia3343fbbea57ae783b272f0c4db05a7060256f85
Signed-off-by: Sudeep Holla <sudeep.holla@arm.com>