### PR TITLE
Add warm reboot support for RD-N2 platform

### DIFF
--- a/module/power_domain/include/mod_power_domain.h
+++ b/module/power_domain/include/mod_power_domain.h
@@ -770,6 +770,9 @@ enum mod_pd_notification_idx {
     /*! Broadcast notification before shutdown starts */
     MOD_PD_NOTIFICATION_IDX_PRE_SHUTDOWN,
 
+    /*! Broadcast warm reset notification */
+    MOD_PD_NOTIFICATION_IDX_PRE_WARM_RESET,
+
     /*! Number of notifications defined by the power domain module */
     MOD_PD_NOTIFICATION_COUNT,
 };
@@ -797,7 +800,17 @@ static const fwk_id_t mod_pd_notification_id_pre_shutdown =
     FWK_ID_NOTIFICATION_INIT(FWK_MODULE_IDX_POWER_DOMAIN,
         MOD_PD_NOTIFICATION_IDX_PRE_SHUTDOWN);
 
-#endif
+/*!
+ * Identifier of the pre-warm reboot notification.
+ *
+ * \note This notification will be broadcast with module identifier only.
+ */
+static const fwk_id_t mod_pd_notification_id_pre_warm_reset =
+    FWK_ID_NOTIFICATION_INIT(
+        FWK_MODULE_IDX_POWER_DOMAIN,
+        MOD_PD_NOTIFICATION_IDX_PRE_WARM_RESET);
+
+#    endif
 #endif /* BUILD_HAS_NOTIFICATION */
 
 /*!

--- a/module/scmi_system_power/src/mod_scmi_system_power.c
+++ b/module/scmi_system_power/src/mod_scmi_system_power.c
@@ -341,15 +341,11 @@ static int scmi_sys_power_state_set_handler(fwk_id_t service_id,
     case SCMI_SYSTEM_STATE_WARM_RESET:
         system_shutdown = system_state2system_shutdown[mod_scmi_system_state];
         status = scmi_sys_power_ctx.pd_api->system_shutdown(system_shutdown);
-        if (status == FWK_PENDING) {
-            /*
-             * The request has been acknowledged but we don't respond back to
-             * the calling agent. This is a fire-and-forget situation.
-             */
-            return FWK_SUCCESS;
-        } else {
-            goto exit;
+        if ((status == FWK_SUCCESS) || (status == FWK_PENDING)) {
+            status = FWK_SUCCESS;
+            return_values.status = (int32_t)SCMI_SUCCESS;
         }
+        goto exit;
         break;
 
     case SCMI_SYSTEM_STATE_SUSPEND:

--- a/product/rdn2/module/platform_system/include/mod_platform_system.h
+++ b/product/rdn2/module/platform_system/include/mod_platform_system.h
@@ -13,6 +13,8 @@
 
 #include <mod_power_domain.h>
 
+#define WARM_RESET_MAX_RETRIES 10
+
 /*!
  * \addtogroup GroupPLATFORMModule PLATFORM Product Modules
  * @{
@@ -52,6 +54,24 @@ enum mod_platform_system_api_idx {
     /*! Number of exposed interfaces */
     MOD_PLATFORM_SYSTEM_API_COUNT
 };
+
+/*!
+ * \brief Events used by platform system module.
+ */
+enum mod_platform_system_event_idx {
+    /*! Event requesting check for power domain OFF */
+    MOD_PLATFORM_SYSTEM_CHECK_PD_OFF,
+
+    /*! Number of defined events */
+    MOD_PLATFORM_SYSTEM_EVENT_COUNT
+};
+
+/*!
+ * \brief Event to check all CPUs are powered off.
+ */
+static const fwk_id_t mod_platform_system_event_check_ppu_off = FWK_ID_EVENT(
+    FWK_MODULE_IDX_PLATFORM_SYSTEM,
+    MOD_PLATFORM_SYSTEM_CHECK_PD_OFF);
 
 /*!
  * \brief List of isolated CPU MPIDs.


### PR DESCRIPTION
Add warm reboot support for RD-N2 platform. During warm reboot, all the CPUs will be powered OFF by keeping rest of the logics in ON state. Once all the CPU completes power down, power ON the boot CPU to start the boot sequence.