### PR TITLE
tools: Update unit-test related checks

### DIFF
--- a/tools/check_copyright.py
+++ b/tools/check_copyright.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -27,7 +27,7 @@ from itertools import islice
 #
 
 # Exclude all mod_test "mocks" directories
-UNIT_TEST_MOCKS = glob.glob("module/*/test/mocks")
+UNIT_TEST_MOCKS = glob.glob('module/*/test/**/mocks', recursive=True)
 
 EXCLUDE_DIRECTORIES = [
     '.git',

--- a/tools/check_spacing.py
+++ b/tools/check_spacing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -24,7 +24,7 @@ import glob
 #
 
 # Exclude all mod_test "mocks" directories
-UNIT_TEST_MOCKS = glob.glob("module/*/test/mocks")
+UNIT_TEST_MOCKS = glob.glob('module/*/test/**/mocks', recursive=True)
 
 EXCLUDE_DIRECTORIES = [
     '.git',

--- a/tools/check_tabs.py
+++ b/tools/check_tabs.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -23,7 +23,7 @@ import glob
 #
 
 # Exclude all mod_test "mocks" directories
-UNIT_TEST_MOCKS = glob.glob("module/*/test/mocks")
+UNIT_TEST_MOCKS = glob.glob('module/*/test/**/mocks', recursive=True)
 
 EXCLUDE_DIRECTORIES = [
     '.git',


### PR DESCRIPTION
It should be possible to add multiple unit-test files for one module. Each file must be in a separate subdirectory under the module test directory. The tools checking for spacing, tabs, and copyright must consider this configuration.

Signed-off-by: Tarek El-Sherbiny <tarek.el-sherbiny@arm.com>
Change-Id: If02db0f0c190736b193494109915eb6e0f8ec592