### PR TITLE
module_common: fix MOCK_REPLACEMENTS reset

### DIFF
--- a/unit_test/module_common.cmake
+++ b/unit_test/module_common.cmake
@@ -120,3 +120,5 @@ if(TEST_ON_HOST)
     # Add test to CTest
     add_test(NAME ${UNIT_TEST_TARGET} COMMAND ${UNIT_TEST_TARGET})
 endif()
+
+unset(MOCK_REPLACEMENTS)


### PR DESCRIPTION
MOCK_REPACEMENTS was accumulating strings from
previously run test modules. This variable is now
reset after module_common.cmake is invoked.