### PR TITLE
MHUv3 Unit tests and misc dependency changes 

### DIFF
--- a/module/mhu3/src/mod_mhu3.c
+++ b/module/mhu3/src/mod_mhu3.c
@@ -221,7 +221,7 @@ static int mhu3_get_fch(fwk_id_t fch_id, struct fast_channel_addr *fch)
     struct mod_mhu3_fc_config *fch_channel;
     uint32_t fch_cfg0;
 
-    if (!fwk_module_is_valid_sub_element_id(fch_id)) {
+    if (!fwk_module_is_valid_sub_element_id(fch_id) || (fch == NULL)) {
         return status;
     }
 

--- a/module/mhu3/test/CMakeLists.txt
+++ b/module/mhu3/test/CMakeLists.txt
@@ -1,0 +1,27 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(TEST_SRC mod_mhu3)
+set(TEST_FILE mod_mhu3)
+
+set(UNIT_TEST_TARGET mod_${TEST_MODULE}_unit_test)
+
+set(MODULE_SRC ${MODULE_ROOT}/${TEST_MODULE}/src)
+set(MODULE_INC ${MODULE_ROOT}/${TEST_MODULE}/include)
+list(APPEND OTHER_MODULE_INC ${MODULE_ROOT}/transport/include)
+set(MODULE_UT_SRC ${CMAKE_CURRENT_LIST_DIR})
+set(MODULE_UT_INC ${CMAKE_CURRENT_LIST_DIR})
+set(MODULE_UT_MOCK_SRC ${CMAKE_CURRENT_LIST_DIR}/mocks)
+
+list(APPEND MOCK_REPLACEMENTS fwk_module)
+list(APPEND MOCK_REPLACEMENTS fwk_core)
+list(APPEND MOCK_REPLACEMENTS fwk_interrupt)
+
+include(${SCP_ROOT}/unit_test/module_common.cmake)
+
+target_compile_definitions(${UNIT_TEST_TARGET} PRIVATE BUILD_HAS_MOD_TRANSPORT)
+target_compile_definitions(${UNIT_TEST_TARGET} PRIVATE BUILD_HAS_FAST_CHANNELS)

--- a/module/mhu3/test/config_mhu3.h
+++ b/module/mhu3/test/config_mhu3.h
@@ -1,0 +1,90 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <Mockfwk_module.h>
+
+#include <internal/mhu3.h>
+
+#include <mod_mhu3.h>
+
+#include <fwk_element.h>
+#include <fwk_id.h>
+#include <fwk_macros.h>
+
+enum mhu3_fake_irqs {
+    /* Some fake random device irq numbers */
+    MHU3_FAKE_IRQ_COMBINED = 40,
+    MHU3_FAKE_IRQ_PBX = 45,
+    MHU3_FAKE_DEVICE_1_PBX = 48,
+    MHU3_FAKE_DEVICE_1_MBX = 49,
+    MHU3_FAKE_DEVICE_1_FAST_CH_TRANSFER_0 = 56,
+    MHU3_FAKE_DEVICE_1_FAST_CH_TRANSFER_1 = 57,
+};
+
+/*
+ * This represents index of the channel descriptor within
+ * element table
+ */
+enum mhu3_fake_device_1_channel_idx {
+    FAKE_DEVICE_1_CHANNEL_DBCH_0_IDX,
+    FAKE_DEVICE_1_CHANNEL_FCH_0_IN_IDX,
+    FAKE_DEVICE_1_CHANNEL_FCH_0_OUT_IDX,
+    FAKE_DEVICE_1_CHANNEL_COUNT,
+};
+
+/* Doorbell channel number */
+enum dbch_channels {
+    FAKE_DEVICE_1_CHANNEL_DBCH_0,
+};
+
+/*
+ * Fast channel number
+ * separate fast channels with different directions
+ * can have same sequence number
+ */
+enum fch_channels {
+    FAKE_DEVICE_CHANNEL_FCH_0,
+};
+
+#define FAKE_DEVICE_1_NUM_CH FAKE_DEVICE_1_CHANNEL_COUNT
+
+enum mhu3_fake_device_idx {
+    MHU3_DEVICE_IDX_DEVICE_1,
+    MHU3_DEVICE_IDX_COUNT,
+};
+
+struct mod_mhu3_channel_config device_1_channel_config[FAKE_DEVICE_1_NUM_CH] = {
+    /* PBX CH 0, FLAG 0, MBX CH 0, FLAG 0 */
+    MOD_MHU3_INIT_DBCH(0, 0, 0, 0),
+    /* FCH 0, group 0, direction in (can changed for few test cases) */
+    MOD_MHU3_INIT_FCH(0, 0, MOD_MHU3_FCH_DIR_IN),
+    MOD_MHU3_INIT_FCH(0, 0, MOD_MHU3_FCH_DIR_OUT),
+};
+
+/* Provide a fake device info */
+static const struct fwk_element element_table[MHU3_DEVICE_IDX_COUNT+1] = {
+    [MHU3_DEVICE_IDX_DEVICE_1] = {
+        .name = "",
+        .sub_element_count = FAKE_DEVICE_1_NUM_CH,
+        .data = &(struct mod_mhu3_device_config) {
+            .irq = (unsigned int) MHU3_FAKE_IRQ_COMBINED,
+            .in = (uintptr_t)NULL,
+            .out = (uintptr_t)NULL,
+            .channels = &device_1_channel_config[0],
+        },
+    },
+    [MHU3_DEVICE_IDX_COUNT] = { 0 },
+};
+
+static const struct fwk_element *get_element_table(fwk_id_t module_id)
+{
+    return element_table;
+}
+
+struct fwk_module_config config_fake_mhu3 = {
+    .elements = FWK_MODULE_DYNAMIC_ELEMENTS(get_element_table),
+};

--- a/module/mhu3/test/fwk_module_idx.h
+++ b/module/mhu3/test/fwk_module_idx.h
@@ -1,0 +1,23 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TEST_FWK_MODULE_MODULE_IDX_H
+#define TEST_FWK_MODULE_MODULE_IDX_H
+
+#include <fwk_id.h>
+
+enum fwk_module_idx {
+    FWK_MODULE_IDX_SCMI,
+    FWK_MODULE_IDX_TRANSPORT,
+    FWK_MODULE_IDX_MHU3,
+    FWK_MODULE_IDX_COUNT,
+};
+
+static const fwk_id_t fwk_module_id_scmi =
+    FWK_ID_MODULE_INIT(FWK_MODULE_IDX_SCMI);
+
+#endif /* TEST_FWK_MODULE_MODULE_IDX_H */

--- a/module/mhu3/test/mocks/.clang-format
+++ b/module/mhu3/test/mocks/.clang-format
@@ -1,0 +1,4 @@
+{
+ "DisableFormat": true,
+ "SortIncludes": false,
+}

--- a/module/mhu3/test/mod_mhu3_unit_test.c
+++ b/module/mhu3/test/mod_mhu3_unit_test.c
@@ -1,0 +1,527 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "config_mhu3.h"
+#include "scp_unity.h"
+#include "unity.h"
+
+#include <Mockfwk_core.h>
+#include <Mockfwk_interrupt.h>
+#include <Mockfwk_module.h>
+
+#include <internal/mhu3.h>
+
+#include <mod_mhu3.h>
+
+#include UNIT_TEST_SRC
+
+/* Some invalid values */
+#define MHU3_TEST_INVALID_VALUE     0xFFFF
+#define MHU3_TEST_INVALID_API_VALUE 0xF
+
+/*!
+ * For unit tests, there is no real MHUv3 hardware.
+ * Below is the allocated memory that will be accessed by unit test
+ * functions as a MHUv3 hardware, therefore unit tests must pre-load desired
+ * values in the memory before calling unit test functions.
+ */
+struct mhu3_pbx_reg *fake_device_1_pbx_base;
+struct mhu3_pbx_pdbcw_reg *fake_device_1_pdbcw;
+struct mhu3_mbx_reg *fake_device_1_mbx_base;
+struct mhu3_mbx_mdbcw_reg *fake_device_1_mdbcw;
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+/*!
+ * \brief mhu3 unit test: mhu3_raise_interrupt(), wrong channel type.
+ *
+ *  \details Handle case in mhu3_raise_interrupt where it detects unexpected
+ *      channel type only valid value is doorbell channel type.
+ */
+void test_mhu3_raise_interrupt_wrong_channel_type(void)
+{
+    int status;
+    enum mod_mhu3_channel_type prev;
+
+    struct mhu3_device_ctx *device_ctx;
+    struct mod_mhu3_channel_config *channel;
+
+    device_ctx = &mhu3_ctx.device_ctx_table[FAKE_DEVICE_1_CHANNEL_DBCH_0];
+    channel = &(device_ctx->config->channels[FAKE_DEVICE_1_CHANNEL_DBCH_0]);
+
+    prev = channel->type;
+
+    /* Force wrong channel type */
+    channel->type = MHU3_TEST_INVALID_VALUE;
+
+    fwk_id_t ch_id = FWK_ID_SUB_ELEMENT(
+        FWK_MODULE_IDX_MHU3,
+        MHU3_DEVICE_IDX_DEVICE_1,
+        FAKE_DEVICE_1_CHANNEL_DBCH_0);
+
+    status = mhu3_raise_interrupt(ch_id);
+    TEST_ASSERT(status == FWK_E_PARAM);
+
+    channel->type = prev;
+}
+
+/*!
+ * \brief mhu3 unit test: mhu3_raise_interrupt(), valid case.
+ *
+ *  \details Handle case in mhu3_raise_interrupt raises interrupt
+ *       without any failures.
+ */
+void test_mhu3_raise_interrupt_valid_case(void)
+{
+    int status;
+
+    fwk_id_t ch_id = FWK_ID_SUB_ELEMENT(
+        FWK_MODULE_IDX_MHU3,
+        MHU3_DEVICE_IDX_DEVICE_1,
+        FAKE_DEVICE_1_CHANNEL_DBCH_0_IDX);
+
+    status = mhu3_raise_interrupt(ch_id);
+    TEST_ASSERT(status == FWK_SUCCESS);
+}
+
+/*!
+ * \brief mhu3 unit test: mhu3_bind(), round 0, successful case.
+ *
+ *  \details Handle case where fwk_module_bind is successful
+ */
+void test_mhu3_bind_round_0_success(void)
+{
+    int status;
+    fwk_id_t device_id = { 0 };
+
+    status = mhu3_bind(device_id, 0);
+    TEST_ASSERT(status == FWK_SUCCESS);
+}
+
+/*!
+ * \brief mhu3 unit test: mhu3_bind(), round 1, successful case.
+ *
+ *  \details Handle case where fwk_module_bind is successful
+ */
+void test_mhu3_bind_round_1_success(void)
+{
+    int status;
+    struct mhu3_device_ctx *device_ctx;
+    struct mhu3_channel_ctx *channel_ctx;
+
+    device_ctx = &mhu3_ctx.device_ctx_table[MHU3_DEVICE_IDX_DEVICE_1];
+    channel_ctx =
+        &device_ctx->channel_ctx_table[FAKE_DEVICE_1_CHANNEL_DBCH_0_IDX];
+    fwk_module_bind_ExpectAnyArgsAndReturn(FWK_SUCCESS);
+    channel_ctx->transport_id_bound = true;
+    fwk_id_t device_id =
+        FWK_ID_ELEMENT(FWK_MODULE_IDX_MHU3, MHU3_DEVICE_IDX_DEVICE_1);
+
+    status = mhu3_bind(device_id, 1);
+    TEST_ASSERT(status == FWK_SUCCESS);
+
+    channel_ctx->transport_id_bound = false;
+}
+
+/*!
+ * \brief mhu3 unit test: mhu3_bind(), failure case.
+ *
+ *  \details Handle case where fwk_module_bind fails
+ */
+void test_mhu3_bind_fail(void)
+{
+    int status;
+    struct mhu3_device_ctx *device_ctx;
+    struct mhu3_channel_ctx *channel_ctx;
+
+    device_ctx = &mhu3_ctx.device_ctx_table[MHU3_DEVICE_IDX_DEVICE_1];
+    channel_ctx =
+        &device_ctx->channel_ctx_table[FAKE_DEVICE_1_CHANNEL_DBCH_0_IDX];
+
+    /* Force fwk_module_bind to fail */
+    fwk_module_bind_ExpectAnyArgsAndReturn(FWK_E_PARAM);
+    channel_ctx->transport_id_bound = true;
+    fwk_id_t device_id =
+        FWK_ID_ELEMENT(FWK_MODULE_IDX_MHU3, MHU3_DEVICE_IDX_DEVICE_1);
+
+    status = mhu3_bind(device_id, 1);
+    channel_ctx->transport_id_bound = false;
+    TEST_ASSERT(status == FWK_E_PARAM);
+}
+
+/*!
+ * \brief mhu3 unit test: mhu3_process_bind_request(), failure bind request
+ *     for invalid api_id
+ *
+ *  \details Handle case where mhu3_process_bind_request fails because
+ *      binding is requested for invalid api_id
+ */
+void test_mhu3_process_bind_request_fail_invalid_api_id(void)
+{
+    int status;
+    fwk_id_t source_id;
+    fwk_id_t target_id;
+    fwk_id_t api_id;
+    const void *api;
+
+    source_id = FWK_ID_SUB_ELEMENT(FWK_MODULE_IDX_TRANSPORT, 0, 0);
+    target_id = FWK_ID_SUB_ELEMENT(FWK_MODULE_IDX_MHU3, 0, 0);
+
+    /* Send invalid api_id */
+    api_id = FWK_ID_API(FWK_MODULE_IDX_MHU3, MOD_MHU3_API_IDX_COUNT);
+    status = mhu3_process_bind_request(source_id, target_id, api_id, &api);
+    TEST_ASSERT(status == FWK_E_PARAM);
+}
+
+/*!
+ * \brief mhu3 unit test: mhu3_process_bind_request(), successful
+ *
+ *  \details Handle case where mhu3_process_bind_request succeeds
+ *
+ */
+void test_mhu3_process_bind_request_success(void)
+{
+    int status;
+    fwk_id_t source_id;
+    fwk_id_t target_id;
+    fwk_id_t api_id;
+    const void *api;
+
+    source_id = FWK_ID_SUB_ELEMENT(FWK_MODULE_IDX_TRANSPORT, 0, 0);
+    target_id = FWK_ID_SUB_ELEMENT(FWK_MODULE_IDX_MHU3, 0, 0);
+
+    api_id = FWK_ID_API(FWK_MODULE_IDX_MHU3, MOD_MHU3_API_IDX_TRANSPORT_DRIVER);
+    status = mhu3_process_bind_request(source_id, target_id, api_id, &api);
+    TEST_ASSERT(status == FWK_SUCCESS);
+}
+/*!
+ * \brief mhu3 unit test: mhu3_process_bind_request(), failure bind request
+ *     for non sub element
+ *
+ *  \details Handle case where mhu3_process_bind_request fails because
+ *      binding is requested for by non-subelement type.
+ */
+void test_mhu3_process_bind_request_fail_non_sub_element(void)
+{
+    int status;
+    fwk_id_t source_id;
+    fwk_id_t target_id;
+    fwk_id_t api_id;
+    const void *api;
+
+    source_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_TRANSPORT, 0);
+    target_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_MHU3, 0);
+    api_id = FWK_ID_API(FWK_MODULE_IDX_MHU3, MOD_MHU3_API_IDX_TRANSPORT_DRIVER);
+    status = mhu3_process_bind_request(source_id, target_id, api_id, &api);
+
+    TEST_ASSERT(status == FWK_E_ACCESS);
+}
+
+void test_mhu3_start_id_module_success(void)
+{
+    int status;
+    fwk_id_t id;
+
+    id = FWK_ID_MODULE(FWK_MODULE_IDX_MHU3);
+    status = mhu3_start(id);
+    TEST_ASSERT(status == FWK_SUCCESS);
+}
+
+void test_mhu3_start_id_element_success(void)
+{
+    int status;
+    fwk_id_t id;
+
+    fwk_interrupt_set_isr_ExpectAnyArgsAndReturn(FWK_SUCCESS);
+    fwk_interrupt_enable_ExpectAnyArgsAndReturn(FWK_SUCCESS);
+    id = FWK_ID_ELEMENT(FWK_MODULE_IDX_MHU3, MHU3_DEVICE_IDX_DEVICE_1);
+    status = mhu3_start(id);
+    TEST_ASSERT(status == FWK_SUCCESS);
+}
+
+void test_mhu3_start_id_element_set_isr_fails(void)
+{
+    int status;
+    fwk_id_t id;
+
+    fwk_interrupt_set_isr_ExpectAnyArgsAndReturn(FWK_E_PARAM);
+    id = FWK_ID_ELEMENT(FWK_MODULE_IDX_MHU3, MHU3_DEVICE_IDX_DEVICE_1);
+    status = mhu3_start(id);
+    TEST_ASSERT(status == FWK_E_PARAM);
+}
+
+void test_mhu3_start_id_interrupt_enable_fails(void)
+{
+    int status;
+    fwk_id_t id;
+
+    fwk_interrupt_set_isr_ExpectAnyArgsAndReturn(FWK_SUCCESS);
+    fwk_interrupt_enable_ExpectAnyArgsAndReturn(FWK_E_STATE);
+    id = FWK_ID_ELEMENT(FWK_MODULE_IDX_MHU3, MHU3_DEVICE_IDX_DEVICE_1);
+    status = mhu3_start(id);
+    TEST_ASSERT(status == FWK_E_STATE);
+}
+
+void test_mhu3_get_fch_invalid_sub_element(void)
+{
+    int status;
+    fwk_id_t id = { 0 };
+    struct fast_channel_addr fch;
+
+    /*
+     * mhu3_get_fch expects a valid id which has a subelement.
+     * check if it returns an FWK_E_PARAM if it gets an id without
+     * field subelement
+     */
+    fwk_module_is_valid_sub_element_id_ExpectAnyArgsAndReturn(false);
+    status = mhu3_get_fch(id, &fch);
+    TEST_ASSERT(status == FWK_E_PARAM);
+}
+
+void test_mhu3_get_fch_invalid_channel_type(void)
+{
+    int status;
+    fwk_id_t id = { 0 };
+    struct fast_channel_addr fch;
+
+    /*
+     * mhu3_get_fch should return FWK_E_PARAM if first parameter fch_id
+     * is of wrong type that is other than the fast channel type
+     */
+    fwk_module_is_valid_sub_element_id_ExpectAnyArgsAndReturn(true);
+    id = FWK_ID_SUB_ELEMENT(
+        FWK_MODULE_IDX_MHU3,
+        MHU3_DEVICE_IDX_DEVICE_1,
+        FAKE_DEVICE_1_CHANNEL_DBCH_0_IDX); /*
+                                            * Note. no
+                                            * FAKE_DEVICE_1_CHANNEL_DBCH_0_IDX
+                                            * is not a fast channel
+                                            */
+
+    status = mhu3_get_fch(id, &fch);
+    TEST_ASSERT(status == FWK_E_PARAM);
+}
+
+void test_mhu3_get_fch_null_fch_addr(void)
+{
+    int status;
+    fwk_id_t id = { 0 };
+    struct fast_channel_addr *null_fch_addr = NULL;
+
+    /*
+     * mhu3_get_fch should return FWK_E_PARAM if second parameter fch_addr
+     * is NULL.
+     */
+    fwk_module_is_valid_sub_element_id_ExpectAnyArgsAndReturn(true);
+    id = FWK_ID_SUB_ELEMENT(
+        FWK_MODULE_IDX_MHU3,
+        MHU3_DEVICE_IDX_DEVICE_1,
+        FAKE_DEVICE_1_CHANNEL_FCH_0_IN_IDX);
+
+    status = mhu3_get_fch(id, null_fch_addr);
+    TEST_ASSERT(status == FWK_E_PARAM);
+}
+
+void test_mhu3_get_fch_valid_fch_dir_in(void)
+{
+    int status;
+    fwk_id_t id = { 0 };
+    struct fast_channel_addr fch;
+
+    /* Success case, send valid id, address and fast channel direction (in) */
+    fwk_module_is_valid_sub_element_id_ExpectAnyArgsAndReturn(true);
+    id = FWK_ID_SUB_ELEMENT(
+        FWK_MODULE_IDX_MHU3,
+        MHU3_DEVICE_IDX_DEVICE_1,
+        FAKE_DEVICE_1_CHANNEL_FCH_0_IN_IDX);
+
+    status = mhu3_get_fch(id, &fch);
+    TEST_ASSERT(status == FWK_SUCCESS);
+}
+
+void test_mhu3_get_fch_valid_fch_dir_out(void)
+{
+    int status;
+    fwk_id_t id;
+    struct fast_channel_addr fch;
+
+    /* Success case, send valid id, address and fast channel direction (out) */
+    fwk_module_is_valid_sub_element_id_ExpectAnyArgsAndReturn(true);
+    id = FWK_ID_SUB_ELEMENT(
+        FWK_MODULE_IDX_MHU3,
+        MHU3_DEVICE_IDX_DEVICE_1,
+        FAKE_DEVICE_1_CHANNEL_FCH_0_OUT_IDX);
+
+    status = mhu3_get_fch(id, &fch);
+    TEST_ASSERT(status == FWK_SUCCESS);
+}
+
+void fch_callback_test(uintptr_t param)
+{
+}
+void test_mhu3_fch_register_callback_valid(void)
+{
+    int status;
+    fwk_id_t id = FWK_ID_SUB_ELEMENT_INIT(
+        FWK_MODULE_IDX_MHU3,
+        MHU3_DEVICE_IDX_DEVICE_1,
+        FAKE_DEVICE_1_CHANNEL_FCH_0_OUT_IDX);
+
+    /* All valid params, expect success */
+    fwk_module_is_valid_sub_element_id_ExpectAnyArgsAndReturn(true);
+    status =
+        mhu3_fch_register_callback(id, (uintptr_t)&status, fch_callback_test);
+    TEST_ASSERT(status == FWK_SUCCESS);
+}
+
+void test_mhu3_fch_register_callback_invalid_sub_element_id(void)
+{
+    int status;
+    fwk_id_t id = { 0 };
+
+    /* Force fwk_module_is_valid_sub_element_id to return false */
+    fwk_module_is_valid_sub_element_id_ExpectAnyArgsAndReturn(false);
+    status =
+        mhu3_fch_register_callback(id, (uintptr_t)&status, fch_callback_test);
+    TEST_ASSERT(status == FWK_E_PARAM);
+}
+
+void test_mhu3_fch_register_callback_null_param(void)
+{
+    int status;
+    fwk_id_t id = FWK_ID_SUB_ELEMENT_INIT(
+        FWK_MODULE_IDX_MHU3,
+        MHU3_DEVICE_IDX_DEVICE_1,
+        FAKE_DEVICE_1_CHANNEL_FCH_0_OUT_IDX);
+
+    /* Check if it returns FWK_E_PARAM if 'param' is NULL */
+    status = mhu3_fch_register_callback(id, (uintptr_t)NULL, fch_callback_test);
+    TEST_ASSERT(status == FWK_E_PARAM);
+}
+
+void test_mhu3_fch_register_callback_null_callback_addr(void)
+{
+    int status;
+    fwk_id_t id = FWK_ID_SUB_ELEMENT_INIT(
+        FWK_MODULE_IDX_MHU3,
+        MHU3_DEVICE_IDX_DEVICE_1,
+        FAKE_DEVICE_1_CHANNEL_FCH_0_OUT_IDX);
+
+    /* Check if it returns FWK_E_PARAM if callback address is NULL */
+    fwk_module_is_valid_sub_element_id_ExpectAnyArgsAndReturn(true);
+    status = mhu3_fch_register_callback(id, (uintptr_t)&status, NULL);
+    TEST_ASSERT(status == FWK_E_PARAM);
+}
+
+/* Helper function to setup values for unit tests */
+static int mhu3_fake_init(void)
+{
+    int status;
+    fwk_id_t module_id;
+    fwk_id_t device_id;
+    unsigned int sub_element_count;
+
+    uint8_t *tmp_pbx_base;
+    uint8_t *tmp_mbx_base;
+    uint32_t *feat_spt0;
+
+    struct mod_mhu3_device_config *device_config;
+
+    device_config =
+        (struct mod_mhu3_device_config *)element_table[MHU3_DEVICE_IDX_DEVICE_1]
+            .data;
+
+    /* Allocate some memory for MHU fake device1 PBX/MBX */
+    tmp_pbx_base = aligned_alloc(
+        sizeof(unsigned long),
+        sizeof(struct mhu3_pbx_reg) + MHU3_PBX_PDBCW_PAGE_OFFSET +
+            sizeof(struct mhu3_pbx_pdbcw_reg));
+    tmp_mbx_base = aligned_alloc(
+        sizeof(unsigned long),
+        sizeof(struct mhu3_mbx_reg) + MHU3_MBX_MDBCW_PAGE_OFFSET +
+            sizeof(struct mhu3_mbx_mdbcw_reg));
+
+    fake_device_1_pbx_base = (struct mhu3_pbx_reg *)tmp_pbx_base;
+    fake_device_1_mbx_base = (struct mhu3_mbx_reg *)tmp_mbx_base;
+
+    fake_device_1_pdbcw = (struct mhu3_pbx_pdbcw_reg
+                               *)(tmp_pbx_base + MHU3_PBX_PDBCW_PAGE_OFFSET);
+    fake_device_1_mdbcw = (struct mhu3_mbx_mdbcw_reg
+                               *)(tmp_mbx_base + MHU3_MBX_MDBCW_PAGE_OFFSET);
+
+    feat_spt0 = (uint32_t *)(&fake_device_1_mbx_base->MBX_FEAT_SPT0);
+    *feat_spt0 |= (1U << MHU3_FEAT_SPT0_FCE_SPT_BITSTART);
+    feat_spt0 = (uint32_t *)(&fake_device_1_pbx_base->PBX_FEAT_SPT0);
+    *feat_spt0 |= (1U << MHU3_FEAT_SPT0_FCE_SPT_BITSTART);
+
+    device_config->in = (uintptr_t)fake_device_1_mbx_base;
+    device_config->out = (uintptr_t)fake_device_1_pbx_base;
+
+    module_id = FWK_ID_MODULE(FWK_MODULE_IDX_MHU3);
+    status = mhu3_init(module_id, MHU3_DEVICE_IDX_COUNT, NULL);
+    if (status != FWK_SUCCESS) {
+        printf("[MHU3 UT] Can not execute test cases mhu3_init failed\n");
+        return -1;
+    }
+
+    device_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_MHU3, MHU3_DEVICE_IDX_DEVICE_1);
+    sub_element_count = FAKE_DEVICE_1_NUM_CH;
+    status = mhu3_device_init(device_id, sub_element_count, device_config);
+    if (status != FWK_SUCCESS) {
+        printf(
+            "[MHU3 UT] Can not execute test cases mhu3_device_init failed\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+int mhu3_test_main(void)
+{
+    int status;
+
+    status = mhu3_fake_init();
+    if (status != 0) {
+        return status;
+    }
+
+    UNITY_BEGIN();
+    RUN_TEST(test_mhu3_raise_interrupt_wrong_channel_type);
+    RUN_TEST(test_mhu3_raise_interrupt_valid_case);
+    RUN_TEST(test_mhu3_bind_round_0_success);
+    RUN_TEST(test_mhu3_bind_round_1_success);
+    RUN_TEST(test_mhu3_bind_fail);
+    RUN_TEST(test_mhu3_process_bind_request_success);
+    RUN_TEST(test_mhu3_process_bind_request_fail_invalid_api_id);
+    RUN_TEST(test_mhu3_process_bind_request_fail_non_sub_element);
+    RUN_TEST(test_mhu3_start_id_module_success);
+    RUN_TEST(test_mhu3_start_id_element_success);
+    RUN_TEST(test_mhu3_start_id_element_set_isr_fails);
+    RUN_TEST(test_mhu3_start_id_interrupt_enable_fails);
+    RUN_TEST(test_mhu3_get_fch_invalid_sub_element);
+    RUN_TEST(test_mhu3_get_fch_invalid_channel_type);
+    RUN_TEST(test_mhu3_get_fch_null_fch_addr);
+    RUN_TEST(test_mhu3_get_fch_valid_fch_dir_in);
+    RUN_TEST(test_mhu3_get_fch_valid_fch_dir_out);
+    RUN_TEST(test_mhu3_fch_register_callback_valid);
+    RUN_TEST(test_mhu3_fch_register_callback_invalid_sub_element_id);
+    RUN_TEST(test_mhu3_fch_register_callback_null_param);
+    RUN_TEST(test_mhu3_fch_register_callback_null_callback_addr);
+
+    return UNITY_END();
+}
+
+int main(void)
+{
+    return mhu3_test_main();
+}

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -111,6 +111,7 @@ list(APPEND UNIT_MODULE scmi_clock)
 list(APPEND UNIT_MODULE scmi_perf)
 list(APPEND UNIT_MODULE scmi_sensor_req)
 list(APPEND UNIT_MODULE scmi_system_power_req)
+list(APPEND UNIT_MODULE mhu3)
 
 list(LENGTH UNIT_MODULE UNIT_TEST_MAX)
 

--- a/unit_test/unity_mocks/mocks/Mockfwk_interrupt.c
+++ b/unit_test/unity_mocks/mocks/Mockfwk_interrupt.c
@@ -17,6 +17,7 @@ static const char* CMockString_fwk_interrupt_is_pending = "fwk_interrupt_is_pend
 static const char* CMockString_fwk_interrupt_set_isr = "fwk_interrupt_set_isr";
 static const char* CMockString_fwk_interrupt_set_isr_param = "fwk_interrupt_set_isr_param";
 static const char* CMockString_fwk_interrupt_set_pending = "fwk_interrupt_set_pending";
+static const char* CMockString_fwk_is_interrupt_context = "fwk_is_interrupt_context";
 static const char* CMockString_interrupt = "interrupt";
 static const char* CMockString_isr = "isr";
 static const char* CMockString_param = "param";
@@ -28,6 +29,7 @@ typedef struct _CMOCK_fwk_interrupt_init_CALL_INSTANCE
   char ExpectAnyArgsBool;
   int ReturnVal;
   const struct fwk_arch_interrupt_driver* Expected_driver;
+  int Expected_driver_Depth;
 
 } CMOCK_fwk_interrupt_init_CALL_INSTANCE;
 
@@ -38,6 +40,10 @@ typedef struct _CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE
   int ReturnVal;
   unsigned int Expected_interrupt;
   bool* Expected_enabled;
+  int Expected_enabled_Depth;
+  char ReturnThruPtr_enabled_Used;
+  bool* ReturnThruPtr_enabled_Val;
+  size_t ReturnThruPtr_enabled_Size;
 
 } CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE;
 
