### PR TITLE
product/rdn2: update base address of expansion block

### DIFF
--- a/product/rdn2/scp_ramfw/config_cmn700.c
+++ b/product/rdn2/scp_ramfw/config_cmn700.c
@@ -430,9 +430,9 @@ static const struct mod_cmn700_mem_region_map mmap[] = {
     {
         /*
          * Non-PCIe IO Macro
-         * Map: 0xC000_0000_0000 - 0xC000_3FFF_FFFF (1 GB)
+         * Map: 0x10_8000_0000 - 0x10_BFFF_FFFF (1 GB)
          */
-        .base = UINT64_C(0xC00000000000),
+        .base = UINT64_C(0x1080000000),
         .size = UINT64_C(1) * FWK_GIB,
         .type = MOD_CMN700_MEM_REGION_TYPE_IO,
         .node_id = NODE_ID_NON_PCIE_IO_MACRO,

--- a/product/rdn2/scp_ramfw/config_pcie_integ_ctrl.c
+++ b/product/rdn2/scp_ramfw/config_pcie_integ_ctrl.c
@@ -92,29 +92,29 @@ static const struct fwk_element pcie_integ_ctrl_element_table[] = {
             .x4_0_ecam_mmio_mmap = {
                 .valid = true,
                 .allow_ns_access = true,
-                .mmioh_start_addr = 0xC00000000000,
-                .mmioh_end_addr = 0xC0000040FFFF,
+                .mmioh_start_addr = 0x1080000000,
+                .mmioh_end_addr = 0x108040FFFF,
             },
-            /* PL330_DMA0_NS (64 KB) and PL330_DMA0_NS (64 KB) */
+            /* PL330_DMA0_NS (64 KB) and PL330_DMA0_S (64 KB) */
             .x4_1_ecam_mmio_mmap = {
                 .valid = true,
                 .allow_ns_access = true,
-                .mmioh_start_addr = 0xC00010000000,
-                .mmioh_end_addr = 0xC0001001FFFF,
+                .mmioh_start_addr = 0x1090000000,
+                .mmioh_end_addr = 0x109001FFFF,
             },
             /* PL011_UART1 (64 KB) */
             .x8_ecam_mmio_mmap = {
                 .valid = true,
                 .allow_ns_access = true,
-                .mmioh_start_addr = 0xC00020000000,
-                .mmioh_end_addr = 0xC0002000FFFF,
+                .mmioh_start_addr = 0x10A0000000,
+                .mmioh_end_addr = 0x10A000FFFF,
             },
-            /* PL330_DMA0_NS (64 KB), PL330_DMA0_NS(64 KB) and MEM1 (4 MB) */
+            /* PL330_DMA0_NS (64 KB), PL330_DMA0_S(64 KB) and MEM1 (4 MB) */
             .x16_ecam_mmio_mmap = {
                 .valid = true,
                 .allow_ns_access = true,
-                .mmioh_start_addr = 0xC00030000000,
-                .mmioh_end_addr = 0xC0003041FFFF,
+                .mmioh_start_addr = 0x10B0000000,
+                .mmioh_end_addr = 0x10B041FFFF,
             },
             .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK,
                 CLOCK_IDX_INTERCONNECT),


### PR DESCRIPTION
Update the base address of the SoC expansion block from 0xC000_0000_0000
to 0x10_8000_0000. This SoC expansion block is connected to one of the
IO Virtualization block present on RD-N2 platforms.
Update this base address in cmn-700 descriptor and the pcie integration
control config.