### PR TITLE
product: rename RD-Edmunds to RD-V2

### DIFF
--- a/product/rdn2/src/config_sid.c
+++ b/product/rdn2/src/config_sid.c
@@ -23,7 +23,7 @@ static const struct fwk_element subsystem_table[] = {
               .part_number = 0x7B6,
 #endif
           } },
-    { .name = "RD-Edmunds",
+    { .name = "RD-V2",
       .data =
           &(struct mod_sid_subsystem_config){
               .part_number = 0x7F2,


### PR DESCRIPTION
Neoverse Reference Design platform RD-Edmunds has been renamed to RD-V2 and all corresponding references have been changed.

Signed-off-by: Joel Goddard <joel.goddard@arm.com>
Change-Id: Ib77cd064403cd162339b3507536dcb296e4b2557