@@ -66,6 +72,10 @@ typedef struct _CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE
   int ReturnVal;
   unsigned int Expected_interrupt;
   bool* Expected_pending;
+  int Expected_pending_Depth;
+  char ReturnThruPtr_pending_Used;
+  bool* ReturnThruPtr_pending_Val;
+  size_t ReturnThruPtr_pending_Size;
 
 } CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE;
 
@@ -114,21 +124,67 @@ typedef struct _CMOCK_fwk_interrupt_get_current_CALL_INSTANCE
   char ExpectAnyArgsBool;
   int ReturnVal;
   unsigned int* Expected_interrupt;
+  int Expected_interrupt_Depth;
+  char ReturnThruPtr_interrupt_Used;
+  unsigned int* ReturnThruPtr_interrupt_Val;
+  size_t ReturnThruPtr_interrupt_Size;
 
 } CMOCK_fwk_interrupt_get_current_CALL_INSTANCE;
 
+typedef struct _CMOCK_fwk_is_interrupt_context_CALL_INSTANCE
+{
+  UNITY_LINE_TYPE LineNumber;
+  char ExpectAnyArgsBool;
+  bool ReturnVal;
+
+} CMOCK_fwk_is_interrupt_context_CALL_INSTANCE;
+
 static struct Mockfwk_interruptInstance
 {
+  char fwk_interrupt_init_CallbackBool;
+  CMOCK_fwk_interrupt_init_CALLBACK fwk_interrupt_init_CallbackFunctionPointer;
+  int fwk_interrupt_init_CallbackCalls;
   CMOCK_MEM_INDEX_TYPE fwk_interrupt_init_CallInstance;
+  char fwk_interrupt_is_enabled_CallbackBool;
+  CMOCK_fwk_interrupt_is_enabled_CALLBACK fwk_interrupt_is_enabled_CallbackFunctionPointer;
+  int fwk_interrupt_is_enabled_CallbackCalls;
   CMOCK_MEM_INDEX_TYPE fwk_interrupt_is_enabled_CallInstance;
+  char fwk_interrupt_enable_CallbackBool;
+  CMOCK_fwk_interrupt_enable_CALLBACK fwk_interrupt_enable_CallbackFunctionPointer;
+  int fwk_interrupt_enable_CallbackCalls;
   CMOCK_MEM_INDEX_TYPE fwk_interrupt_enable_CallInstance;
+  char fwk_interrupt_disable_CallbackBool;
+  CMOCK_fwk_interrupt_disable_CALLBACK fwk_interrupt_disable_CallbackFunctionPointer;
+  int fwk_interrupt_disable_CallbackCalls;
   CMOCK_MEM_INDEX_TYPE fwk_interrupt_disable_CallInstance;
+  char fwk_interrupt_is_pending_CallbackBool;
+  CMOCK_fwk_interrupt_is_pending_CALLBACK fwk_interrupt_is_pending_CallbackFunctionPointer;
+  int fwk_interrupt_is_pending_CallbackCalls;
   CMOCK_MEM_INDEX_TYPE fwk_interrupt_is_pending_CallInstance;
+  char fwk_interrupt_set_pending_CallbackBool;
+  CMOCK_fwk_interrupt_set_pending_CALLBACK fwk_interrupt_set_pending_CallbackFunctionPointer;
+  int fwk_interrupt_set_pending_CallbackCalls;
   CMOCK_MEM_INDEX_TYPE fwk_interrupt_set_pending_CallInstance;
+  char fwk_interrupt_clear_pending_CallbackBool;
+  CMOCK_fwk_interrupt_clear_pending_CALLBACK fwk_interrupt_clear_pending_CallbackFunctionPointer;
+  int fwk_interrupt_clear_pending_CallbackCalls;
   CMOCK_MEM_INDEX_TYPE fwk_interrupt_clear_pending_CallInstance;
+  char fwk_interrupt_set_isr_CallbackBool;
+  CMOCK_fwk_interrupt_set_isr_CALLBACK fwk_interrupt_set_isr_CallbackFunctionPointer;
+  int fwk_interrupt_set_isr_CallbackCalls;
   CMOCK_MEM_INDEX_TYPE fwk_interrupt_set_isr_CallInstance;
+  char fwk_interrupt_set_isr_param_CallbackBool;
+  CMOCK_fwk_interrupt_set_isr_param_CALLBACK fwk_interrupt_set_isr_param_CallbackFunctionPointer;
+  int fwk_interrupt_set_isr_param_CallbackCalls;
   CMOCK_MEM_INDEX_TYPE fwk_interrupt_set_isr_param_CallInstance;
+  char fwk_interrupt_get_current_CallbackBool;
+  CMOCK_fwk_interrupt_get_current_CALLBACK fwk_interrupt_get_current_CallbackFunctionPointer;
+  int fwk_interrupt_get_current_CallbackCalls;
   CMOCK_MEM_INDEX_TYPE fwk_interrupt_get_current_CallInstance;
+  char fwk_is_interrupt_context_CallbackBool;
+  CMOCK_fwk_is_interrupt_context_CALLBACK fwk_is_interrupt_context_CallbackFunctionPointer;
+  int fwk_is_interrupt_context_CallbackCalls;
+  CMOCK_MEM_INDEX_TYPE fwk_is_interrupt_context_CallInstance;
 } Mock;
 
 extern jmp_buf AbortFrame;
