### PR TITLE
Fix number of PCIe enabled IO-Macros for RD-N2-Cfg1

### DIFF
--- a/product/rdn2/scp_ramfw/config_pcie_integ_ctrl.c
+++ b/product/rdn2/scp_ramfw/config_pcie_integ_ctrl.c
@@ -61,16 +61,14 @@ static const struct fwk_element pcie_integ_ctrl_element_table[] = {
         AP_PCIE_MMIOL_SIZE_PER_RC,
         AP_PCIE_MMIOH_SIZE_PER_RC),
 
-#if (PLATFORM_VARIANT == 0 || PLATFORM_VARIANT == 1)
+#if (PLATFORM_VARIANT == 0)
     IO_MACRO_ELEMENT_CONFIG(
         1,
         PCIE_INTEG_CTRL_REG_BASE(1),
         AP_PCIE_ECAM_SIZE_PER_RC,
         AP_PCIE_MMIOL_SIZE_PER_RC,
         AP_PCIE_MMIOH_SIZE_PER_RC),
-#endif
 
-#if (PLATFORM_VARIANT == 0)
     IO_MACRO_ELEMENT_CONFIG(
         2,
         PCIE_INTEG_CTRL_REG_BASE(2),


### PR DESCRIPTION
On RD-N2-Cfg1 (variant 1), non-pcie devices are behind the IO Macro #1. The PCIe devices are only behind IO Macro#0.
So remove initialization of PCIe configurations for IO Macro #1.