### PR TITLE
morello: Configure the default OPP to the highest

### DIFF
--- a/product/morello/scp_ramfw_fvp/config_css_clock.c
+++ b/product/morello/scp_ramfw_fvp/config_css_clock.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -156,7 +156,7 @@ static const struct fwk_element css_clock_element_table[] = {
                 .member_api_id = FWK_ID_API_INIT(
                     FWK_MODULE_IDX_PIK_CLOCK,
                     MOD_PIK_CLOCK_API_TYPE_CSS),
-                .initial_rate = CSS_CLK_RATE_CPU_GRP0_SUPER_UNDERDRIVE,
+                .initial_rate = CSS_CLK_RATE_CPU_GRP0_SUPER_OVERDRIVE,
                 .modulation_supported = true,
             }),
         },
@@ -180,7 +180,7 @@ static const struct fwk_element css_clock_element_table[] = {
                 .member_api_id = FWK_ID_API_INIT(
                     FWK_MODULE_IDX_PIK_CLOCK,
                     MOD_PIK_CLOCK_API_TYPE_CSS),
-                .initial_rate = CSS_CLK_RATE_CPU_GRP1_SUPER_UNDERDRIVE,
+                .initial_rate = CSS_CLK_RATE_CPU_GRP1_SUPER_OVERDRIVE,
                 .modulation_supported = true,
             }),
         },

--- a/product/morello/scp_ramfw_fvp/config_dvfs.c
+++ b/product/morello/scp_ramfw_fvp/config_dvfs.c
@@ -23,7 +23,7 @@ static const struct mod_dvfs_domain_config cpu_group_0 = {
     .psu_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_PSU, 0),
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_CPU_GROUP0),
     .latency = 1200,
-    .sustained_idx = 2,
+    .sustained_idx = 4,
     .opps =
         (struct mod_dvfs_opp[]){
             {
@@ -64,7 +64,7 @@ static const struct mod_dvfs_domain_config cpu_group_1 = {
     .psu_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_PSU, 0),
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_CPU_GROUP1),
     .latency = 1200,
-    .sustained_idx = 2,
+    .sustained_idx = 4,
     .opps =
         (struct mod_dvfs_opp[]){
             {

--- a/product/morello/scp_ramfw_soc/config_dvfs.c
+++ b/product/morello/scp_ramfw_soc/config_dvfs.c
@@ -23,7 +23,7 @@ static const struct mod_dvfs_domain_config cpu_group_0 = {
     .psu_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_PSU, 0),
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_CPU_GROUP0),
     .latency = 1200,
-    .sustained_idx = 2,
+    .sustained_idx = 4,
     .opps =
         (struct mod_dvfs_opp[]){
             {
@@ -64,7 +64,7 @@ static const struct mod_dvfs_domain_config cpu_group_1 = {
     .psu_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_PSU, 1),
     .clock_id = FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_IDX_CPU_GROUP1),
     .latency = 1200,
-    .sustained_idx = 2,
+    .sustained_idx = 4,
     .opps =
         (struct mod_dvfs_opp[]){
             {


### PR DESCRIPTION
Change the DVFS sustained index of the Morello platforms (SoC and FVP) to boot at the highest supported OPP level.

Signed-off-by: Anurag Koul <anurag.koul@arm.com>
Change-Id: Id2dfb5fa585d9aae03249496348529e5304c3e97