@@ -143,11 +199,21 @@ void Mockfwk_interrupt_Verify(void)
     UNITY_SET_DETAIL(CMockString_fwk_interrupt_init);
     UNITY_TEST_FAIL(cmock_line, CMockStringCalledLess);
   }
+  if (Mock.fwk_interrupt_init_CallbackFunctionPointer != NULL)
+  {
+    call_instance = CMOCK_GUTS_NONE;
+    (void)call_instance;
+  }
   call_instance = Mock.fwk_interrupt_is_enabled_CallInstance;
   if (CMOCK_GUTS_NONE != call_instance)
   {
     UNITY_SET_DETAIL(CMockString_fwk_interrupt_is_enabled);
     UNITY_TEST_FAIL(cmock_line, CMockStringCalledLess);
+  }
+  if (Mock.fwk_interrupt_is_enabled_CallbackFunctionPointer != NULL)
+  {
+    call_instance = CMOCK_GUTS_NONE;
+    (void)call_instance;
   }
   call_instance = Mock.fwk_interrupt_enable_CallInstance;
   if (CMOCK_GUTS_NONE != call_instance)
@@ -155,11 +221,21 @@ void Mockfwk_interrupt_Verify(void)
     UNITY_SET_DETAIL(CMockString_fwk_interrupt_enable);
     UNITY_TEST_FAIL(cmock_line, CMockStringCalledLess);
   }
+  if (Mock.fwk_interrupt_enable_CallbackFunctionPointer != NULL)
+  {
+    call_instance = CMOCK_GUTS_NONE;
+    (void)call_instance;
+  }
   call_instance = Mock.fwk_interrupt_disable_CallInstance;
   if (CMOCK_GUTS_NONE != call_instance)
   {
     UNITY_SET_DETAIL(CMockString_fwk_interrupt_disable);
     UNITY_TEST_FAIL(cmock_line, CMockStringCalledLess);
+  }
+  if (Mock.fwk_interrupt_disable_CallbackFunctionPointer != NULL)
+  {
+    call_instance = CMOCK_GUTS_NONE;
+    (void)call_instance;
   }
   call_instance = Mock.fwk_interrupt_is_pending_CallInstance;
   if (CMOCK_GUTS_NONE != call_instance)
