### PR TITLE
product/rdn2: fix remote_agentid for chip-0 to chip-1 data

### DIFF
--- a/product/rdn2/scp_ramfw/config_cmn700.c
+++ b/product/rdn2/scp_ramfw/config_cmn700.c
@@ -493,8 +493,8 @@ static const struct mod_cmn700_ccg_config ccg_config_table_chip_0[] = {
         },
         .remote_agentid_to_linkid_map = {
             {
-                .remote_agentid_start = (RNF_PER_CHIP_CFG2 * PLATFORM_CHIP_0),
-                .remote_agentid_end = (RNF_PER_CHIP_CFG2 * PLATFORM_CHIP_0) +
+                .remote_agentid_start = (RNF_PER_CHIP_CFG2 * PLATFORM_CHIP_1),
+                .remote_agentid_end = (RNF_PER_CHIP_CFG2 * PLATFORM_CHIP_1) +
                     RNF_PER_CHIP_CFG2 - 1
             },
         },


### PR DESCRIPTION
Remote agentid in Chip-0's config data for Chip-1 is pointing to the local agentid's instead of the remote agentid. Fix this.