### PR TITLE
arch: optee: fw_assert.h wrapper for fwk_expect() return value

### DIFF
--- a/arch/none/optee/include/fwk_assert.h
+++ b/arch/none/optee/include/fwk_assert.h
@@ -1,0 +1,40 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Linaro Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef OPTEE_FWK_ASSERT_H
+#define OPTEE_FWK_ASSERT_H
+
+#include <assert.h>
+#include_next <fwk_assert.h>
+
+#if !defined(NDEBUG) && !defined(BUILD_TESTS)
+/*
+ * Redefine fwk_expect() as SCP-firmware implementation expects
+ * assert() macro to return a value fwk_expect() can propgate.
+ *
+ * SCP-firmware documentation regarding fwk_expect():
+ * In debug builds, the macro will evaluate the condition and trigger
+ * an assertion if it fails. In release builds, or if running tests, the
+ * macro will evaluate the condition and discard its result.
+ */
+#undef fwk_expect
+static inline bool _fwk_expect(bool cond, const char *expr,
+			       const char *file, const int line,
+			       const char *func)
+{
+	if (!cond) {
+		_assert_log(expr, file, line, func);
+		_assert_break();
+	}
+
+	return true;
+}
+
+#define fwk_expect(condition) _fwk_expect(condition, #condition, \
+					  __FILE__, __LINE__, __func__)
+#endif /* !NDEBUG && !BUILD_TESTS */
+#endif /* OPTEE_FWK_ASSERT_H */


### PR DESCRIPTION
Implements wrapper header file fwk_assert.h for optee architecture to overcome the issue building with OP-TEE. OP-TEE OS assert() function does not provide a return value resulting a compilation failure as reported in the below build traces:

/tmp/optee-3.19/build/../scp-firmware/framework/src/fwk_arch.c: In function ‘fwk_arch_init’: lib/libutils/isoc/include/assert.h:20:2: error: expected expression before ‘do’
   20 |  do { \
      |  ^~
/tmp/optee-3.19/build/../scp-firmware/framework/include/fwk_assert.h:147:35: note: in expansion of macro ‘assert’
  147 | #    define fwk_assert(condition) assert(condition)
      |                                   ^~~~~~
/tmp/optee-3.19/build/../scp-firmware/framework/include/fwk_assert.h:180:34: note: in expansion of macro ‘fwk_assert’
  180 | #    define fwk_check(condition) fwk_assert(condition)
      |                                  ^~~~~~~~~~
/tmp/optee-3.19/build/../scp-firmware/framework/include/fwk_assert.h:212:42: note: in expansion of macro ‘fwk_check’
  212 | #    define fwk_expect(condition) (bool)(fwk_check(condition), 1)
      |                                          ^~~~~~~~~
/tmp/optee-3.19/build/../scp-firmware/framework/src/fwk_arch.c:73:10: note: in expansion of macro ‘fwk_expect’
   73 |     if (!fwk_expect(status == FWK_SUCCESS)) {
      |          ^~~~~~~~~~

This change works around the issue by implementing a functional fwk_expect() function using OP-TEE OS standard lib libutils resources.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>