### PR TITLE
Enable CPPC on cmake build and update SCMI perf configuration.

### DIFF
--- a/product/rdn2/scp_ramfw/CMakeLists.txt
+++ b/product/rdn2/scp_ramfw/CMakeLists.txt
@@ -62,6 +62,10 @@ target_sources(
             "${CMAKE_CURRENT_SOURCE_DIR}/config_apremap.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_power_domain.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_platform_system.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mock_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dvfs.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_perf.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_pl011.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c")

--- a/product/rdn2/scp_ramfw/Firmware.cmake
+++ b/product/rdn2/scp_ramfw/Firmware.cmake
@@ -24,6 +24,8 @@ set(SCP_ARCHITECTURE "arm-m")
 
 set(SCP_ENABLE_NEWLIB_NANO FALSE)
 
+set(SCP_ENABLE_FAST_CHANNELS TRUE)
+
 list(PREPEND SCP_MODULE_PATHS
      "${CMAKE_CURRENT_LIST_DIR}/../module/platform_system")
 list(PREPEND SCP_MODULE_PATHS
@@ -62,3 +64,7 @@ list(APPEND SCP_MODULES "power-domain")
 list(APPEND SCP_MODULES "scmi-power-domain")
 list(APPEND SCP_MODULES "scmi-system-power")
 list(APPEND SCP_MODULES "platform-system")
+list(APPEND SCP_MODULES "psu")
+list(APPEND SCP_MODULES "mock-psu")
+list(APPEND SCP_MODULES "dvfs")
+list(APPEND SCP_MODULES "scmi-perf")

--- a/product/rdn2/scp_ramfw/config_scmi_perf.c
+++ b/product/rdn2/scp_ramfw/config_scmi_perf.c
@@ -107,6 +107,7 @@ static const struct mod_scmi_perf_domain_config domains[4] = { 0 };
 const struct fwk_module_config config_scmi_perf = {
     .data = &((struct mod_scmi_perf_config){
         .domains = &domains,
+        .perf_doms_count = FWK_ARRAY_SIZE(domains),
 #ifdef BUILD_HAS_SCMI_PERF_FAST_CHANNELS
         .fast_channels_alarm_id = FWK_ID_SUB_ELEMENT_INIT(
             FWK_MODULE_IDX_TIMER,

--- a/product/rdv1/scp_ramfw/CMakeLists.txt
+++ b/product/rdv1/scp_ramfw/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -37,6 +37,10 @@ target_sources(
             "config_clock.c"
             "config_apcontext.c"
             "config_scmi_power_domain.c"
+            "config_psu.c"
+            "config_mock_psu.c"
+            "config_dvfs.c"
+            "config_scmi_perf.c"
             "../src/config_system_info.c"
             "../src/config_pl011.c"
             "../src/config_sid.c")

--- a/product/rdv1/scp_ramfw/Firmware.cmake
+++ b/product/rdv1/scp_ramfw/Firmware.cmake
@@ -19,6 +19,8 @@ set(SCP_ENABLE_NOTIFICATIONS TRUE)
 
 set(SCP_ENABLE_IPO_INIT FALSE)
 
+set(SCP_ENABLE_FAST_CHANNELS TRUE)
+
 list(PREPEND SCP_MODULE_PATHS
      "${CMAKE_CURRENT_LIST_DIR}/../module/platform_system")
 
@@ -52,3 +54,7 @@ list(APPEND SCP_MODULES "power-domain")
 list(APPEND SCP_MODULES "scmi-power-domain")
 list(APPEND SCP_MODULES "scmi-system-power")
 list(APPEND SCP_MODULES "platform-system")
+list(APPEND SCP_MODULES "psu")
+list(APPEND SCP_MODULES "mock-psu")
+list(APPEND SCP_MODULES "dvfs")
+list(APPEND SCP_MODULES "scmi-perf")

--- a/product/rdv1/scp_ramfw/config_scmi_perf.c
+++ b/product/rdv1/scp_ramfw/config_scmi_perf.c
@@ -95,6 +95,7 @@ static const struct mod_scmi_perf_domain_config domains[16] = { 0 };
 const struct fwk_module_config config_scmi_perf = {
     .data = &((struct mod_scmi_perf_config){
         .domains = &domains,
+        .perf_doms_count = FWK_ARRAY_SIZE(domains),
 #ifdef BUILD_HAS_SCMI_PERF_FAST_CHANNELS
         .fast_channels_alarm_id = FWK_ID_SUB_ELEMENT_INIT(
             FWK_MODULE_IDX_TIMER,

--- a/product/rdv1mc/scp_ramfw/CMakeLists.txt
+++ b/product/rdv1mc/scp_ramfw/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -37,6 +37,10 @@ target_sources(
             "${CMAKE_CURRENT_SOURCE_DIR}/config_css_clock.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_clock.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_apcontext.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_mock_psu.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_dvfs.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/config_scmi_perf.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_system_info.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_pl011.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/../src/config_sid.c")

--- a/product/rdv1mc/scp_ramfw/Firmware.cmake
+++ b/product/rdv1mc/scp_ramfw/Firmware.cmake
@@ -23,6 +23,8 @@ set(SCP_ENABLE_IPO_INIT FALSE)
 
 set(SCP_ARCHITECTURE "arm-m")
 
+set(SCP_ENABLE_FAST_CHANNELS TRUE)
+
 list(PREPEND SCP_MODULE_PATHS
      "${CMAKE_CURRENT_LIST_DIR}/../module/platform_system")
 
@@ -56,3 +58,7 @@ list(APPEND SCP_MODULES "power-domain")
 list(APPEND SCP_MODULES "scmi-power-domain")
 list(APPEND SCP_MODULES "scmi-system-power")
 list(APPEND SCP_MODULES "platform-system")
+list(APPEND SCP_MODULES "psu")
+list(APPEND SCP_MODULES "mock-psu")
+list(APPEND SCP_MODULES "dvfs")
+list(APPEND SCP_MODULES "scmi-perf")

--- a/product/rdv1mc/scp_ramfw/config_scmi_perf.c
+++ b/product/rdv1mc/scp_ramfw/config_scmi_perf.c
@@ -71,6 +71,7 @@ static const struct mod_scmi_perf_domain_config domains[4] = { 0 };
 const struct fwk_module_config config_scmi_perf = {
     .data = &((struct mod_scmi_perf_config){
         .domains = &domains,
+        .perf_doms_count = FWK_ARRAY_SIZE(domains),
 #ifdef BUILD_HAS_SCMI_PERF_FAST_CHANNELS
         .fast_channels_alarm_id = FWK_ID_SUB_ELEMENT_INIT(
             FWK_MODULE_IDX_TIMER,


### PR DESCRIPTION
This patch series enable CPPC support with cmake build system. This series also fixup the performance domain count in the configuration data.