### PR TITLE
rdfremont/lcp: Append bl2 to firmware target

### DIFF
--- a/product/rdfremont/lcp_ramfw/CMakeLists.txt
+++ b/product/rdfremont/lcp_ramfw/CMakeLists.txt
@@ -9,16 +9,16 @@
 # Create the firmware target.
 #
 
-add_executable(rdfremont-lcp)
+add_executable(rdfremont-lcp-bl2)
 
 target_include_directories(
-    rdfremont-lcp PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
+    rdfremont-lcp-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
                     "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # cmake-lint: disable=E1122
 
 target_sources(
-    rdfremont-lcp
+    rdfremont-lcp-bl2
     PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/config_armv8m_mpu.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_pl011.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/config_transport.c"
@@ -28,7 +28,7 @@ target_sources(
 # Some of our firmware includes require CMSIS.
 #
 
-target_link_libraries(rdfremont-lcp PUBLIC cmsis::core-m)
+target_link_libraries(rdfremont-lcp-bl2 PUBLIC cmsis::core-m)
 
 #
 # We explicitly add the CMSIS include directories to our interface include
@@ -36,5 +36,5 @@ target_link_libraries(rdfremont-lcp PUBLIC cmsis::core-m)
 # allowing them to include any firmware includes we expose.
 #
 
-target_include_directories(rdfremont-lcp
+target_include_directories(rdfremont-lcp-bl2
     PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)

--- a/product/rdfremont/lcp_ramfw/Firmware.cmake
+++ b/product/rdfremont/lcp_ramfw/Firmware.cmake
@@ -9,9 +9,9 @@
 # Configure the build system.
 #
 
-set(SCP_FIRMWARE "rdfremont-lcp")
+set(SCP_FIRMWARE "rdfremont-lcp-bl2")
 
-set(SCP_FIRMWARE_TARGET "rdfremont-lcp")
+set(SCP_FIRMWARE_TARGET "rdfremont-lcp-bl2")
 
 set(SCP_TOOLCHAIN_INIT "GNU")
 


### PR DESCRIPTION
All the firmware targets in the codebase terminate with -blX. This is useful to understand the load stage and required to be aligned with other platforms.

rdfremont/lcp target is missing the -blX, so let's add it.

Change-Id: I895dfd995847113aba32fea433afaabfafa03e2c
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>