### PR TITLE
morello: Updated the RTT_PARK setting for dual rank DIMM

### DIFF
--- a/product/morello/module/dmc_bing/src/mod_dmc_bing.c
+++ b/product/morello/module/dmc_bing/src/mod_dmc_bing.c
@@ -851,8 +851,13 @@ static int direct_ddr_cmd(struct mod_dmc_bing_reg *dmc)
 
     addr = addr & 0xFFFFFF7F;
     execute_ddr_cmd(dmc, addr, ((ddr_info.ranks_to_train << 16) | 0x0601), 1);
-    execute_ddr_cmd(
-        dmc, 0x00000180, ((ddr_info.ranks_to_train << 16) | 0x0501), 0);
+    if (ddr_info.number_of_ranks == 1) {
+        execute_ddr_cmd(
+            dmc, 0x00000180, ((ddr_info.ranks_to_train << 16) | 0x0501), 0);
+    } else {
+        execute_ddr_cmd(
+            dmc, 0x00000100, ((ddr_info.ranks_to_train << 16) | 0x0501), 0);
+    }
     execute_ddr_cmd(
         dmc, 0x00000000, ((ddr_info.ranks_to_train << 16) | 0x0401), 0);
 


### PR DESCRIPTION
Morello SoC supports 32 GB dual rank DIMMs. To support
this, the RTT_PARK value is updated to work with the dual
rank DIMMs.

Signed-off-by: Chandni Cherukuri <chandni.cherukuri@arm.com>
Change-Id: I85c442a618163a6b4e8de88c9e512f4733b773fd