### PR TITLE
cmn700: fix SYS_CACHE_GRP_SN_NODEID calculation

### DIFF
--- a/module/cmn700/include/internal/cmn700_ctx.h
+++ b/module/cmn700/include/internal/cmn700_ctx.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -30,7 +30,6 @@ struct cmn700_device_ctx {
     uintptr_t *hnf_node;
 
     uint64_t *hnf_cache_group;
-    uint64_t *sn_nodeid_group;
 
     /*
      * External RN-SAMs. The driver keeps a list of tuples (node identifier and

--- a/module/cmn700/src/mod_cmn700.c
+++ b/module/cmn700/src/mod_cmn700.c
@@ -535,7 +535,6 @@ static int cmn700_setup_sam(struct cmn700_rnsam_reg *rnsam)
     unsigned int cxra_ldid;
     unsigned int cxra_node_id;
     unsigned int group;
-    unsigned int group_count;
     unsigned int hnf_count;
     unsigned int hnf_count_in_scg;
     unsigned int hnf_count_per_cluster;
@@ -649,7 +648,7 @@ static int cmn700_setup_sam(struct cmn700_rnsam_reg *rnsam)
                         if (hnf_nodeid % 2 == 0) {
                             rnsam->SYS_CACHE_GRP_HN_NODEID[group] +=
                                 (uint64_t)hnf_nodeid << bit_pos;
-                            ctx->sn_nodeid_group[group] +=
+                            rnsam->SYS_CACHE_GRP_SN_NODEID[group] +=
                                 ((uint64_t)config->snf_table[logical_id])
                                 << bit_pos;
                             hnf_count_in_scg++;
@@ -658,7 +657,7 @@ static int cmn700_setup_sam(struct cmn700_rnsam_reg *rnsam)
                     } else {
                         rnsam->SYS_CACHE_GRP_HN_NODEID[group] +=
                             (uint64_t)hnf_nodeid << bit_pos;
-                        ctx->sn_nodeid_group[group] +=
+                        rnsam->SYS_CACHE_GRP_SN_NODEID[group] +=
                             ((uint64_t)config->snf_table[logical_id])
                             << bit_pos;
                         hnf_count_in_scg++;
@@ -755,17 +754,7 @@ static int cmn700_setup_sam(struct cmn700_rnsam_reg *rnsam)
             rnsam->SYS_CACHE_GRP_CAL_MODE |= scg_regions_enabled[region_idx] *
                 (CMN700_RNSAM_SCG_HNF_CAL_MODE_EN
                  << (region_idx * CMN700_RNSAM_SCG_HNF_CAL_MODE_SHIFT));
-
-    /* Program the SYS_CACHE_GRP_SN_NODEID register for PrefetchTgt */
-        group_count = config->snf_count /
-            (CMN700_RNSAM_SYS_CACHE_GRP_SN_NODEID_ENTRIES_PER_GROUP * 2);
-    } else {
-        group_count = config->snf_count /
-            CMN700_RNSAM_SYS_CACHE_GRP_SN_NODEID_ENTRIES_PER_GROUP;
     }
-
-    for (group = 0; group < group_count; group++)
-        rnsam->SYS_CACHE_GRP_SN_NODEID[group] = ctx->sn_nodeid_group[group];
 
     /* Hierarchical Hashing support */
     if (config->hierarchical_hashing_enable) {
@@ -857,10 +846,6 @@ static int cmn700_setup(void)
             ctx->hnf_cache_group = fwk_mm_calloc(
                 cmn700_hnf_cache_group_count(ctx->hnf_count),
                 sizeof(*ctx->hnf_cache_group));
-            ctx->sn_nodeid_group = fwk_mm_calloc(
-                ctx->hnf_count /
-                    CMN700_RNSAM_SYS_CACHE_GRP_SN_NODEID_ENTRIES_PER_GROUP,
-                sizeof(*ctx->sn_nodeid_group));
         }
 
         /* Allocate resource for the CCG nodes */


### PR DESCRIPTION
Every internal RN-SAM node has 32 SYS_CACHE_GRP_SN_NODEID registers to
store corresponding SNF ids. Each SYS_CACHE_GRP_SN_NODEID register
targets four SN node IDs. Previously, the value for each register was
calculated iteratively and was stored in the sn_nodeid_group[group]
array temporarily. Once the entire calculation was over, the contents of
the array were assigned to the corresponding SYS_CACHE_GRP_SN_NODEID
registers.

The values in the sn_nodeid_group[group] array were not cleared before
the calculation of the next RN-SAM nodes. This caused incorrect
calculation of the SYS_CACHE_GRP_SN_NODEID register values for the next
RN-SAM nodes.

To fix this, this patch directly calculates SYS_CACHE_GRP_SN_NODEID
values for each cache group from the values in the snf_table array. The
array sn_nodeid group is removed from the device context since it is no
longer used for SYS_CACHE_GRP_SN_NODEID calculation.

Change-Id: Ic9dc4b4520c09aad4589576b9eeb644e68e8afb3
Signed-off-by: Tony K Nadackal <tony.nadackal@arm.com>