### PR TITLE
ci: add build for each log level

### DIFF
--- a/tools/ci_cmake.py
+++ b/tools/ci_cmake.py
@@ -151,7 +151,8 @@ def check_errors(ignore_errors: bool, results: List[Tuple[str, int]]) -> bool:
                                                  results)))
 
 
-def main(ignore_errors: bool, output_path: str, skip_container: bool):
+def main(ignore_errors: bool, skip_container: bool, log_level: str,
+         output_path: str):
     # This code is only applicable if there is valid docker instance
     # On CI there is no docker instance at the moment
     if not skip_container:
@@ -184,6 +185,8 @@ def main(ignore_errors: bool, output_path: str, skip_container: bool):
     output_path = os.path.join(output_path, "build-output")
 
     for product in products:
+        if log_level != "":
+            product.log_level = Parameter(log_level)
         results.extend(do_build(product.builds, output_path))
         if check_errors(ignore_errors, results):
             print('Errors detected! Excecution stopped')
@@ -201,6 +204,11 @@ def parse_args():
                         required=False, default=False, action='store_true',
                         help='Ignore errors and continue testing.')
 
+    parser.add_argument('-ll', '--log-level', dest='log_level',
+                        required=False, default="", type=str,
+                        action='store', help='Build every product with the \
+                        specified log level.')
+
     parser.add_argument('-bod', '--build-output-dir', dest='output_path',
                         required=False, default="", type=str, action='store',
                         help='Parent directory of the "build-output" directory\
@@ -217,4 +225,5 @@ def parse_args():
 
 if __name__ == "__main__":
     args = parse_args()
-    sys.exit(main(args.ignore_errors, args.output_path, args.skip_container))
+    sys.exit(main(args.ignore_errors, args.skip_container, args.log_level,
+                  args.output_path))

--- a/tools/product.py
+++ b/tools/product.py
@@ -27,6 +27,7 @@ class Build:
     name: str
     toolchain: Parameter
     build_type: Parameter
+    log_level: Parameter
     variant: Parameter = None
 
     def tag(self):
@@ -34,15 +35,19 @@ class Build:
                                                         self.name,
                                                         self.toolchain.name,
                                                         self.build_type.name)
-        if (self.variant):
+        if self.variant:
             build_str += ' - Variant {}'.format(self.variant.name)
+        if self.log_level:
+            build_str += ' - Log Level {}'.format(self.log_level.name)
         return build_str
 
     def file_name(self):
         filename = self.name + "_" + self.toolchain.name + "_" + \
             self.build_type.name[0]
+        if self.log_level:
+            filename += "_" + self.log_level.name
         if self.variant:
-            filename += self.variant.name[0]
+            filename += "_" + self.variant.name[0]
         filename += ".txt"
         return filename
 
@@ -51,6 +56,8 @@ class Build:
         cmd += 'PRODUCT={} TOOLCHAIN={} MODE={} '.format(self.name,
                                                          self.toolchain.name,
                                                          self.build_type.name)
+        if self.log_level:
+            cmd += 'LOG_LEVEL={} '.format(self.log_level.name)
         if self.variant:
             cmd += 'PLATFORM_VARIANT=\"{}\" '.format(self.variant.name)
             for extra in self.variant.arguments:
@@ -82,23 +89,19 @@ class Product:
         Parameter('debug'),
         Parameter('release'),
         ])
-    variants: List[Parameter] = field(default_factory=list)
+    variants: List[Parameter] = field(default_factory=lambda: [None])
+    log_level: Parameter = None
 
     @property
     def builds(self) -> List[Build]:
         builds = []
         for toolchain in self.toolchains:
             for build_type in self.build_types:
-                if self.variants:
-                    for variant in self.variants:
-                        builds.append(Build(
-                            self.name,
-                            toolchain,
-                            build_type,
-                            variant))
-                else:
+                for variant in self.variants:
                     builds.append(Build(
                         self.name,
                         toolchain,
-                        build_type))
+                        build_type,
+                        self.log_level,
+                        variant))
         return builds


### PR DESCRIPTION
The CI is only testing the build for the default log
level.
Add a parameter "ll" (log-level) to test the builds
with a specified log level.
This is done so that multiple runs of the ci_cmake
tests can be done in parallel by calling this script
multiple times with the different log levels.
These changes are done while improving the readability
of the constructor calls of Build() with the different optional
parameters.

Signed-off-by: Tomás Agustín González Orlando <tomasagustin.gonzalezorlando@arm.com>
Change-Id: I30004a65194618237643464b19337bafdde26610