### PR TITLE
scmi_pd: Fix handling of device power OFF

### DIFF
--- a/module/scmi_power_domain/src/mod_scmi_power_domain.c
+++ b/module/scmi_power_domain/src/mod_scmi_power_domain.c
@@ -869,7 +869,7 @@ FWK_WEAK int scmi_pd_power_state_set_policy(
         uint32_t dev_state_idx;
         uint32_t dev_state_table_size = sizeof(pd_state_to_scmi_dev_state) /
             sizeof(pd_state_to_scmi_dev_state[0]);
-        uint32_t dev_state = *state & SCMI_PD_DEVICE_STATE_ID_MASK;
+        uint32_t dev_state = *state;
         /*
          * Convert the device SCMI power state sent by the agent,
          * into the internal power domain state as defined by the


### PR DESCRIPTION
Since commit 656f089b97d5 ("scmi_pd:Add power domain set state sync request handling"), the scmi_power_domain module incorrectly masks the power state parameter for device power domains.

The SCMI specification defines a parameter of value 0 as the ON state, and value 0x40000000 as the OFF state. Any other value for bits 27:0 is IMPLEMENTATION DEFINED. Currently, in order to convert the SCMI parameter into an internal state, scmi_pd_power_state_set_policy() masks all bits but 27:0, so that a OFF parameter incorrectly matches MOD_PD_STATE_ON. To fix it, compare the complete parameter value against pd_state_to_scmi_dev_state.

Signed-off-by: Jean-Philippe Brucker <jean-philippe@linaro.org>