### PR TITLE
mod/mhu3: Fix doorbell channel trigger interrupt

### DIFF
--- a/module/mhu3/src/mod_mhu3.c
+++ b/module/mhu3/src/mod_mhu3.c
@@ -190,7 +190,7 @@ static int mhu3_raise_interrupt(fwk_id_t ch_id)
          * we are using only 1 flag(bit) per channel
          */
         if ((pdbcw_reg[dbch_channel->pbx_channel].PDBCW_ST &
-             0x1u << dbch_channel->pbx_flag_pos) != 0u) {
+             0x1u << dbch_channel->pbx_flag_pos) == 0u) {
             pdbcw_reg[dbch_channel->pbx_channel].PDBCW_SET |= 0x1u
                 << dbch_channel->pbx_flag_pos;
             status = FWK_SUCCESS;


### PR DESCRIPTION
To trigger an interrupt on a doorbell channel
corresponding PDBCW_ST bit of the PBX(postbox) is validated. If corresponding bit is unset then the code will raise the doorbell interrupt, otherwise it will return an error FWK_E_STATE. This validation check is incorrect and this change fixes this.

Change-Id: I84b19832b1d128176a2b77f2f5abc3c3cb1d92c0
Signed-off-by: Girish Pathak <girish.pathak@arm.com>