### PR TITLE
mod_timer: Add clarifying comments

### DIFF
--- a/module/timer/include/mod_timer.h
+++ b/module/timer/include/mod_timer.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -91,13 +91,25 @@ struct mod_timer_driver_api {
     /*! Name of the driver. */
     const char *name;
 
-    /*! Enable timer events */
+    /*!
+     * Enable timer events
+     * It is expected that the driver enables the timer's interrupt
+     * source (i.e. using the timer's registers) within this function.
+     */
     int (*enable)(fwk_id_t dev_id);
 
-    /*! Disable timer events */
+    /*!
+     * Disable timer events
+     * It is expected that the driver disables the timer's interrupt
+     * source (i.e.using the timer's registers) within this function.
+     */
     int (*disable)(fwk_id_t dev_id);
 
-    /*! Set timer event for a specified timestamp */
+    /*!
+     * Set timer event for a specified timestamp
+     * The timer HAL clears the interrupt via the framework interrupt interface.
+     * So it is expected from the timer driver to set the timer value only.
+     */
     int (*set_timer)(fwk_id_t dev_id, uint64_t timestamp);
 
     /*! Get remaining time until the next pending timer event is due to fire */


### PR DESCRIPTION
The timer module depends on the timer driver to enable and
disable the timer's interrupt source, however the timer module is
the one that clears the interrupt flag.

This behavior is explained in the timer driver API to avoid
ambiguity for timer driver developers.

Signed-off-by: Ahmed Gadallah <ahmed.gadallah@arm.com>
Change-Id: I982a9bffd3618c6b514e280e4601d4a58a9ce34a