### PR TITLE
scp: Update firmware version to 2.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 
 project(
     SCP
-    VERSION 2.10.0
+    VERSION 2.11.0
     DESCRIPTION "Arm SCP/MCP Software"
     HOMEPAGE_URL
         "https://developer.arm.com/tools-and-software/open-source-software/firmware/scp-firmware"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # Version
 #
 export VERSION_MAJOR := 2
-export VERSION_MINOR := 10
+export VERSION_MINOR := 11
 export VERSION_PATCH := 0
 
 #

--- a/framework/test/CMakeLists.txt
+++ b/framework/test/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.18.3)
 
 project(
     SCP_FWK_TEST
-    VERSION 2.10.0
+    VERSION 2.11.0
     DESCRIPTION "Arm SCP/MCP Software Framework tests"
     HOMEPAGE_URL
         "https://developer.arm.com/tools-and-software/open-source-software/firmware/scp-firmware"

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-SCP-firmware - version 2.10
+SCP-firmware - version 2.11
 ===========================
 
 Copyright (c) 2011-2022, Arm Limited. All rights reserved.


### PR DESCRIPTION
This patch updates the SCP-firmware version to 2.11.0.

Change-Id: I9f85b3113a2cd3bb057f58ac3b1750f5a326aaf3
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>