### PR TITLE
ci_cmake: adds variant 1 and 2 for RDN2

### DIFF
--- a/tools/ci_cmake.py
+++ b/tools/ci_cmake.py
@@ -48,7 +48,7 @@ products = [
     Product('tc0', variants=[Parameter('0'), Parameter('1')]),
     Product('tc1'),
     Product('rcar', toolchains=[Parameter('GNU')]),
-    Product('rdn2', variants=[Parameter('0')]),
+    Product('rdn2', variants=[Parameter('0'), Parameter('1'), Parameter('2')]),
     Product('rdfremont'),
 ]
 


### PR DESCRIPTION
This patch adds missing variants in `ci_cmake.py` script
for RDN2.

Signed-off-by: Leandro Belli <leandro.belli@arm.com>
Change-Id: I6f5fb512cc7f2fc62d3586f259ee3c536ac24094