### PR TITLE
synquacer: allocate secure DRAM for BL31

### DIFF
--- a/product/synquacer/module/synquacer_memc/include/synquacer_ddr.h
+++ b/product/synquacer/module/synquacer_memc/include/synquacer_ddr.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -41,8 +41,8 @@
 
 #define DRAM_AREA_1_START_ADDR UINT64_C(0x0080000000)
 
-/* top 64MiB in DRAM1 region is reserved for Secure App */
-#define DRAM_RESERVED_FOR_SECURE_APP_SIZE UINT64_C(0x04000000)
+/* top 66MiB in DRAM1 region is reserved for Secure App */
+#define DRAM_RESERVED_FOR_SECURE_APP_SIZE UINT64_C(0x04200000)
 #define DRAM_AREA_1_END_ADDR UINT64_C(0x0100000000)
 #define DRAM_AREA_2_START_ADDR UINT64_C(0x0880000000)
 #define DRAM_AREA_2_END_ADDR UINT64_C(0x1000000000)

--- a/product/synquacer/module/synquacer_memc/src/ddr_init.c
+++ b/product/synquacer/module/synquacer_memc/src/ddr_init.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -186,10 +186,10 @@ int ddr_ch0_init_mp(void)
 
     ddr_init_mc0_mp(REG_DMC520_0);
 
-    /* allocate 60MiB secure DRAM for OP-TEE */
+    /* allocate 62MiB secure DRAM for secure software */
     if (ddr_is_secure_dram_enabled()) {
         FWK_LOG_INFO("[DDR] secure DRAM enabled");
-        REG_DMC520_0->access_address_min0_31_00_next = 0xFC00000C;
+        REG_DMC520_0->access_address_min0_31_00_next = 0xFBE0000C;
         REG_DMC520_0->access_address_min0_43_32_next = 0x00000000;
         REG_DMC520_0->access_address_max0_31_00_next = 0xFFBF0000;
         REG_DMC520_0->access_address_max0_43_32_next = 0x00000000;


### PR DESCRIPTION
When the TF-A BL2 is enabled on the SynQuacer platform, BL31 does not fit in the secure SRAM(512KiB).
This commit allocates the additional 1MiB secure DRAM for BL31.

Signed-off-by: Masahisa Kojima <masahisa.kojima@linaro.org>
Change-Id: Icba17f4a183f75a180d23a100f0b68d60f60f06a