### PR TITLE
Include support for Armv8m in CI tests

### DIFF
--- a/arch/arm/arm-m/CMakeLists.txt
+++ b/arch/arm/arm-m/CMakeLists.txt
@@ -12,7 +12,8 @@ add_library(arch-arm-m)
 # the used CPU
 #
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m(33|55)")
+if((CMAKE_SYSTEM_PROCESSOR MATCHES "cortex-m(33|55)")
+                           OR (CMAKE_SYSTEM_ARCH MATCHES "armv8(\.1)?-m"))
     target_compile_definitions(arch-arm-m PUBLIC "ARMV8M")
 else()
     target_compile_definitions(arch-arm-m PUBLIC "ARMV7M")

--- a/cmake/Toolchain/Clang-Base.cmake
+++ b/cmake/Toolchain/Clang-Base.cmake
@@ -6,15 +6,15 @@
 #
 
 set(CMAKE_ASM_COMPILER
-    clang-11
+    clang-13
     CACHE FILEPATH "Path to the assembler.")
 set(CMAKE_C_COMPILER
-    clang-11
+    clang-13
     CACHE FILEPATH "Path to the C compiler.")
 set(CMAKE_CXX_COMPILER
-    clang-11
+    clang-13
     CACHE FILEPATH "Path to the C++ compiler.")
 
 set(CMAKE_OBJCOPY
-    llvm-objcopy-11
+    llvm-objcopy-13
     CACHE FILEPATH "Path to objcopy tool.")

--- a/product/rdfremont/lcp_ramfw/Toolchain-ArmClang.cmake
+++ b/product/rdfremont/lcp_ramfw/Toolchain-ArmClang.cmake
@@ -9,7 +9,8 @@
 
 include_guard()
 
-set(CMAKE_SYSTEM_PROCESSOR "cortex-m55+nodsp")
+# No Helium, no FPU, No DSP features
+set(CMAKE_SYSTEM_ARCH "armv8.1-m.main")
 
 set(CMAKE_ASM_COMPILER_TARGET "arm-arm-none-eabi")
 set(CMAKE_C_COMPILER_TARGET "arm-arm-none-eabi")

--- a/tools/ci_cmake.py
+++ b/tools/ci_cmake.py
@@ -49,6 +49,7 @@ products = [
     Product('tc1'),
     Product('rcar', toolchains=[Parameter('GNU')]),
     Product('rdn2', variants=[Parameter('0')]),
+    Product('rdfremont'),
 ]
 
 


### PR DESCRIPTION
This PR includes:
1) Workaround Armclang issue with cmake versions older than 3.21
2) Updating used LLVM version to 13 to support cortex-m55
3) Adding rdfremont target (which includes a cortex-m55 target) to CI tests