### PR TITLE
module: cmake: add option to replace modules

### DIFF
--- a/module/CMakeLists.txt
+++ b/module/CMakeLists.txt
@@ -86,6 +86,14 @@ list(APPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/traffic_cop")
 list(APPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/transport")
 list(APPEND SCP_MODULE_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/voltage_domain")
 
+#
+# Remove paths if this variable is defined by the platform target's
+# Firmware.cmake
+#
+if(SCP_MODULE_EXCLUDE_PATHS)
+    list(REMOVE_ITEM SCP_MODULE_PATHS ${SCP_MODULE_EXCLUDE_PATHS})
+endif()
+
 foreach(source_dir IN LISTS SCP_MODULE_PATHS)
     unset(SCP_MODULE)
 


### PR DESCRIPTION
Some platforms have special feature need to slightly modify upstream module. Add option to replace with the module defined in product path.

Change-Id: I1dc89ca49eecb1f2fb2e2537234cea7f98116c1c
Signed-off-by: Joe Zhu <Chunguang.Zhu@verisilicon.com>