### PR TITLE
Fix inconsistencies with BUILD_HAS_xxx

### DIFF
--- a/arch/none/optee/src/arch_main.c
+++ b/arch/none/optee/src/arch_main.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Linaro Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Linaro Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -64,7 +64,7 @@ int scmi_get_device(unsigned int id)
 
 void scmi_process_mbx_smt(unsigned int fwk_id)
 {
-#if BUILD_HAS_MOD_OPTEE_SMT
+#ifdef BUILD_HAS_MOD_OPTEE_SMT
     fwk_id_t device_id;
 
     device_id.value = fwk_id;
@@ -80,7 +80,7 @@ void scmi_process_mbx_smt(unsigned int fwk_id)
 void scmi_process_mbx_msg(unsigned int fwk_id, void *in_buf, size_t in_size,
                           void *out_buf, size_t *out_size)
 {
-#if BUILD_HAS_MOD_MSG_SMT
+#ifdef BUILD_HAS_MOD_MSG_SMT
     fwk_id_t device_id;
 
     device_id.value = fwk_id;

--- a/module/dvfs/src/mod_dvfs.c
+++ b/module/dvfs/src/mod_dvfs.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -1126,7 +1126,7 @@ static int dvfs_bind_element(fwk_id_t domain_id, unsigned int round)
 
     /* Bind to the alarm HAL if required */
     if (ctx->config->retry_ms > 0) {
-#if BUILD_HAS_MOD_TIMER
+#ifdef BUILD_HAS_MOD_TIMER
         status = fwk_module_bind(
             ctx->config->alarm_id,
             MOD_TIMER_API_ID_ALARM,

--- a/module/mock_ppu/src/mod_mock_ppu.c
+++ b/module/mock_ppu/src/mod_mock_ppu.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Linaro Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Linaro Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -12,7 +12,7 @@
 #include <fwk_mm.h>
 #include <mod_power_domain.h>
 #include <mod_mock_ppu.h>
-#if BUILD_HAS_MOD_SYSTEM_POWER
+#ifdef BUILD_HAS_MOD_SYSTEM_POWER
 #include <mod_system_power.h>
 #endif
 
@@ -177,7 +177,7 @@ static int mock_ppu_bind(fwk_id_t id, unsigned int round)
         return FWK_SUCCESS;
 
     switch (fwk_id_get_module_idx(pd_ctx->bound_id)) {
-    #if BUILD_HAS_MOD_POWER_DOMAIN
+    #ifdef BUILD_HAS_MOD_POWER_DOMAIN
     case FWK_MODULE_IDX_POWER_DOMAIN:
         return fwk_module_bind(pd_ctx->bound_id,
                                mod_pd_api_id_driver_input,
@@ -185,7 +185,7 @@ static int mock_ppu_bind(fwk_id_t id, unsigned int round)
         break;
     #endif
 
-    #if BUILD_HAS_MOD_SYSTEM_POWER
+    #ifdef BUILD_HAS_MOD_SYSTEM_POWER
     case FWK_MODULE_IDX_SYSTEM_POWER:
         return fwk_module_bind(pd_ctx->bound_id,
                                mod_system_power_api_id_pd_driver_input,
@@ -217,14 +217,14 @@ static int mock_ppu_process_bind_request(fwk_id_t source_id,
 
     case MOD_PD_TYPE_DEVICE:
     case MOD_PD_TYPE_DEVICE_DEBUG:
-        #if BUILD_HAS_MOD_POWER_DOMAIN
+        #ifdef BUILD_HAS_MOD_POWER_DOMAIN
         if (fwk_id_get_module_idx(source_id) == FWK_MODULE_IDX_POWER_DOMAIN) {
             pd_ctx->bound_id = source_id;
             *api = &pd_driver;
             break;
         }
         #endif
-        #if BUILD_HAS_MOD_SYSTEM_POWER
+        #ifdef BUILD_HAS_MOD_SYSTEM_POWER
         if (fwk_id_get_module_idx(source_id) == FWK_MODULE_IDX_SYSTEM_POWER) {
             pd_ctx->bound_id = source_id;
             *api = &pd_driver;

--- a/module/optee/mbx/src/mod_optee_mbx.c
+++ b/module/optee/mbx/src/mod_optee_mbx.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Linaro Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Linaro Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -52,7 +52,7 @@ struct mbx_ctx {
 
 static struct mbx_ctx mbx_ctx;
 
-#if BUILD_HAS_MOD_OPTEE_SMT
+#ifdef BUILD_HAS_MOD_OPTEE_SMT
 void optee_mbx_signal_smt_message(fwk_id_t device_id)
 {
     struct mbx_device_ctx *device_ctx;
@@ -74,7 +74,7 @@ void optee_mbx_signal_smt_message(fwk_id_t device_id)
 }
 #endif
 
-#if BUILD_HAS_MOD_MSG_SMT
+#ifdef BUILD_HAS_MOD_MSG_SMT
 void optee_mbx_signal_msg_message(fwk_id_t device_id, void *in_buf,
                                   size_t in_size, void *out_buf,
                                   size_t *out_size)
@@ -237,12 +237,12 @@ static int mbx_process_bind_request(fwk_id_t source_id,
     }
 
     switch (fwk_id_get_module_idx(source_id)) {
-#if BUILD_HAS_MOD_OPTEE_SMT
+#ifdef BUILD_HAS_MOD_OPTEE_SMT
     case FWK_MODULE_IDX_OPTEE_SMT:
         *api = &mbx_smt_api;
         break;
 #endif
-#if BUILD_HAS_MOD_MSG_SMT
+#ifdef BUILD_HAS_MOD_MSG_SMT
     case FWK_MODULE_IDX_MSG_SMT:
         *api = &mbx_shm_api;
         break;

--- a/module/scmi_power_domain/src/mod_scmi_power_domain.c
+++ b/module/scmi_power_domain/src/mod_scmi_power_domain.c
@@ -654,7 +654,7 @@ static int scmi_pd_power_state_get_handler(fwk_id_t service_id,
 #ifdef BUILD_HAS_MOD_DEBUG
     struct fwk_event event;
     struct event_request_params *event_params;
-    #endif
+#endif
 
     parameters = (const struct scmi_pd_power_state_get_a2p *)payload;
 
@@ -700,7 +700,7 @@ static int scmi_pd_power_state_get_handler(fwk_id_t service_id,
         ops_set_busy(pd_id, service_id);
 
         return FWK_SUCCESS;
-    #endif
+#endif
     case MOD_PD_TYPE_DEVICE:
 
         status = scmi_pd_ctx.pd_api->get_state(pd_id, &pd_power_state);
@@ -1041,7 +1041,7 @@ static int scmi_pd_init(fwk_id_t module_id, unsigned int element_count,
 {
 #ifdef BUILD_HAS_MOD_DEBUG
     struct mod_scmi_pd_config *config = (struct mod_scmi_pd_config *)data;
-    #endif
+#endif
 
     if (element_count != 0) {
         return FWK_E_SUPPORT;

--- a/module/scmi_power_domain/src/mod_scmi_power_domain.c
+++ b/module/scmi_power_domain/src/mod_scmi_power_domain.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -60,7 +60,7 @@ struct mod_scmi_pd_ctx {
 
     /* Power domain module API */
     const struct mod_pd_restricted_api *pd_api;
-#if BUILD_HAS_MOD_DEBUG
+#ifdef BUILD_HAS_MOD_DEBUG
     /* Debug module API */
     const struct mod_debug_api *debug_api;
 


### PR DESCRIPTION
Few occurence of `#if BUILD_HAS_xxx` are replaced with `#ifdef BUILD_HAS_xxx`.