### PR TITLE
arch: optee: add missing header inclusions

### DIFF
--- a/arch/none/optee/src/arch_interrupt.c
+++ b/arch/none/optee/src/arch_interrupt.c
@@ -14,6 +14,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include <arch_interrupt.h>
+
 static int global_enable(void)
 {
     return FWK_E_SUPPORT;

--- a/arch/none/optee/src/arch_main.c
+++ b/arch/none/optee/src/arch_main.c
@@ -22,6 +22,7 @@
 #include <mod_optee_mbx.h>
 
 #include <arch_interrupt.h>
+#include <arch_main.h>
 
 static const struct fwk_arch_init_driver scmi_init_driver = {
     .interrupt = arch_interrupt_init,


### PR DESCRIPTION
Fixes arch_main.c and arch_interrupt.c in optee arch implementation that missed header files inclusion.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>