### PR TITLE
scmi_clock: Update comments about source of event

### DIFF
--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -1614,15 +1614,15 @@ static int process_response_event(const struct fwk_event *event)
 static int scmi_clock_process_event(const struct fwk_event *event,
                                     struct fwk_event *resp_event)
 {
+    /* Request events from SCMI */
     if (fwk_id_get_module_idx(event->source_id) ==
         fwk_id_get_module_idx(fwk_module_id_scmi)) {
-        /* Request events */
         return process_request_event(event);
     }
 
+    /* Response events from Clock HAL */
     if (fwk_id_get_module_idx(event->source_id) ==
         fwk_id_get_module_idx(fwk_module_id_clock)) {
-        /* Responses from Clock HAL */
         return process_response_event(event);
     }
 


### PR DESCRIPTION
Hi, I want to change the comments in scmi_clock slightly. In current status, event source is missing for the first comment.
When I looked module/scmi_perf/src/mod_scmi_perf.c file (2304 - 2310 lines), the comments helped me a lot to understand the codes. So I want to suggest changing the comments as the same format.
Any feedback is welcome including suggestion of commit message.