@@ -167,11 +243,21 @@ void Mockfwk_interrupt_Verify(void)
     UNITY_SET_DETAIL(CMockString_fwk_interrupt_is_pending);
     UNITY_TEST_FAIL(cmock_line, CMockStringCalledLess);
   }
+  if (Mock.fwk_interrupt_is_pending_CallbackFunctionPointer != NULL)
+  {
+    call_instance = CMOCK_GUTS_NONE;
+    (void)call_instance;
+  }
   call_instance = Mock.fwk_interrupt_set_pending_CallInstance;
   if (CMOCK_GUTS_NONE != call_instance)
   {
     UNITY_SET_DETAIL(CMockString_fwk_interrupt_set_pending);
     UNITY_TEST_FAIL(cmock_line, CMockStringCalledLess);
+  }
+  if (Mock.fwk_interrupt_set_pending_CallbackFunctionPointer != NULL)
+  {
+    call_instance = CMOCK_GUTS_NONE;
+    (void)call_instance;
   }
   call_instance = Mock.fwk_interrupt_clear_pending_CallInstance;
   if (CMOCK_GUTS_NONE != call_instance)
@@ -179,11 +265,21 @@ void Mockfwk_interrupt_Verify(void)
     UNITY_SET_DETAIL(CMockString_fwk_interrupt_clear_pending);
     UNITY_TEST_FAIL(cmock_line, CMockStringCalledLess);
   }
+  if (Mock.fwk_interrupt_clear_pending_CallbackFunctionPointer != NULL)
+  {
+    call_instance = CMOCK_GUTS_NONE;
+    (void)call_instance;
+  }
   call_instance = Mock.fwk_interrupt_set_isr_CallInstance;
   if (CMOCK_GUTS_NONE != call_instance)
   {
     UNITY_SET_DETAIL(CMockString_fwk_interrupt_set_isr);
     UNITY_TEST_FAIL(cmock_line, CMockStringCalledLess);
+  }
+  if (Mock.fwk_interrupt_set_isr_CallbackFunctionPointer != NULL)
+  {
+    call_instance = CMOCK_GUTS_NONE;
+    (void)call_instance;
   }
   call_instance = Mock.fwk_interrupt_set_isr_param_CallInstance;
   if (CMOCK_GUTS_NONE != call_instance)
@@ -191,11 +287,32 @@ void Mockfwk_interrupt_Verify(void)
     UNITY_SET_DETAIL(CMockString_fwk_interrupt_set_isr_param);
     UNITY_TEST_FAIL(cmock_line, CMockStringCalledLess);
   }
+  if (Mock.fwk_interrupt_set_isr_param_CallbackFunctionPointer != NULL)
+  {
+    call_instance = CMOCK_GUTS_NONE;
+    (void)call_instance;
+  }
   call_instance = Mock.fwk_interrupt_get_current_CallInstance;
   if (CMOCK_GUTS_NONE != call_instance)
   {
     UNITY_SET_DETAIL(CMockString_fwk_interrupt_get_current);
     UNITY_TEST_FAIL(cmock_line, CMockStringCalledLess);
+  }
+  if (Mock.fwk_interrupt_get_current_CallbackFunctionPointer != NULL)
+  {
+    call_instance = CMOCK_GUTS_NONE;
+    (void)call_instance;
+  }
+  call_instance = Mock.fwk_is_interrupt_context_CallInstance;
+  if (CMOCK_GUTS_NONE != call_instance)
+  {
+    UNITY_SET_DETAIL(CMockString_fwk_is_interrupt_context);
+    UNITY_TEST_FAIL(cmock_line, CMockStringCalledLess);
+  }
+  if (Mock.fwk_is_interrupt_context_CallbackFunctionPointer != NULL)
+  {
+    call_instance = CMOCK_GUTS_NONE;
+    (void)call_instance;
   }
 }
 
@@ -217,23 +334,38 @@ int fwk_interrupt_init(const struct fwk_arch_interrupt_driver* driver)
   UNITY_SET_DETAIL(CMockString_fwk_interrupt_init);
   cmock_call_instance = (CMOCK_fwk_interrupt_init_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.fwk_interrupt_init_CallInstance);
   Mock.fwk_interrupt_init_CallInstance = CMock_Guts_MemNext(Mock.fwk_interrupt_init_CallInstance);
+  if (!Mock.fwk_interrupt_init_CallbackBool &&
+      Mock.fwk_interrupt_init_CallbackFunctionPointer != NULL)
+  {
+    int cmock_cb_ret = Mock.fwk_interrupt_init_CallbackFunctionPointer(driver, Mock.fwk_interrupt_init_CallbackCalls++);
+    UNITY_CLR_DETAILS();
+    return cmock_cb_ret;
+  }
   UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);
   cmock_line = cmock_call_instance->LineNumber;
   if (!cmock_call_instance->ExpectAnyArgsBool)
   {
   {
     UNITY_SET_DETAILS(CMockString_fwk_interrupt_init,CMockString_driver);
-    UNITY_TEST_ASSERT_EQUAL_MEMORY((void*)(cmock_call_instance->Expected_driver), (void*)(driver), sizeof(const struct fwk_arch_interrupt_driver), cmock_line, CMockStringMismatch);
+    if (cmock_call_instance->Expected_driver == NULL)
+      { UNITY_TEST_ASSERT_NULL(driver, cmock_line, CMockStringExpNULL); }
+    else
+      { UNITY_TEST_ASSERT_EQUAL_MEMORY_ARRAY((void*)(cmock_call_instance->Expected_driver), (void*)(driver), sizeof(const struct fwk_arch_interrupt_driver), cmock_call_instance->Expected_driver_Depth, cmock_line, CMockStringMismatch); }
   }
+  }
+  if (Mock.fwk_interrupt_init_CallbackFunctionPointer != NULL)
+  {
+    cmock_call_instance->ReturnVal = Mock.fwk_interrupt_init_CallbackFunctionPointer(driver, Mock.fwk_interrupt_init_CallbackCalls++);
   }
   UNITY_CLR_DETAILS();
   return cmock_call_instance->ReturnVal;
 }
 
-void CMockExpectParameters_fwk_interrupt_init(CMOCK_fwk_interrupt_init_CALL_INSTANCE* cmock_call_instance, const struct fwk_arch_interrupt_driver* driver);
-void CMockExpectParameters_fwk_interrupt_init(CMOCK_fwk_interrupt_init_CALL_INSTANCE* cmock_call_instance, const struct fwk_arch_interrupt_driver* driver)
+void CMockExpectParameters_fwk_interrupt_init(CMOCK_fwk_interrupt_init_CALL_INSTANCE* cmock_call_instance, const struct fwk_arch_interrupt_driver* driver, int driver_Depth);
+void CMockExpectParameters_fwk_interrupt_init(CMOCK_fwk_interrupt_init_CALL_INSTANCE* cmock_call_instance, const struct fwk_arch_interrupt_driver* driver, int driver_Depth)
 {
   cmock_call_instance->Expected_driver = driver;
+  cmock_call_instance->Expected_driver_Depth = driver_Depth;
 }
 
 void fwk_interrupt_init_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return)
@@ -258,7 +390,32 @@ void fwk_interrupt_init_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, const s
   Mock.fwk_interrupt_init_CallInstance = CMock_Guts_MemChain(Mock.fwk_interrupt_init_CallInstance, cmock_guts_index);
   cmock_call_instance->LineNumber = cmock_line;
   cmock_call_instance->ExpectAnyArgsBool = (char)0;
-  CMockExpectParameters_fwk_interrupt_init(cmock_call_instance, driver);
+  CMockExpectParameters_fwk_interrupt_init(cmock_call_instance, driver, 1);
+  cmock_call_instance->ReturnVal = cmock_to_return;
+}
+
+void fwk_interrupt_init_AddCallback(CMOCK_fwk_interrupt_init_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_init_CallbackBool = (char)1;
+  Mock.fwk_interrupt_init_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_init_Stub(CMOCK_fwk_interrupt_init_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_init_CallbackBool = (char)0;
+  Mock.fwk_interrupt_init_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_init_CMockExpectWithArrayAndReturn(UNITY_LINE_TYPE cmock_line, const struct fwk_arch_interrupt_driver* driver, int driver_Depth, int cmock_to_return)
+{
+  CMOCK_MEM_INDEX_TYPE cmock_guts_index = CMock_Guts_MemNew(sizeof(CMOCK_fwk_interrupt_init_CALL_INSTANCE));
+  CMOCK_fwk_interrupt_init_CALL_INSTANCE* cmock_call_instance = (CMOCK_fwk_interrupt_init_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);
+  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringOutOfMemory);
+  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));
+  Mock.fwk_interrupt_init_CallInstance = CMock_Guts_MemChain(Mock.fwk_interrupt_init_CallInstance, cmock_guts_index);
+  cmock_call_instance->LineNumber = cmock_line;
+  cmock_call_instance->ExpectAnyArgsBool = (char)0;
+  CMockExpectParameters_fwk_interrupt_init(cmock_call_instance, driver, driver_Depth);
   cmock_call_instance->ReturnVal = cmock_to_return;
 }
 
@@ -269,6 +426,13 @@ int fwk_interrupt_is_enabled(unsigned int interrupt, bool* enabled)
   UNITY_SET_DETAIL(CMockString_fwk_interrupt_is_enabled);
   cmock_call_instance = (CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.fwk_interrupt_is_enabled_CallInstance);
   Mock.fwk_interrupt_is_enabled_CallInstance = CMock_Guts_MemNext(Mock.fwk_interrupt_is_enabled_CallInstance);
+  if (!Mock.fwk_interrupt_is_enabled_CallbackBool &&
+      Mock.fwk_interrupt_is_enabled_CallbackFunctionPointer != NULL)
+  {
+    int cmock_cb_ret = Mock.fwk_interrupt_is_enabled_CallbackFunctionPointer(interrupt, enabled, Mock.fwk_interrupt_is_enabled_CallbackCalls++);
+    UNITY_CLR_DETAILS();
+    return cmock_cb_ret;
+  }
   UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);
   cmock_line = cmock_call_instance->LineNumber;
   if (!cmock_call_instance->ExpectAnyArgsBool)
@@ -282,18 +446,30 @@ int fwk_interrupt_is_enabled(unsigned int interrupt, bool* enabled)
     if (cmock_call_instance->Expected_enabled == NULL)
       { UNITY_TEST_ASSERT_NULL(enabled, cmock_line, CMockStringExpNULL); }
     else
-      { UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(cmock_call_instance->Expected_enabled, enabled, 1, cmock_line, CMockStringMismatch); }
+      { UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(cmock_call_instance->Expected_enabled, enabled, cmock_call_instance->Expected_enabled_Depth, cmock_line, CMockStringMismatch); }
   }
+  }
+  if (Mock.fwk_interrupt_is_enabled_CallbackFunctionPointer != NULL)
+  {
+    cmock_call_instance->ReturnVal = Mock.fwk_interrupt_is_enabled_CallbackFunctionPointer(interrupt, enabled, Mock.fwk_interrupt_is_enabled_CallbackCalls++);
+  }
+  if (cmock_call_instance->ReturnThruPtr_enabled_Used)
+  {
+    UNITY_TEST_ASSERT_NOT_NULL(enabled, cmock_line, CMockStringPtrIsNULL);
+    memcpy((void*)enabled, (void*)cmock_call_instance->ReturnThruPtr_enabled_Val,
+      cmock_call_instance->ReturnThruPtr_enabled_Size);
   }
   UNITY_CLR_DETAILS();
   return cmock_call_instance->ReturnVal;
 }
 
-void CMockExpectParameters_fwk_interrupt_is_enabled(CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE* cmock_call_instance, unsigned int interrupt, bool* enabled);
-void CMockExpectParameters_fwk_interrupt_is_enabled(CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE* cmock_call_instance, unsigned int interrupt, bool* enabled)
+void CMockExpectParameters_fwk_interrupt_is_enabled(CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE* cmock_call_instance, unsigned int interrupt, bool* enabled, int enabled_Depth);
+void CMockExpectParameters_fwk_interrupt_is_enabled(CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE* cmock_call_instance, unsigned int interrupt, bool* enabled, int enabled_Depth)
 {
   cmock_call_instance->Expected_interrupt = interrupt;
   cmock_call_instance->Expected_enabled = enabled;
+  cmock_call_instance->Expected_enabled_Depth = enabled_Depth;
+  cmock_call_instance->ReturnThruPtr_enabled_Used = 0;
 }
 
 void fwk_interrupt_is_enabled_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return)
