### PR TITLE
product/optee-stm32mp1: configure log

### DIFF
--- a/product/optee-stm32mp1/include/fmw_io.h
+++ b/product/optee-stm32mp1/include/fmw_io.h
@@ -1,0 +1,17 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Linaro Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef FMW_IO_H
+#define FMW_IO_H
+
+#include <fwk_id.h>
+#include <fwk_module_idx.h>
+
+#define FMW_IO_STDIN_ID FWK_ID_NONE
+#define FMW_IO_STDOUT_ID FWK_ID_ELEMENT(FWK_MODULE_IDX_OPTEE_CONSOLE, 0)
+
+#endif /* FMW_IO_H */


### PR DESCRIPTION
Adds fwm_io.h to product optee-stm32mp1 to get optee_console device bound to framework log support.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>