### PR TITLE
product/rdn2: add support for RD-Edmunds platform variant

### DIFF
--- a/product/rdn2/src/config_sid.c
+++ b/product/rdn2/src/config_sid.c
@@ -23,6 +23,11 @@ static const struct fwk_element subsystem_table[] = {
               .part_number = 0x7B6,
 #endif
           } },
+    { .name = "RD-Edmunds",
+      .data =
+          &(struct mod_sid_subsystem_config){
+              .part_number = 0x7F2,
+          } },
     { 0 },
 };
 


### PR DESCRIPTION
Add support for RD-Edmunds platform variant. This variant and the RD-N2
platform share the same variant number, that is 0, but have different
part numbers. So add a new element in the SID module configuration to
support the RD-Edmunds part number as well.

Signed-off-by: Tony K Nadackal <tony.nadackal@arm.com>
Change-Id: I848367b1025308e094f71a2ad6f7f8ed853aeb17