@@ -318,8 +494,42 @@ void fwk_interrupt_is_enabled_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, u
   Mock.fwk_interrupt_is_enabled_CallInstance = CMock_Guts_MemChain(Mock.fwk_interrupt_is_enabled_CallInstance, cmock_guts_index);
   cmock_call_instance->LineNumber = cmock_line;
   cmock_call_instance->ExpectAnyArgsBool = (char)0;
-  CMockExpectParameters_fwk_interrupt_is_enabled(cmock_call_instance, interrupt, enabled);
+  CMockExpectParameters_fwk_interrupt_is_enabled(cmock_call_instance, interrupt, enabled, 1);
   cmock_call_instance->ReturnVal = cmock_to_return;
+}
+
+void fwk_interrupt_is_enabled_AddCallback(CMOCK_fwk_interrupt_is_enabled_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_is_enabled_CallbackBool = (char)1;
+  Mock.fwk_interrupt_is_enabled_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_is_enabled_Stub(CMOCK_fwk_interrupt_is_enabled_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_is_enabled_CallbackBool = (char)0;
+  Mock.fwk_interrupt_is_enabled_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_is_enabled_CMockExpectWithArrayAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, bool* enabled, int enabled_Depth, int cmock_to_return)
+{
+  CMOCK_MEM_INDEX_TYPE cmock_guts_index = CMock_Guts_MemNew(sizeof(CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE));
+  CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE* cmock_call_instance = (CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);
+  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringOutOfMemory);
+  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));
+  Mock.fwk_interrupt_is_enabled_CallInstance = CMock_Guts_MemChain(Mock.fwk_interrupt_is_enabled_CallInstance, cmock_guts_index);
+  cmock_call_instance->LineNumber = cmock_line;
+  cmock_call_instance->ExpectAnyArgsBool = (char)0;
+  CMockExpectParameters_fwk_interrupt_is_enabled(cmock_call_instance, interrupt, enabled, enabled_Depth);
+  cmock_call_instance->ReturnVal = cmock_to_return;
+}
+
+void fwk_interrupt_is_enabled_CMockReturnMemThruPtr_enabled(UNITY_LINE_TYPE cmock_line, bool* enabled, size_t cmock_size)
+{
+  CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE* cmock_call_instance = (CMOCK_fwk_interrupt_is_enabled_CALL_INSTANCE*)CMock_Guts_GetAddressFor(CMock_Guts_MemEndOfChain(Mock.fwk_interrupt_is_enabled_CallInstance));
+  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringPtrPreExp);
+  cmock_call_instance->ReturnThruPtr_enabled_Used = 1;
+  cmock_call_instance->ReturnThruPtr_enabled_Val = enabled;
+  cmock_call_instance->ReturnThruPtr_enabled_Size = cmock_size;
 }
 
 int fwk_interrupt_enable(unsigned int interrupt)
@@ -329,6 +539,13 @@ int fwk_interrupt_enable(unsigned int interrupt)
   UNITY_SET_DETAIL(CMockString_fwk_interrupt_enable);
   cmock_call_instance = (CMOCK_fwk_interrupt_enable_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.fwk_interrupt_enable_CallInstance);
   Mock.fwk_interrupt_enable_CallInstance = CMock_Guts_MemNext(Mock.fwk_interrupt_enable_CallInstance);
+  if (!Mock.fwk_interrupt_enable_CallbackBool &&
+      Mock.fwk_interrupt_enable_CallbackFunctionPointer != NULL)
+  {
+    int cmock_cb_ret = Mock.fwk_interrupt_enable_CallbackFunctionPointer(interrupt, Mock.fwk_interrupt_enable_CallbackCalls++);
+    UNITY_CLR_DETAILS();
+    return cmock_cb_ret;
+  }
   UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);
   cmock_line = cmock_call_instance->LineNumber;
   if (!cmock_call_instance->ExpectAnyArgsBool)
@@ -337,6 +554,10 @@ int fwk_interrupt_enable(unsigned int interrupt)
     UNITY_SET_DETAILS(CMockString_fwk_interrupt_enable,CMockString_interrupt);
     UNITY_TEST_ASSERT_EQUAL_HEX32(cmock_call_instance->Expected_interrupt, interrupt, cmock_line, CMockStringMismatch);
   }
+  }
+  if (Mock.fwk_interrupt_enable_CallbackFunctionPointer != NULL)
+  {
+    cmock_call_instance->ReturnVal = Mock.fwk_interrupt_enable_CallbackFunctionPointer(interrupt, Mock.fwk_interrupt_enable_CallbackCalls++);
   }
   UNITY_CLR_DETAILS();
   return cmock_call_instance->ReturnVal;
@@ -374,6 +595,18 @@ void fwk_interrupt_enable_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsig
   cmock_call_instance->ReturnVal = cmock_to_return;
 }
 
+void fwk_interrupt_enable_AddCallback(CMOCK_fwk_interrupt_enable_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_enable_CallbackBool = (char)1;
+  Mock.fwk_interrupt_enable_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_enable_Stub(CMOCK_fwk_interrupt_enable_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_enable_CallbackBool = (char)0;
+  Mock.fwk_interrupt_enable_CallbackFunctionPointer = Callback;
+}
+
 int fwk_interrupt_disable(unsigned int interrupt)
 {
   UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;
@@ -381,6 +614,13 @@ int fwk_interrupt_disable(unsigned int interrupt)
   UNITY_SET_DETAIL(CMockString_fwk_interrupt_disable);
   cmock_call_instance = (CMOCK_fwk_interrupt_disable_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.fwk_interrupt_disable_CallInstance);
   Mock.fwk_interrupt_disable_CallInstance = CMock_Guts_MemNext(Mock.fwk_interrupt_disable_CallInstance);
+  if (!Mock.fwk_interrupt_disable_CallbackBool &&
+      Mock.fwk_interrupt_disable_CallbackFunctionPointer != NULL)
+  {
+    int cmock_cb_ret = Mock.fwk_interrupt_disable_CallbackFunctionPointer(interrupt, Mock.fwk_interrupt_disable_CallbackCalls++);
+    UNITY_CLR_DETAILS();
+    return cmock_cb_ret;
+  }
   UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);
   cmock_line = cmock_call_instance->LineNumber;
   if (!cmock_call_instance->ExpectAnyArgsBool)
@@ -389,6 +629,10 @@ int fwk_interrupt_disable(unsigned int interrupt)
     UNITY_SET_DETAILS(CMockString_fwk_interrupt_disable,CMockString_interrupt);
     UNITY_TEST_ASSERT_EQUAL_HEX32(cmock_call_instance->Expected_interrupt, interrupt, cmock_line, CMockStringMismatch);
   }
+  }
+  if (Mock.fwk_interrupt_disable_CallbackFunctionPointer != NULL)
+  {
+    cmock_call_instance->ReturnVal = Mock.fwk_interrupt_disable_CallbackFunctionPointer(interrupt, Mock.fwk_interrupt_disable_CallbackCalls++);
   }
   UNITY_CLR_DETAILS();
   return cmock_call_instance->ReturnVal;
@@ -426,6 +670,18 @@ void fwk_interrupt_disable_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsi
   cmock_call_instance->ReturnVal = cmock_to_return;
 }
 
+void fwk_interrupt_disable_AddCallback(CMOCK_fwk_interrupt_disable_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_disable_CallbackBool = (char)1;
+  Mock.fwk_interrupt_disable_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_disable_Stub(CMOCK_fwk_interrupt_disable_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_disable_CallbackBool = (char)0;
+  Mock.fwk_interrupt_disable_CallbackFunctionPointer = Callback;
+}
+
 int fwk_interrupt_is_pending(unsigned int interrupt, bool* pending)
 {
   UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;
@@ -433,6 +689,13 @@ int fwk_interrupt_is_pending(unsigned int interrupt, bool* pending)
   UNITY_SET_DETAIL(CMockString_fwk_interrupt_is_pending);
   cmock_call_instance = (CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.fwk_interrupt_is_pending_CallInstance);
   Mock.fwk_interrupt_is_pending_CallInstance = CMock_Guts_MemNext(Mock.fwk_interrupt_is_pending_CallInstance);
+  if (!Mock.fwk_interrupt_is_pending_CallbackBool &&
+      Mock.fwk_interrupt_is_pending_CallbackFunctionPointer != NULL)
+  {
+    int cmock_cb_ret = Mock.fwk_interrupt_is_pending_CallbackFunctionPointer(interrupt, pending, Mock.fwk_interrupt_is_pending_CallbackCalls++);
+    UNITY_CLR_DETAILS();
+    return cmock_cb_ret;
+  }
   UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);
   cmock_line = cmock_call_instance->LineNumber;
   if (!cmock_call_instance->ExpectAnyArgsBool)
@@ -446,18 +709,30 @@ int fwk_interrupt_is_pending(unsigned int interrupt, bool* pending)
     if (cmock_call_instance->Expected_pending == NULL)
       { UNITY_TEST_ASSERT_NULL(pending, cmock_line, CMockStringExpNULL); }
     else
-      { UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(cmock_call_instance->Expected_pending, pending, 1, cmock_line, CMockStringMismatch); }
+      { UNITY_TEST_ASSERT_EQUAL_INT_ARRAY(cmock_call_instance->Expected_pending, pending, cmock_call_instance->Expected_pending_Depth, cmock_line, CMockStringMismatch); }
   }
+  }
+  if (Mock.fwk_interrupt_is_pending_CallbackFunctionPointer != NULL)
+  {
+    cmock_call_instance->ReturnVal = Mock.fwk_interrupt_is_pending_CallbackFunctionPointer(interrupt, pending, Mock.fwk_interrupt_is_pending_CallbackCalls++);
+  }
+  if (cmock_call_instance->ReturnThruPtr_pending_Used)
+  {
+    UNITY_TEST_ASSERT_NOT_NULL(pending, cmock_line, CMockStringPtrIsNULL);
+    memcpy((void*)pending, (void*)cmock_call_instance->ReturnThruPtr_pending_Val,
+      cmock_call_instance->ReturnThruPtr_pending_Size);
   }
   UNITY_CLR_DETAILS();
   return cmock_call_instance->ReturnVal;
 }
 
-void CMockExpectParameters_fwk_interrupt_is_pending(CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE* cmock_call_instance, unsigned int interrupt, bool* pending);
-void CMockExpectParameters_fwk_interrupt_is_pending(CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE* cmock_call_instance, unsigned int interrupt, bool* pending)
+void CMockExpectParameters_fwk_interrupt_is_pending(CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE* cmock_call_instance, unsigned int interrupt, bool* pending, int pending_Depth);
+void CMockExpectParameters_fwk_interrupt_is_pending(CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE* cmock_call_instance, unsigned int interrupt, bool* pending, int pending_Depth)
 {
   cmock_call_instance->Expected_interrupt = interrupt;
   cmock_call_instance->Expected_pending = pending;
+  cmock_call_instance->Expected_pending_Depth = pending_Depth;
+  cmock_call_instance->ReturnThruPtr_pending_Used = 0;
 }
 
 void fwk_interrupt_is_pending_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return)
@@ -482,8 +757,42 @@ void fwk_interrupt_is_pending_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, u
   Mock.fwk_interrupt_is_pending_CallInstance = CMock_Guts_MemChain(Mock.fwk_interrupt_is_pending_CallInstance, cmock_guts_index);
   cmock_call_instance->LineNumber = cmock_line;
   cmock_call_instance->ExpectAnyArgsBool = (char)0;
-  CMockExpectParameters_fwk_interrupt_is_pending(cmock_call_instance, interrupt, pending);
+  CMockExpectParameters_fwk_interrupt_is_pending(cmock_call_instance, interrupt, pending, 1);
   cmock_call_instance->ReturnVal = cmock_to_return;
+}
+
+void fwk_interrupt_is_pending_AddCallback(CMOCK_fwk_interrupt_is_pending_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_is_pending_CallbackBool = (char)1;
+  Mock.fwk_interrupt_is_pending_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_is_pending_Stub(CMOCK_fwk_interrupt_is_pending_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_is_pending_CallbackBool = (char)0;
+  Mock.fwk_interrupt_is_pending_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_is_pending_CMockExpectWithArrayAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, bool* pending, int pending_Depth, int cmock_to_return)
+{
+  CMOCK_MEM_INDEX_TYPE cmock_guts_index = CMock_Guts_MemNew(sizeof(CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE));
+  CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE* cmock_call_instance = (CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);
+  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringOutOfMemory);
+  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));
+  Mock.fwk_interrupt_is_pending_CallInstance = CMock_Guts_MemChain(Mock.fwk_interrupt_is_pending_CallInstance, cmock_guts_index);
+  cmock_call_instance->LineNumber = cmock_line;
+  cmock_call_instance->ExpectAnyArgsBool = (char)0;
+  CMockExpectParameters_fwk_interrupt_is_pending(cmock_call_instance, interrupt, pending, pending_Depth);
+  cmock_call_instance->ReturnVal = cmock_to_return;
+}
+
+void fwk_interrupt_is_pending_CMockReturnMemThruPtr_pending(UNITY_LINE_TYPE cmock_line, bool* pending, size_t cmock_size)
+{
+  CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE* cmock_call_instance = (CMOCK_fwk_interrupt_is_pending_CALL_INSTANCE*)CMock_Guts_GetAddressFor(CMock_Guts_MemEndOfChain(Mock.fwk_interrupt_is_pending_CallInstance));
+  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringPtrPreExp);
+  cmock_call_instance->ReturnThruPtr_pending_Used = 1;
+  cmock_call_instance->ReturnThruPtr_pending_Val = pending;
+  cmock_call_instance->ReturnThruPtr_pending_Size = cmock_size;
 }
 
 int fwk_interrupt_set_pending(unsigned int interrupt)
@@ -493,6 +802,13 @@ int fwk_interrupt_set_pending(unsigned int interrupt)
   UNITY_SET_DETAIL(CMockString_fwk_interrupt_set_pending);
   cmock_call_instance = (CMOCK_fwk_interrupt_set_pending_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.fwk_interrupt_set_pending_CallInstance);
   Mock.fwk_interrupt_set_pending_CallInstance = CMock_Guts_MemNext(Mock.fwk_interrupt_set_pending_CallInstance);
+  if (!Mock.fwk_interrupt_set_pending_CallbackBool &&
+      Mock.fwk_interrupt_set_pending_CallbackFunctionPointer != NULL)
+  {
+    int cmock_cb_ret = Mock.fwk_interrupt_set_pending_CallbackFunctionPointer(interrupt, Mock.fwk_interrupt_set_pending_CallbackCalls++);
+    UNITY_CLR_DETAILS();
+    return cmock_cb_ret;
+  }
   UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);
   cmock_line = cmock_call_instance->LineNumber;
   if (!cmock_call_instance->ExpectAnyArgsBool)
@@ -501,6 +817,10 @@ int fwk_interrupt_set_pending(unsigned int interrupt)
     UNITY_SET_DETAILS(CMockString_fwk_interrupt_set_pending,CMockString_interrupt);
     UNITY_TEST_ASSERT_EQUAL_HEX32(cmock_call_instance->Expected_interrupt, interrupt, cmock_line, CMockStringMismatch);
   }
+  }
+  if (Mock.fwk_interrupt_set_pending_CallbackFunctionPointer != NULL)
+  {
+    cmock_call_instance->ReturnVal = Mock.fwk_interrupt_set_pending_CallbackFunctionPointer(interrupt, Mock.fwk_interrupt_set_pending_CallbackCalls++);
   }
   UNITY_CLR_DETAILS();
   return cmock_call_instance->ReturnVal;
@@ -538,6 +858,18 @@ void fwk_interrupt_set_pending_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, 
   cmock_call_instance->ReturnVal = cmock_to_return;
 }
 
+void fwk_interrupt_set_pending_AddCallback(CMOCK_fwk_interrupt_set_pending_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_set_pending_CallbackBool = (char)1;
+  Mock.fwk_interrupt_set_pending_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_set_pending_Stub(CMOCK_fwk_interrupt_set_pending_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_set_pending_CallbackBool = (char)0;
+  Mock.fwk_interrupt_set_pending_CallbackFunctionPointer = Callback;
+}
+
 int fwk_interrupt_clear_pending(unsigned int interrupt)
 {
   UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;
@@ -545,6 +877,13 @@ int fwk_interrupt_clear_pending(unsigned int interrupt)
   UNITY_SET_DETAIL(CMockString_fwk_interrupt_clear_pending);
   cmock_call_instance = (CMOCK_fwk_interrupt_clear_pending_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.fwk_interrupt_clear_pending_CallInstance);
   Mock.fwk_interrupt_clear_pending_CallInstance = CMock_Guts_MemNext(Mock.fwk_interrupt_clear_pending_CallInstance);
+  if (!Mock.fwk_interrupt_clear_pending_CallbackBool &&
+      Mock.fwk_interrupt_clear_pending_CallbackFunctionPointer != NULL)
+  {
+    int cmock_cb_ret = Mock.fwk_interrupt_clear_pending_CallbackFunctionPointer(interrupt, Mock.fwk_interrupt_clear_pending_CallbackCalls++);
+    UNITY_CLR_DETAILS();
+    return cmock_cb_ret;
+  }
   UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);
   cmock_line = cmock_call_instance->LineNumber;
   if (!cmock_call_instance->ExpectAnyArgsBool)
@@ -553,6 +892,10 @@ int fwk_interrupt_clear_pending(unsigned int interrupt)
     UNITY_SET_DETAILS(CMockString_fwk_interrupt_clear_pending,CMockString_interrupt);
     UNITY_TEST_ASSERT_EQUAL_HEX32(cmock_call_instance->Expected_interrupt, interrupt, cmock_line, CMockStringMismatch);
   }
+  }
+  if (Mock.fwk_interrupt_clear_pending_CallbackFunctionPointer != NULL)
+  {
+    cmock_call_instance->ReturnVal = Mock.fwk_interrupt_clear_pending_CallbackFunctionPointer(interrupt, Mock.fwk_interrupt_clear_pending_CallbackCalls++);
   }
   UNITY_CLR_DETAILS();
   return cmock_call_instance->ReturnVal;
@@ -590,6 +933,18 @@ void fwk_interrupt_clear_pending_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line
   cmock_call_instance->ReturnVal = cmock_to_return;
 }
 
+void fwk_interrupt_clear_pending_AddCallback(CMOCK_fwk_interrupt_clear_pending_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_clear_pending_CallbackBool = (char)1;
+  Mock.fwk_interrupt_clear_pending_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_clear_pending_Stub(CMOCK_fwk_interrupt_clear_pending_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_clear_pending_CallbackBool = (char)0;
+  Mock.fwk_interrupt_clear_pending_CallbackFunctionPointer = Callback;
+}
+
 int fwk_interrupt_set_isr(unsigned int interrupt, cmock_fwk_interrupt_func_ptr1 isr)
 {
   UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;
@@ -597,6 +952,13 @@ int fwk_interrupt_set_isr(unsigned int interrupt, cmock_fwk_interrupt_func_ptr1 
   UNITY_SET_DETAIL(CMockString_fwk_interrupt_set_isr);
   cmock_call_instance = (CMOCK_fwk_interrupt_set_isr_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.fwk_interrupt_set_isr_CallInstance);
   Mock.fwk_interrupt_set_isr_CallInstance = CMock_Guts_MemNext(Mock.fwk_interrupt_set_isr_CallInstance);
+  if (!Mock.fwk_interrupt_set_isr_CallbackBool &&
+      Mock.fwk_interrupt_set_isr_CallbackFunctionPointer != NULL)
+  {
+    int cmock_cb_ret = Mock.fwk_interrupt_set_isr_CallbackFunctionPointer(interrupt, isr, Mock.fwk_interrupt_set_isr_CallbackCalls++);
+    UNITY_CLR_DETAILS();
+    return cmock_cb_ret;
+  }
   UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);
   cmock_line = cmock_call_instance->LineNumber;
   if (!cmock_call_instance->ExpectAnyArgsBool)
@@ -609,6 +971,10 @@ int fwk_interrupt_set_isr(unsigned int interrupt, cmock_fwk_interrupt_func_ptr1 
     UNITY_SET_DETAILS(CMockString_fwk_interrupt_set_isr,CMockString_isr);
     UNITY_TEST_ASSERT_EQUAL_PTR(cmock_call_instance->Expected_isr, isr, cmock_line, CMockStringMismatch);
   }
+  }
+  if (Mock.fwk_interrupt_set_isr_CallbackFunctionPointer != NULL)
+  {
+    cmock_call_instance->ReturnVal = Mock.fwk_interrupt_set_isr_CallbackFunctionPointer(interrupt, isr, Mock.fwk_interrupt_set_isr_CallbackCalls++);
   }
   UNITY_CLR_DETAILS();
   return cmock_call_instance->ReturnVal;
@@ -648,6 +1014,18 @@ void fwk_interrupt_set_isr_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsi
   cmock_call_instance->ReturnVal = cmock_to_return;
 }
 
+void fwk_interrupt_set_isr_AddCallback(CMOCK_fwk_interrupt_set_isr_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_set_isr_CallbackBool = (char)1;
+  Mock.fwk_interrupt_set_isr_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_set_isr_Stub(CMOCK_fwk_interrupt_set_isr_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_set_isr_CallbackBool = (char)0;
+  Mock.fwk_interrupt_set_isr_CallbackFunctionPointer = Callback;
+}
+
 int fwk_interrupt_set_isr_param(unsigned int interrupt, cmock_fwk_interrupt_func_ptr2 isr, uintptr_t param)
 {
   UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;
@@ -655,6 +1033,13 @@ int fwk_interrupt_set_isr_param(unsigned int interrupt, cmock_fwk_interrupt_func
   UNITY_SET_DETAIL(CMockString_fwk_interrupt_set_isr_param);
   cmock_call_instance = (CMOCK_fwk_interrupt_set_isr_param_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.fwk_interrupt_set_isr_param_CallInstance);
   Mock.fwk_interrupt_set_isr_param_CallInstance = CMock_Guts_MemNext(Mock.fwk_interrupt_set_isr_param_CallInstance);
+  if (!Mock.fwk_interrupt_set_isr_param_CallbackBool &&
+      Mock.fwk_interrupt_set_isr_param_CallbackFunctionPointer != NULL)
+  {
+    int cmock_cb_ret = Mock.fwk_interrupt_set_isr_param_CallbackFunctionPointer(interrupt, isr, param, Mock.fwk_interrupt_set_isr_param_CallbackCalls++);
+    UNITY_CLR_DETAILS();
+    return cmock_cb_ret;
+  }
   UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);
   cmock_line = cmock_call_instance->LineNumber;
   if (!cmock_call_instance->ExpectAnyArgsBool)
@@ -671,6 +1056,10 @@ int fwk_interrupt_set_isr_param(unsigned int interrupt, cmock_fwk_interrupt_func
     UNITY_SET_DETAILS(CMockString_fwk_interrupt_set_isr_param,CMockString_param);
     UNITY_TEST_ASSERT_EQUAL_MEMORY((void*)(&cmock_call_instance->Expected_param), (void*)(&param), sizeof(uintptr_t), cmock_line, CMockStringMismatch);
   }
+  }
+  if (Mock.fwk_interrupt_set_isr_param_CallbackFunctionPointer != NULL)
+  {
+    cmock_call_instance->ReturnVal = Mock.fwk_interrupt_set_isr_param_CallbackFunctionPointer(interrupt, isr, param, Mock.fwk_interrupt_set_isr_param_CallbackCalls++);
   }
   UNITY_CLR_DETAILS();
   return cmock_call_instance->ReturnVal;
@@ -712,6 +1101,18 @@ void fwk_interrupt_set_isr_param_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line
   cmock_call_instance->ReturnVal = cmock_to_return;
 }
 
+void fwk_interrupt_set_isr_param_AddCallback(CMOCK_fwk_interrupt_set_isr_param_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_set_isr_param_CallbackBool = (char)1;
+  Mock.fwk_interrupt_set_isr_param_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_set_isr_param_Stub(CMOCK_fwk_interrupt_set_isr_param_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_set_isr_param_CallbackBool = (char)0;
+  Mock.fwk_interrupt_set_isr_param_CallbackFunctionPointer = Callback;
+}
+
 int fwk_interrupt_get_current(unsigned int* interrupt)
 {
   UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;
@@ -719,6 +1120,13 @@ int fwk_interrupt_get_current(unsigned int* interrupt)
   UNITY_SET_DETAIL(CMockString_fwk_interrupt_get_current);
   cmock_call_instance = (CMOCK_fwk_interrupt_get_current_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.fwk_interrupt_get_current_CallInstance);
   Mock.fwk_interrupt_get_current_CallInstance = CMock_Guts_MemNext(Mock.fwk_interrupt_get_current_CallInstance);
+  if (!Mock.fwk_interrupt_get_current_CallbackBool &&
+      Mock.fwk_interrupt_get_current_CallbackFunctionPointer != NULL)
+  {
+    int cmock_cb_ret = Mock.fwk_interrupt_get_current_CallbackFunctionPointer(interrupt, Mock.fwk_interrupt_get_current_CallbackCalls++);
+    UNITY_CLR_DETAILS();
+    return cmock_cb_ret;
+  }
   UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);
   cmock_line = cmock_call_instance->LineNumber;
   if (!cmock_call_instance->ExpectAnyArgsBool)
@@ -728,17 +1136,29 @@ int fwk_interrupt_get_current(unsigned int* interrupt)
     if (cmock_call_instance->Expected_interrupt == NULL)
       { UNITY_TEST_ASSERT_NULL(interrupt, cmock_line, CMockStringExpNULL); }
     else
-      { UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY(cmock_call_instance->Expected_interrupt, interrupt, 1, cmock_line, CMockStringMismatch); }
+      { UNITY_TEST_ASSERT_EQUAL_HEX32_ARRAY(cmock_call_instance->Expected_interrupt, interrupt, cmock_call_instance->Expected_interrupt_Depth, cmock_line, CMockStringMismatch); }
   }
+  }
+  if (Mock.fwk_interrupt_get_current_CallbackFunctionPointer != NULL)
+  {
+    cmock_call_instance->ReturnVal = Mock.fwk_interrupt_get_current_CallbackFunctionPointer(interrupt, Mock.fwk_interrupt_get_current_CallbackCalls++);
+  }
+  if (cmock_call_instance->ReturnThruPtr_interrupt_Used)
+  {
+    UNITY_TEST_ASSERT_NOT_NULL(interrupt, cmock_line, CMockStringPtrIsNULL);
+    memcpy((void*)interrupt, (void*)cmock_call_instance->ReturnThruPtr_interrupt_Val,
+      cmock_call_instance->ReturnThruPtr_interrupt_Size);
   }
   UNITY_CLR_DETAILS();
   return cmock_call_instance->ReturnVal;
 }
 
-void CMockExpectParameters_fwk_interrupt_get_current(CMOCK_fwk_interrupt_get_current_CALL_INSTANCE* cmock_call_instance, unsigned int* interrupt);
-void CMockExpectParameters_fwk_interrupt_get_current(CMOCK_fwk_interrupt_get_current_CALL_INSTANCE* cmock_call_instance, unsigned int* interrupt)
+void CMockExpectParameters_fwk_interrupt_get_current(CMOCK_fwk_interrupt_get_current_CALL_INSTANCE* cmock_call_instance, unsigned int* interrupt, int interrupt_Depth);
+void CMockExpectParameters_fwk_interrupt_get_current(CMOCK_fwk_interrupt_get_current_CALL_INSTANCE* cmock_call_instance, unsigned int* interrupt, int interrupt_Depth)
 {
   cmock_call_instance->Expected_interrupt = interrupt;
+  cmock_call_instance->Expected_interrupt_Depth = interrupt_Depth;
+  cmock_call_instance->ReturnThruPtr_interrupt_Used = 0;
 }
 
 void fwk_interrupt_get_current_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return)
@@ -763,7 +1183,89 @@ void fwk_interrupt_get_current_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, 
   Mock.fwk_interrupt_get_current_CallInstance = CMock_Guts_MemChain(Mock.fwk_interrupt_get_current_CallInstance, cmock_guts_index);
   cmock_call_instance->LineNumber = cmock_line;
   cmock_call_instance->ExpectAnyArgsBool = (char)0;
-  CMockExpectParameters_fwk_interrupt_get_current(cmock_call_instance, interrupt);
+  CMockExpectParameters_fwk_interrupt_get_current(cmock_call_instance, interrupt, 1);
   cmock_call_instance->ReturnVal = cmock_to_return;
+}
+
+void fwk_interrupt_get_current_AddCallback(CMOCK_fwk_interrupt_get_current_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_get_current_CallbackBool = (char)1;
+  Mock.fwk_interrupt_get_current_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_get_current_Stub(CMOCK_fwk_interrupt_get_current_CALLBACK Callback)
+{
+  Mock.fwk_interrupt_get_current_CallbackBool = (char)0;
+  Mock.fwk_interrupt_get_current_CallbackFunctionPointer = Callback;
+}
+
+void fwk_interrupt_get_current_CMockExpectWithArrayAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int* interrupt, int interrupt_Depth, int cmock_to_return)
+{
+  CMOCK_MEM_INDEX_TYPE cmock_guts_index = CMock_Guts_MemNew(sizeof(CMOCK_fwk_interrupt_get_current_CALL_INSTANCE));
+  CMOCK_fwk_interrupt_get_current_CALL_INSTANCE* cmock_call_instance = (CMOCK_fwk_interrupt_get_current_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);
+  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringOutOfMemory);
+  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));
+  Mock.fwk_interrupt_get_current_CallInstance = CMock_Guts_MemChain(Mock.fwk_interrupt_get_current_CallInstance, cmock_guts_index);
+  cmock_call_instance->LineNumber = cmock_line;
+  cmock_call_instance->ExpectAnyArgsBool = (char)0;
+  CMockExpectParameters_fwk_interrupt_get_current(cmock_call_instance, interrupt, interrupt_Depth);
+  cmock_call_instance->ReturnVal = cmock_to_return;
+}
+
+void fwk_interrupt_get_current_CMockReturnMemThruPtr_interrupt(UNITY_LINE_TYPE cmock_line, unsigned int* interrupt, size_t cmock_size)
+{
+  CMOCK_fwk_interrupt_get_current_CALL_INSTANCE* cmock_call_instance = (CMOCK_fwk_interrupt_get_current_CALL_INSTANCE*)CMock_Guts_GetAddressFor(CMock_Guts_MemEndOfChain(Mock.fwk_interrupt_get_current_CallInstance));
+  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringPtrPreExp);
+  cmock_call_instance->ReturnThruPtr_interrupt_Used = 1;
+  cmock_call_instance->ReturnThruPtr_interrupt_Val = interrupt;
+  cmock_call_instance->ReturnThruPtr_interrupt_Size = cmock_size;
+}
+
+bool fwk_is_interrupt_context(void)
+{
+  UNITY_LINE_TYPE cmock_line = TEST_LINE_NUM;
+  CMOCK_fwk_is_interrupt_context_CALL_INSTANCE* cmock_call_instance;
+  UNITY_SET_DETAIL(CMockString_fwk_is_interrupt_context);
+  cmock_call_instance = (CMOCK_fwk_is_interrupt_context_CALL_INSTANCE*)CMock_Guts_GetAddressFor(Mock.fwk_is_interrupt_context_CallInstance);
+  Mock.fwk_is_interrupt_context_CallInstance = CMock_Guts_MemNext(Mock.fwk_is_interrupt_context_CallInstance);
+  if (!Mock.fwk_is_interrupt_context_CallbackBool &&
+      Mock.fwk_is_interrupt_context_CallbackFunctionPointer != NULL)
+  {
+    bool cmock_cb_ret = Mock.fwk_is_interrupt_context_CallbackFunctionPointer(Mock.fwk_is_interrupt_context_CallbackCalls++);
+    UNITY_CLR_DETAILS();
+    return cmock_cb_ret;
+  }
+  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringCalledMore);
+  cmock_line = cmock_call_instance->LineNumber;
+  if (Mock.fwk_is_interrupt_context_CallbackFunctionPointer != NULL)
+  {
+    cmock_call_instance->ReturnVal = Mock.fwk_is_interrupt_context_CallbackFunctionPointer(Mock.fwk_is_interrupt_context_CallbackCalls++);
+  }
+  UNITY_CLR_DETAILS();
+  return cmock_call_instance->ReturnVal;
+}
+
+void fwk_is_interrupt_context_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, bool cmock_to_return)
+{
+  CMOCK_MEM_INDEX_TYPE cmock_guts_index = CMock_Guts_MemNew(sizeof(CMOCK_fwk_is_interrupt_context_CALL_INSTANCE));
+  CMOCK_fwk_is_interrupt_context_CALL_INSTANCE* cmock_call_instance = (CMOCK_fwk_is_interrupt_context_CALL_INSTANCE*)CMock_Guts_GetAddressFor(cmock_guts_index);
+  UNITY_TEST_ASSERT_NOT_NULL(cmock_call_instance, cmock_line, CMockStringOutOfMemory);
+  memset(cmock_call_instance, 0, sizeof(*cmock_call_instance));
+  Mock.fwk_is_interrupt_context_CallInstance = CMock_Guts_MemChain(Mock.fwk_is_interrupt_context_CallInstance, cmock_guts_index);
+  cmock_call_instance->LineNumber = cmock_line;
+  cmock_call_instance->ExpectAnyArgsBool = (char)0;
+  cmock_call_instance->ReturnVal = cmock_to_return;
+}
+
+void fwk_is_interrupt_context_AddCallback(CMOCK_fwk_is_interrupt_context_CALLBACK Callback)
+{
+  Mock.fwk_is_interrupt_context_CallbackBool = (char)1;
+  Mock.fwk_is_interrupt_context_CallbackFunctionPointer = Callback;
+}
+
+void fwk_is_interrupt_context_Stub(CMOCK_fwk_is_interrupt_context_CALLBACK Callback)
+{
+  Mock.fwk_is_interrupt_context_CallbackBool = (char)0;
+  Mock.fwk_is_interrupt_context_CallbackFunctionPointer = Callback;
 }
 

--- a/unit_test/unity_mocks/mocks/Mockfwk_interrupt.h
+++ b/unit_test/unity_mocks/mocks/Mockfwk_interrupt.h
@@ -30,42 +30,108 @@ typedef void(*cmock_fwk_interrupt_func_ptr2)(uintptr_t param);
 void fwk_interrupt_init_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return);
 #define fwk_interrupt_init_ExpectAndReturn(driver, cmock_retval) fwk_interrupt_init_CMockExpectAndReturn(__LINE__, driver, cmock_retval)
 void fwk_interrupt_init_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, const struct fwk_arch_interrupt_driver* driver, int cmock_to_return);
+typedef int (* CMOCK_fwk_interrupt_init_CALLBACK)(const struct fwk_arch_interrupt_driver* driver, int cmock_num_calls);
+void fwk_interrupt_init_AddCallback(CMOCK_fwk_interrupt_init_CALLBACK Callback);
+void fwk_interrupt_init_Stub(CMOCK_fwk_interrupt_init_CALLBACK Callback);
+#define fwk_interrupt_init_StubWithCallback fwk_interrupt_init_Stub
+#define fwk_interrupt_init_ExpectWithArrayAndReturn(driver, driver_Depth, cmock_retval) fwk_interrupt_init_CMockExpectWithArrayAndReturn(__LINE__, driver, driver_Depth, cmock_retval)
+void fwk_interrupt_init_CMockExpectWithArrayAndReturn(UNITY_LINE_TYPE cmock_line, const struct fwk_arch_interrupt_driver* driver, int driver_Depth, int cmock_to_return);
 #define fwk_interrupt_is_enabled_ExpectAnyArgsAndReturn(cmock_retval) fwk_interrupt_is_enabled_CMockExpectAnyArgsAndReturn(__LINE__, cmock_retval)
 void fwk_interrupt_is_enabled_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return);
 #define fwk_interrupt_is_enabled_ExpectAndReturn(interrupt, enabled, cmock_retval) fwk_interrupt_is_enabled_CMockExpectAndReturn(__LINE__, interrupt, enabled, cmock_retval)
 void fwk_interrupt_is_enabled_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, bool* enabled, int cmock_to_return);
+typedef int (* CMOCK_fwk_interrupt_is_enabled_CALLBACK)(unsigned int interrupt, bool* enabled, int cmock_num_calls);
+void fwk_interrupt_is_enabled_AddCallback(CMOCK_fwk_interrupt_is_enabled_CALLBACK Callback);
+void fwk_interrupt_is_enabled_Stub(CMOCK_fwk_interrupt_is_enabled_CALLBACK Callback);
+#define fwk_interrupt_is_enabled_StubWithCallback fwk_interrupt_is_enabled_Stub
+#define fwk_interrupt_is_enabled_ExpectWithArrayAndReturn(interrupt, enabled, enabled_Depth, cmock_retval) fwk_interrupt_is_enabled_CMockExpectWithArrayAndReturn(__LINE__, interrupt, enabled, enabled_Depth, cmock_retval)
+void fwk_interrupt_is_enabled_CMockExpectWithArrayAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, bool* enabled, int enabled_Depth, int cmock_to_return);
+#define fwk_interrupt_is_enabled_ReturnThruPtr_enabled(enabled) fwk_interrupt_is_enabled_CMockReturnMemThruPtr_enabled(__LINE__, enabled, sizeof(bool))
+#define fwk_interrupt_is_enabled_ReturnArrayThruPtr_enabled(enabled, cmock_len) fwk_interrupt_is_enabled_CMockReturnMemThruPtr_enabled(__LINE__, enabled, cmock_len * sizeof(*enabled))
+#define fwk_interrupt_is_enabled_ReturnMemThruPtr_enabled(enabled, cmock_size) fwk_interrupt_is_enabled_CMockReturnMemThruPtr_enabled(__LINE__, enabled, cmock_size)
+void fwk_interrupt_is_enabled_CMockReturnMemThruPtr_enabled(UNITY_LINE_TYPE cmock_line, bool* enabled, size_t cmock_size);
 #define fwk_interrupt_enable_ExpectAnyArgsAndReturn(cmock_retval) fwk_interrupt_enable_CMockExpectAnyArgsAndReturn(__LINE__, cmock_retval)
 void fwk_interrupt_enable_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return);
 #define fwk_interrupt_enable_ExpectAndReturn(interrupt, cmock_retval) fwk_interrupt_enable_CMockExpectAndReturn(__LINE__, interrupt, cmock_retval)
 void fwk_interrupt_enable_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, int cmock_to_return);
+typedef int (* CMOCK_fwk_interrupt_enable_CALLBACK)(unsigned int interrupt, int cmock_num_calls);
+void fwk_interrupt_enable_AddCallback(CMOCK_fwk_interrupt_enable_CALLBACK Callback);
+void fwk_interrupt_enable_Stub(CMOCK_fwk_interrupt_enable_CALLBACK Callback);
+#define fwk_interrupt_enable_StubWithCallback fwk_interrupt_enable_Stub
 #define fwk_interrupt_disable_ExpectAnyArgsAndReturn(cmock_retval) fwk_interrupt_disable_CMockExpectAnyArgsAndReturn(__LINE__, cmock_retval)
 void fwk_interrupt_disable_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return);
 #define fwk_interrupt_disable_ExpectAndReturn(interrupt, cmock_retval) fwk_interrupt_disable_CMockExpectAndReturn(__LINE__, interrupt, cmock_retval)
 void fwk_interrupt_disable_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, int cmock_to_return);
+typedef int (* CMOCK_fwk_interrupt_disable_CALLBACK)(unsigned int interrupt, int cmock_num_calls);
+void fwk_interrupt_disable_AddCallback(CMOCK_fwk_interrupt_disable_CALLBACK Callback);
+void fwk_interrupt_disable_Stub(CMOCK_fwk_interrupt_disable_CALLBACK Callback);
+#define fwk_interrupt_disable_StubWithCallback fwk_interrupt_disable_Stub
 #define fwk_interrupt_is_pending_ExpectAnyArgsAndReturn(cmock_retval) fwk_interrupt_is_pending_CMockExpectAnyArgsAndReturn(__LINE__, cmock_retval)
 void fwk_interrupt_is_pending_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return);
 #define fwk_interrupt_is_pending_ExpectAndReturn(interrupt, pending, cmock_retval) fwk_interrupt_is_pending_CMockExpectAndReturn(__LINE__, interrupt, pending, cmock_retval)
 void fwk_interrupt_is_pending_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, bool* pending, int cmock_to_return);
+typedef int (* CMOCK_fwk_interrupt_is_pending_CALLBACK)(unsigned int interrupt, bool* pending, int cmock_num_calls);
+void fwk_interrupt_is_pending_AddCallback(CMOCK_fwk_interrupt_is_pending_CALLBACK Callback);
+void fwk_interrupt_is_pending_Stub(CMOCK_fwk_interrupt_is_pending_CALLBACK Callback);
+#define fwk_interrupt_is_pending_StubWithCallback fwk_interrupt_is_pending_Stub
+#define fwk_interrupt_is_pending_ExpectWithArrayAndReturn(interrupt, pending, pending_Depth, cmock_retval) fwk_interrupt_is_pending_CMockExpectWithArrayAndReturn(__LINE__, interrupt, pending, pending_Depth, cmock_retval)
+void fwk_interrupt_is_pending_CMockExpectWithArrayAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, bool* pending, int pending_Depth, int cmock_to_return);
+#define fwk_interrupt_is_pending_ReturnThruPtr_pending(pending) fwk_interrupt_is_pending_CMockReturnMemThruPtr_pending(__LINE__, pending, sizeof(bool))
+#define fwk_interrupt_is_pending_ReturnArrayThruPtr_pending(pending, cmock_len) fwk_interrupt_is_pending_CMockReturnMemThruPtr_pending(__LINE__, pending, cmock_len * sizeof(*pending))
+#define fwk_interrupt_is_pending_ReturnMemThruPtr_pending(pending, cmock_size) fwk_interrupt_is_pending_CMockReturnMemThruPtr_pending(__LINE__, pending, cmock_size)
+void fwk_interrupt_is_pending_CMockReturnMemThruPtr_pending(UNITY_LINE_TYPE cmock_line, bool* pending, size_t cmock_size);
 #define fwk_interrupt_set_pending_ExpectAnyArgsAndReturn(cmock_retval) fwk_interrupt_set_pending_CMockExpectAnyArgsAndReturn(__LINE__, cmock_retval)
 void fwk_interrupt_set_pending_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return);
 #define fwk_interrupt_set_pending_ExpectAndReturn(interrupt, cmock_retval) fwk_interrupt_set_pending_CMockExpectAndReturn(__LINE__, interrupt, cmock_retval)
 void fwk_interrupt_set_pending_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, int cmock_to_return);
+typedef int (* CMOCK_fwk_interrupt_set_pending_CALLBACK)(unsigned int interrupt, int cmock_num_calls);
+void fwk_interrupt_set_pending_AddCallback(CMOCK_fwk_interrupt_set_pending_CALLBACK Callback);
+void fwk_interrupt_set_pending_Stub(CMOCK_fwk_interrupt_set_pending_CALLBACK Callback);
+#define fwk_interrupt_set_pending_StubWithCallback fwk_interrupt_set_pending_Stub
 #define fwk_interrupt_clear_pending_ExpectAnyArgsAndReturn(cmock_retval) fwk_interrupt_clear_pending_CMockExpectAnyArgsAndReturn(__LINE__, cmock_retval)
 void fwk_interrupt_clear_pending_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return);
 #define fwk_interrupt_clear_pending_ExpectAndReturn(interrupt, cmock_retval) fwk_interrupt_clear_pending_CMockExpectAndReturn(__LINE__, interrupt, cmock_retval)
 void fwk_interrupt_clear_pending_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, int cmock_to_return);
+typedef int (* CMOCK_fwk_interrupt_clear_pending_CALLBACK)(unsigned int interrupt, int cmock_num_calls);
+void fwk_interrupt_clear_pending_AddCallback(CMOCK_fwk_interrupt_clear_pending_CALLBACK Callback);
+void fwk_interrupt_clear_pending_Stub(CMOCK_fwk_interrupt_clear_pending_CALLBACK Callback);
+#define fwk_interrupt_clear_pending_StubWithCallback fwk_interrupt_clear_pending_Stub
 #define fwk_interrupt_set_isr_ExpectAnyArgsAndReturn(cmock_retval) fwk_interrupt_set_isr_CMockExpectAnyArgsAndReturn(__LINE__, cmock_retval)
 void fwk_interrupt_set_isr_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return);
 #define fwk_interrupt_set_isr_ExpectAndReturn(interrupt, isr, cmock_retval) fwk_interrupt_set_isr_CMockExpectAndReturn(__LINE__, interrupt, isr, cmock_retval)
 void fwk_interrupt_set_isr_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, cmock_fwk_interrupt_func_ptr1 isr, int cmock_to_return);
+typedef int (* CMOCK_fwk_interrupt_set_isr_CALLBACK)(unsigned int interrupt, cmock_fwk_interrupt_func_ptr1 isr, int cmock_num_calls);
+void fwk_interrupt_set_isr_AddCallback(CMOCK_fwk_interrupt_set_isr_CALLBACK Callback);
+void fwk_interrupt_set_isr_Stub(CMOCK_fwk_interrupt_set_isr_CALLBACK Callback);
+#define fwk_interrupt_set_isr_StubWithCallback fwk_interrupt_set_isr_Stub
 #define fwk_interrupt_set_isr_param_ExpectAnyArgsAndReturn(cmock_retval) fwk_interrupt_set_isr_param_CMockExpectAnyArgsAndReturn(__LINE__, cmock_retval)
 void fwk_interrupt_set_isr_param_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return);
 #define fwk_interrupt_set_isr_param_ExpectAndReturn(interrupt, isr, param, cmock_retval) fwk_interrupt_set_isr_param_CMockExpectAndReturn(__LINE__, interrupt, isr, param, cmock_retval)
 void fwk_interrupt_set_isr_param_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int interrupt, cmock_fwk_interrupt_func_ptr2 isr, uintptr_t param, int cmock_to_return);
+typedef int (* CMOCK_fwk_interrupt_set_isr_param_CALLBACK)(unsigned int interrupt, cmock_fwk_interrupt_func_ptr2 isr, uintptr_t param, int cmock_num_calls);
+void fwk_interrupt_set_isr_param_AddCallback(CMOCK_fwk_interrupt_set_isr_param_CALLBACK Callback);
+void fwk_interrupt_set_isr_param_Stub(CMOCK_fwk_interrupt_set_isr_param_CALLBACK Callback);
+#define fwk_interrupt_set_isr_param_StubWithCallback fwk_interrupt_set_isr_param_Stub
 #define fwk_interrupt_get_current_ExpectAnyArgsAndReturn(cmock_retval) fwk_interrupt_get_current_CMockExpectAnyArgsAndReturn(__LINE__, cmock_retval)
 void fwk_interrupt_get_current_CMockExpectAnyArgsAndReturn(UNITY_LINE_TYPE cmock_line, int cmock_to_return);
 #define fwk_interrupt_get_current_ExpectAndReturn(interrupt, cmock_retval) fwk_interrupt_get_current_CMockExpectAndReturn(__LINE__, interrupt, cmock_retval)
 void fwk_interrupt_get_current_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int* interrupt, int cmock_to_return);
+typedef int (* CMOCK_fwk_interrupt_get_current_CALLBACK)(unsigned int* interrupt, int cmock_num_calls);
+void fwk_interrupt_get_current_AddCallback(CMOCK_fwk_interrupt_get_current_CALLBACK Callback);
+void fwk_interrupt_get_current_Stub(CMOCK_fwk_interrupt_get_current_CALLBACK Callback);
+#define fwk_interrupt_get_current_StubWithCallback fwk_interrupt_get_current_Stub
+#define fwk_interrupt_get_current_ExpectWithArrayAndReturn(interrupt, interrupt_Depth, cmock_retval) fwk_interrupt_get_current_CMockExpectWithArrayAndReturn(__LINE__, interrupt, interrupt_Depth, cmock_retval)
+void fwk_interrupt_get_current_CMockExpectWithArrayAndReturn(UNITY_LINE_TYPE cmock_line, unsigned int* interrupt, int interrupt_Depth, int cmock_to_return);
+#define fwk_interrupt_get_current_ReturnThruPtr_interrupt(interrupt) fwk_interrupt_get_current_CMockReturnMemThruPtr_interrupt(__LINE__, interrupt, sizeof(unsigned int))
+#define fwk_interrupt_get_current_ReturnArrayThruPtr_interrupt(interrupt, cmock_len) fwk_interrupt_get_current_CMockReturnMemThruPtr_interrupt(__LINE__, interrupt, cmock_len * sizeof(*interrupt))
+#define fwk_interrupt_get_current_ReturnMemThruPtr_interrupt(interrupt, cmock_size) fwk_interrupt_get_current_CMockReturnMemThruPtr_interrupt(__LINE__, interrupt, cmock_size)
+void fwk_interrupt_get_current_CMockReturnMemThruPtr_interrupt(UNITY_LINE_TYPE cmock_line, unsigned int* interrupt, size_t cmock_size);
+#define fwk_is_interrupt_context_ExpectAndReturn(cmock_retval) fwk_is_interrupt_context_CMockExpectAndReturn(__LINE__, cmock_retval)
+void fwk_is_interrupt_context_CMockExpectAndReturn(UNITY_LINE_TYPE cmock_line, bool cmock_to_return);
+typedef bool (* CMOCK_fwk_is_interrupt_context_CALLBACK)(int cmock_num_calls);
+void fwk_is_interrupt_context_AddCallback(CMOCK_fwk_is_interrupt_context_CALLBACK Callback);
+void fwk_is_interrupt_context_Stub(CMOCK_fwk_is_interrupt_context_CALLBACK Callback);
+#define fwk_is_interrupt_context_StubWithCallback fwk_is_interrupt_context_Stub
 
 #if defined(__GNUC__) && !defined(__ICC) && !defined(__TMS470__)
 #if __GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ > 6 || (__GNUC_MINOR__ == 6 && __GNUC_PATCHLEVEL__ > 0)))


### PR DESCRIPTION
This PR mainly adds unit tests for MHUv3 driver. see [module/mhu3: Add unit tests](https://github.com/ARM-software/SCP-firmware/commit/62ea9c26061ce6d3f638385ecadfebf8e3ad7dc1)
It also adds misc dependency changes such as [unit_test: Regenerate mocks for fwk_interrupt.h](https://github.com/ARM-software/SCP-firmware/commit/0aeafcd275d7b10fc4dea5a31e7e7c2c8a7810a4) and minor fix in MHUv3 driver