### PR TITLE
fwk: add FWK_TRACE

### DIFF
--- a/cmake/SCPModuleTrace.cmake
+++ b/cmake/SCPModuleTrace.cmake
@@ -1,0 +1,31 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+include_guard()
+
+include(SCPPreprocessSource)
+
+# .rst:
+#
+# .. command:: scp_module_trace
+#
+# Checks if SCP_TRACE_ENABLE_MOD_<module name>` is set and enables `FWK_TRACE`
+#
+# .. cmake:: scp_module_trace(<module_name>)
+#
+macro(scp_module_trace module_name)
+
+    # Creates a module name tag moving to upper case and replacing `-` by `_`.
+    string(TOUPPER ${module_name} SCP_MODULE_TAG)
+    string(REPLACE "-" "_" SCP_MODULE_TAG ${SCP_MODULE_TAG})
+    set(MOD_TRACE_ENABLE_FLAG "SCP_TRACE_ENABLE_MOD_${SCP_MODULE_TAG}")
+
+    # Checks if the enable flag is set.
+    if(${MOD_TRACE_ENABLE_FLAG})
+        add_compile_definitions(PUBLIC FWK_TRACE_ENABLE)
+    endif()
+endmacro()

--- a/doc/framework.md
+++ b/doc/framework.md
@@ -1,6 +1,6 @@
 # Framework Guide
 
-Copyright (c) 2011-2022, Arm Limited. All rights reserved.
+Copyright (c) 2011-2023, Arm Limited. All rights reserved.
 
 This guide covers the framework that is used to implement the SCP/MCP Software
 and which can also be used to extend the provided implementation. Each of the
@@ -598,3 +598,18 @@ void *fwk_log_driver_config = &cfg;
 The driver module can then access its log framework related configuration data
 at any time. It is expected that the driver module performs initialization using
 this configuration data in the fwk_log_driver_init() function.
+
+#### Tracing
+To enable tracing functionality `FWK_TRACE_ENABLE` should be defined.
+There is an example configuration for CMake that should be included in
+`CMakeLists.txt` in every module that uses this feature. This configuration
+ requires `SCP_TRACE_ENABLE_MOD_<module name>` to be defined as a build flag
+ parameter.
+
+```
+include(SCPModuleTrace)
+
+...
+
+scp_module_trace(${SCP_MODULE})
+```

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -119,7 +119,7 @@ if(NOT DEFINED SCP_LOG_LEVEL)
         "${SCP_LOG_LEVEL_DEFAULT}"
         CACHE STRING "Minimum logging level.")
 
-    set_property(CACHE SCP_LOG_LEVEL PROPERTY STRINGS "TRACE" "INFO" "WARN"
+    set_property(CACHE SCP_LOG_LEVEL PROPERTY STRINGS "DEBUG" "INFO" "WARN"
                                                       "ERROR" "CRIT")
 endif()
 

--- a/framework/include/fwk_log.h
+++ b/framework/include/fwk_log.h
@@ -197,6 +197,20 @@
 #define FWK_LOG_FLUSH() fwk_log_flush()
 
 /*!
+ * \def FWK_TRACE
+ *
+ * \brief Trace a message.
+ *
+ * \param[in] ... Format string and any associated parameters.
+ */
+
+#ifdef FWK_TRACE_ENABLE
+#    define FWK_TRACE(...) fwk_log_printf(__VA_ARGS__)
+#else
+#    define FWK_TRACE(...)
+#endif
+
+/*!
  * \def FWK_LOG_DEBUG
  *
  * \brief Log a [debug](::FWK_LOG_LEVEL_DEBUG) message.

--- a/framework/include/fwk_log.h
+++ b/framework/include/fwk_log.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -32,7 +32,7 @@
  *      Log messages are assigned a filter level based on the logging macro
  *      used. These macros are as follows:
  *
- *       - ::FWK_LOG_TRACE
+ *       - ::FWK_LOG_DEBUG
  *       - ::FWK_LOG_INFO
  *       - ::FWK_LOG_WARN
  *       - ::FWK_LOG_ERR
@@ -139,12 +139,12 @@
  */
 
 /*!
- * \def FWK_LOG_LEVEL_TRACE
+ * \def FWK_LOG_LEVEL_DEBUG
  *
- * \brief *Trace* filter level.
+ * \brief *Debug* filter level.
  *
  * \details Messages assigned this filter level represent messages used for
- *      tracing logic and debugging.
+ *      diagnosing problems.
  *
  * \def FWK_LOG_LEVEL_INFO
  *
@@ -173,7 +173,7 @@
  * \details Messages assigned this filter level represent fatal errors.
  */
 
-#define FWK_LOG_LEVEL_TRACE 0
+#define FWK_LOG_LEVEL_DEBUG 0
 #define FWK_LOG_LEVEL_INFO 1
 #define FWK_LOG_LEVEL_WARN 2
 #define FWK_LOG_LEVEL_ERROR 3
@@ -197,17 +197,17 @@
 #define FWK_LOG_FLUSH() fwk_log_flush()
 
 /*!
- * \def FWK_LOG_TRACE
+ * \def FWK_LOG_DEBUG
  *
- * \brief Log a [trace](::FWK_LOG_LEVEL_TRACE) message.
+ * \brief Log a [debug](::FWK_LOG_LEVEL_DEBUG) message.
  *
  * \param[in] ... Format string and any associated parameters.
  */
 
-#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
-#    define FWK_LOG_TRACE(...) fwk_log_printf(__VA_ARGS__)
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
+#    define FWK_LOG_DEBUG(...) fwk_log_printf(__VA_ARGS__)
 #else
-#    define FWK_LOG_TRACE(...)
+#    define FWK_LOG_DEBUG(...)
 #endif
 
 /*!

--- a/framework/src/fwk_core.c
+++ b/framework/src/fwk_core.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -149,8 +149,8 @@ static int put_event(
         fwk_list_push_tail(&ctx.isr_event_queue, &allocated_event->slist_node);
     }
 
-#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
-    FWK_LOG_TRACE(
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
+    FWK_LOG_DEBUG(
         "[FWK] Sent %" PRIu32 ": %s @ %s -> %s",
         std_event != NULL ? std_event->cookie : 0,
         FWK_ID_STR(allocated_event->id),
@@ -181,8 +181,8 @@ static void process_next_event(void)
     ctx.current_event = event = FWK_LIST_GET(
         fwk_list_pop_head(&ctx.event_queue), struct fwk_event, slist_node);
 
-#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
-    FWK_LOG_TRACE(
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
+    FWK_LOG_DEBUG(
         "[FWK] Processing %" PRIu32 ": %s @ %s -> %s\n",
         event->cookie,
         FWK_ID_STR(event->id),
@@ -252,8 +252,8 @@ static bool process_isr(void)
         return false;
     }
 
-#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
-    FWK_LOG_TRACE(
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
+    FWK_LOG_DEBUG(
         "[FWK] Pulled ISR event (%s: %s -> %s)\n",
         FWK_ID_STR(isr_event->id),
         FWK_ID_STR(isr_event->source_id),

--- a/module/cmn700/src/mod_cmn700.c
+++ b/module/cmn700/src/mod_cmn700.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -211,7 +211,7 @@ static int cmn700_discovery(void)
     FWK_LOG_INFO(
         MOD_NAME "CMN-700 revision: %s", get_cmn700_revision_name(ctx->root));
     FWK_LOG_INFO(MOD_NAME "Starting discovery...");
-    FWK_LOG_TRACE(MOD_NAME "Rootnode Base address: 0x%x", (uintptr_t)ctx->root);
+    FWK_LOG_DEBUG(MOD_NAME "Rootnode Base address: 0x%x", (uintptr_t)ctx->root);
 
     fwk_assert(get_node_type(ctx->root) == NODE_TYPE_CFG);
 

--- a/module/dvfs/src/mod_dvfs.c
+++ b/module/dvfs/src/mod_dvfs.c
@@ -289,7 +289,7 @@ static void dvfs_flush_pending_request(struct mod_dvfs_domain_ctx *ctx)
             ctx->pending_request.retry_request,
             ctx->pending_request.num_retries);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[DVFS] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[DVFS] %s @%d", __func__, __LINE__);
         }
     }
     ctx->pending_request = (struct mod_dvfs_request){ 0 };
@@ -310,7 +310,7 @@ static void alarm_callback(uintptr_t param)
 
     status = fwk_put_event(&req);
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[DVFS] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[DVFS] %s @%d", __func__, __LINE__);
     }
 }
 
@@ -617,7 +617,7 @@ static void dvfs_complete_respond(
             }
             status = fwk_put_event(&read_req_event);
             if (status != FWK_SUCCESS) {
-                FWK_LOG_TRACE("[DVFS] %s @%d", __func__, __LINE__);
+                FWK_LOG_DEBUG("[DVFS] %s @%d", __func__, __LINE__);
             }
         }
         ctx->cookie = 0;

--- a/module/mhu/src/mod_mhu.c
+++ b/module/mhu/src/mod_mhu.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -104,7 +104,7 @@ static void mhu_isr(void)
             status =
                 transport_channel->api->signal_message(transport_channel->id);
             if (status != FWK_SUCCESS) {
-                FWK_LOG_TRACE("[MHU] %s @%d", __func__, __LINE__);
+                FWK_LOG_DEBUG("[MHU] %s @%d", __func__, __LINE__);
             }
         }
 

--- a/module/optee/clock/src/mod_optee_clock.c
+++ b/module/optee/clock/src/mod_optee_clock.c
@@ -1,6 +1,7 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Linaro Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Linaro Limited and Contributors. All rights
+ * reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -70,8 +71,11 @@ static int get_rate(fwk_id_t dev_id, uint64_t *rate)
 
     *rate = clk_get_rate(ctx->clk);
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI optee_clock (%u/\"%s\"): clk_get_rate() = %"PRIu64,
-         fwk_id_get_element_idx(dev_id), clk_get_name(ctx->clk), *rate);
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI optee_clock (%u/\"%s\"): clk_get_rate() = %" PRIu64,
+        fwk_id_get_element_idx(dev_id),
+        clk_get_name(ctx->clk),
+        *rate);
 
     return FWK_SUCCESS;
 }
@@ -102,25 +106,33 @@ static int set_state(fwk_id_t dev_id, enum mod_clock_state state)
 
     if (state == MOD_CLOCK_STATE_STOPPED) {
         if (ctx->enabled) {
-            FWK_LOG_TRACE(MOD_NAME "SCMI optee_clock (%u/\"%s\") disable",
-                 fwk_id_get_element_idx(dev_id), clk_get_name(ctx->clk));
+            FWK_LOG_DEBUG(
+                MOD_NAME "SCMI optee_clock (%u/\"%s\") disable",
+                fwk_id_get_element_idx(dev_id),
+                clk_get_name(ctx->clk));
 
             clk_disable(ctx->clk);
             ctx->enabled = false;
         } else {
-            FWK_LOG_TRACE(MOD_NAME "SCMI optee_clock (%u/\"%s\") is already OFF",
-                fwk_id_get_element_idx(dev_id), clk_get_name(ctx->clk));
+            FWK_LOG_DEBUG(
+                MOD_NAME "SCMI optee_clock (%u/\"%s\") is already OFF",
+                fwk_id_get_element_idx(dev_id),
+                clk_get_name(ctx->clk));
         }
     } else {
         if (!ctx->enabled) {
-            FWK_LOG_TRACE(MOD_NAME "SCMI optee_clock (%u/\"%s\") enable",
-                 fwk_id_get_element_idx(dev_id), clk_get_name(ctx->clk));
+            FWK_LOG_DEBUG(
+                MOD_NAME "SCMI optee_clock (%u/\"%s\") enable",
+                fwk_id_get_element_idx(dev_id),
+                clk_get_name(ctx->clk));
 
             clk_enable(ctx->clk);
             ctx->enabled = true;
         } else {
-            FWK_LOG_TRACE(MOD_NAME "SCMI optee_clock (%u/\"%s\") is already ON",
-                fwk_id_get_element_idx(dev_id), clk_get_name(ctx->clk));
+            FWK_LOG_DEBUG(
+                MOD_NAME "SCMI optee_clock (%u/\"%s\") is already ON",
+                fwk_id_get_element_idx(dev_id),
+                clk_get_name(ctx->clk));
         }
     }
 
@@ -146,9 +158,11 @@ static int get_state(fwk_id_t dev_id, enum mod_clock_state *state)
         *state = MOD_CLOCK_STATE_STOPPED;
     }
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI optee_clock (%u/\"%s\") is %s",
-         fwk_id_get_element_idx(dev_id), clk_get_name(ctx->clk),
-         *state == MOD_CLOCK_STATE_STOPPED ? "off" : "on");
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI optee_clock (%u/\"%s\") is %s",
+        fwk_id_get_element_idx(dev_id),
+        clk_get_name(ctx->clk),
+        *state == MOD_CLOCK_STATE_STOPPED ? "off" : "on");
 
     return FWK_SUCCESS;
 }
@@ -224,8 +238,11 @@ static int set_rate(fwk_id_t dev_id, uint64_t rate,
         return FWK_E_SUPPORT;
     }
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI optee_clock (%u/\"%s\"): rate = %"PRIu64,
-         fwk_id_get_element_idx(dev_id), clk_get_name(ctx->clk), rate);
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI optee_clock (%u/\"%s\"): rate = %" PRIu64,
+        fwk_id_get_element_idx(dev_id),
+        clk_get_name(ctx->clk),
+        rate);
 
     return FWK_SUCCESS;
 }
@@ -266,9 +283,12 @@ static int get_rate_from_index(fwk_id_t dev_id,
         fwk_assert(!res && rate_count == 1);
     *rate = rate_ul;
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI optee_clock (%u/\"%s\"): rate(index %u) = %lu",
-         fwk_id_get_element_idx(dev_id), clk_get_name(ctx->clk), rate_index,
-         rate_ul);
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI optee_clock (%u/\"%s\"): rate(index %u) = %lu",
+        fwk_id_get_element_idx(dev_id),
+        clk_get_name(ctx->clk),
+        rate_index,
+        rate_ul);
 
     return FWK_SUCCESS;
 }

--- a/module/optee/reset/src/mod_optee_reset.c
+++ b/module/optee/reset/src/mod_optee_reset.c
@@ -1,6 +1,7 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Linaro Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Linaro Limited and Contributors. All rights
+ * reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -71,24 +72,30 @@ static int reset_set_state(fwk_id_t dev_id, enum mod_reset_domain_mode mode,
 
     switch (mode) {
     case MOD_RESET_DOMAIN_MODE_EXPLICIT_ASSERT:
-        FWK_LOG_TRACE(MOD_NAME "SCMI reset %u: assert(%s)",
-             fwk_id_get_element_idx(dev_id), rstctrl_name(ctx->rstctrl));
+        FWK_LOG_DEBUG(
+            MOD_NAME "SCMI reset %u: assert(%s)",
+            fwk_id_get_element_idx(dev_id),
+            rstctrl_name(ctx->rstctrl));
 
         if (rstctrl_assert(ctx->rstctrl)) {
             status = FWK_E_DEVICE;
         }
         break;
     case MOD_RESET_DOMAIN_MODE_EXPLICIT_DEASSERT:
-        FWK_LOG_TRACE(MOD_NAME "SCMI reset %u: deassert(%s)",
-             fwk_id_get_element_idx(dev_id), rstctrl_name(ctx->rstctrl));
+        FWK_LOG_DEBUG(
+            MOD_NAME "SCMI reset %u: deassert(%s)",
+            fwk_id_get_element_idx(dev_id),
+            rstctrl_name(ctx->rstctrl));
 
         if (rstctrl_deassert(ctx->rstctrl)) {
             status = FWK_E_DEVICE;
         }
         break;
     case MOD_RESET_DOMAIN_AUTO_RESET:
-        FWK_LOG_TRACE(MOD_NAME "SCMI reset %u: cycle(%s)",
-             fwk_id_get_element_idx(dev_id), rstctrl_name(ctx->rstctrl));
+        FWK_LOG_DEBUG(
+            MOD_NAME "SCMI reset %u: cycle(%s)",
+            fwk_id_get_element_idx(dev_id),
+            rstctrl_name(ctx->rstctrl));
 
         if (rstctrl_assert_to(ctx->rstctrl, TIMEOUT_US_1MS)) {
             status = FWK_E_TIMEOUT;

--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -662,7 +662,7 @@ static bool initiate_power_state_pre_transition_notification(struct pd_ctx *pd)
         &notification_event,
         &pd->power_state_pre_transition_notification_ctx.pending_responses);
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[PD] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[PD] %s @%d", __func__, __LINE__);
     }
 
     pd->power_state_pre_transition_notification_ctx.state = state;
@@ -694,8 +694,8 @@ static int initiate_power_state_transition(struct pd_ctx *pd)
 
     if ((pd->driver_api->deny != NULL) &&
         pd->driver_api->deny(pd->driver_id, state)) {
-#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
-        FWK_LOG_TRACE(
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
+        FWK_LOG_DEBUG(
             "[PD] Transition of %s to state <%s> denied by driver",
             fwk_module_get_element_name(pd->id),
             get_state_name(pd, state));
@@ -705,9 +705,9 @@ static int initiate_power_state_transition(struct pd_ctx *pd)
 
     status = pd->driver_api->set_state(pd->driver_id, state);
 
-#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
     if (status == FWK_SUCCESS) {
-        FWK_LOG_TRACE(
+        FWK_LOG_DEBUG(
             "[PD] Transition of %s from <%s> to <%s> succeeded",
             fwk_module_get_element_name(pd->id),
             get_state_name(pd, pd->state_requested_to_driver),
@@ -762,7 +762,7 @@ static void respond(struct pd_ctx *pd, int resp_status)
 
     status = fwk_put_event(&resp_event);
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[PD] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[PD] %s @%d", __func__, __LINE__);
     }
 }
 
@@ -1113,7 +1113,7 @@ static void process_power_state_transition_report_deeper_state(
     if (!initiate_power_state_pre_transition_notification(parent)) {
         status = initiate_power_state_transition(parent);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[PD] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[PD] %s @%d", __func__, __LINE__);
         }
     }
 }
@@ -1147,7 +1147,7 @@ static void process_power_state_transition_report_shallower_state(
         if (!initiate_power_state_pre_transition_notification(child)) {
             status = initiate_power_state_transition(child);
             if (status != FWK_SUCCESS) {
-                FWK_LOG_TRACE("[PD] %s @%d", __func__, __LINE__);
+                FWK_LOG_DEBUG("[PD] %s @%d", __func__, __LINE__);
             }
         }
     }
@@ -1192,7 +1192,7 @@ static void process_power_state_transition_report(struct pd_ctx *pd,
             &notification_event,
             &pd->power_state_transition_notification_ctx.pending_responses);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[PD] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[PD] %s @%d", __func__, __LINE__);
         }
     }
 #endif
@@ -1202,7 +1202,7 @@ static void process_power_state_transition_report(struct pd_ctx *pd,
         mod_pd_ctx.system_suspend.last_core_off_ongoing = false;
         status = complete_system_suspend(pd);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[PD] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[PD] %s @%d", __func__, __LINE__);
         }
 
         return;
@@ -1427,7 +1427,7 @@ static bool check_and_notify_system_shutdown(
     status = fwk_notification_notify(
         &notification, &mod_pd_ctx.system_shutdown.notifications_count);
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[PD] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[PD] %s @%d", __func__, __LINE__);
     }
 
     return (mod_pd_ctx.system_shutdown.notifications_count != 0);
@@ -1874,7 +1874,7 @@ static int pd_start(fwk_id_t id)
 
             status = report_power_state_transition(pd, state);
             if (status != FWK_SUCCESS) {
-                FWK_LOG_TRACE("[PD] %s @%d", __func__, __LINE__);
+                FWK_LOG_DEBUG("[PD] %s @%d", __func__, __LINE__);
             }
         }
     }

--- a/module/scmi/src/mod_scmi.c
+++ b/module/scmi/src/mod_scmi.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -296,10 +296,9 @@ static int respond(fwk_id_t service_id, const void *payload, size_t size)
         (void)message_type_name;
 #endif
     } else {
-#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
-        FWK_LOG_TRACE(
-            "[SCMI] %s: %s [%" PRIu16
-            " (0x%x:0x%x)] returned successfully",
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
+        FWK_LOG_DEBUG(
+            "[SCMI] %s: %s [%" PRIu16 " (0x%x:0x%x)] returned successfully",
             service_name,
             message_type_name,
             ctx->scmi_token,
@@ -371,7 +370,7 @@ static void scmi_notify(fwk_id_t id, int protocol_id, int message_id,
         size,
         request_ack_by_interrupt);
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI] %s @%d", __func__, __LINE__);
     }
 }
 
@@ -419,7 +418,7 @@ int scmi_send_message(
 
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_ERROR
     if (status == FWK_SUCCESS) {
-        FWK_LOG_TRACE(
+        FWK_LOG_DEBUG(
             "[SCMI] %s: Cmd [%" PRIu16 " (0x%x:0x%x)] was sent",
             fwk_module_get_element_name(service_id),
             token,
@@ -988,8 +987,8 @@ static int scmi_process_event(const struct fwk_event *event,
     ctx->scmi_token = read_token(message_header);
     message_type_name = get_message_type_str(ctx);
 
-#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
-    FWK_LOG_TRACE(
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
+    FWK_LOG_DEBUG(
         "[SCMI] %s: %s [%" PRIu16 " (0x%x:0x%x)] was received",
         service_name,
         message_type_name,
@@ -1018,7 +1017,7 @@ static int scmi_process_event(const struct fwk_event *event,
                 &(int32_t){ SCMI_NOT_SUPPORTED },
                 sizeof(int32_t));
             if (status != FWK_SUCCESS) {
-                FWK_LOG_TRACE("[SCMI] %s @%d", __func__, __LINE__);
+                FWK_LOG_DEBUG("[SCMI] %s @%d", __func__, __LINE__);
             }
             return FWK_SUCCESS;
         }
@@ -1064,7 +1063,7 @@ static int scmi_process_event(const struct fwk_event *event,
                 status = ctx->respond(
                     transport_id, &(int32_t){ SCMI_DENIED }, sizeof(int32_t));
                 if (status != FWK_SUCCESS) {
-                    FWK_LOG_TRACE("[SCMI] %s @%d", __func__, __LINE__);
+                    FWK_LOG_DEBUG("[SCMI] %s @%d", __func__, __LINE__);
                 }
                 return FWK_SUCCESS;
             }

--- a/module/scmi/src/mod_scmi_base.c
+++ b/module/scmi/src/mod_scmi_base.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -495,7 +495,7 @@ error:
         (return_values.status == SCMI_SUCCESS) ? sizeof(return_values) :
                                                  sizeof(return_values.status));
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI_BASE] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI_BASE] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -657,7 +657,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI_BASE] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI_BASE] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -730,7 +730,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI_BASE] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI_BASE] %s @%d", __func__, __LINE__);
     }
 
     return status;

--- a/module/scmi_apcore/src/mod_scmi_apcore.c
+++ b/module/scmi_apcore/src/mod_scmi_apcore.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -311,7 +311,7 @@ exit:
         service_id, &return_values, sizeof(return_values));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-APCORE] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-APCORE] %s @%d", __func__, __LINE__);
     }
 
     return status;

--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -330,7 +330,7 @@ static void clock_ops_update_state(unsigned int clock_dev_idx, int status)
             scmi_clock_ctx.clock_ops[clock_dev_idx].service_id,
             scmi_clock_ctx.clock_ops[clock_dev_idx].clock_dev_id);
         if (set_policy_status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[SCMI-CLK] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[SCMI-CLK] %s @%d", __func__, __LINE__);
         }
     }
 }
@@ -383,7 +383,7 @@ static void get_state_respond(fwk_id_t clock_dev_id,
     respond_status = scmi_clock_ctx.scmi_api->respond(
         service_id, &return_values, response_size);
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-CLK] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-CLK] %s @%d", __func__, __LINE__);
     }
 }
 
@@ -413,7 +413,7 @@ static void get_rate_respond(fwk_id_t service_id,
     respond_status = scmi_clock_ctx.scmi_api->respond(
         service_id, &return_values, response_size);
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-CLK] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-CLK] %s @%d", __func__, __LINE__);
     }
 }
 
@@ -436,7 +436,7 @@ static void request_response(int response_status,
     respond_status = scmi_clock_ctx.scmi_api->respond(
         service_id, &return_values, sizeof(return_values.status));
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-CLK] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-CLK] %s @%d", __func__, __LINE__);
     }
 }
 
@@ -461,7 +461,7 @@ static void set_request_respond(fwk_id_t service_id, int status)
     respond_status = scmi_clock_ctx.scmi_api->respond(
         service_id, &return_values, sizeof(return_values.status));
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-CLK] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-CLK] %s @%d", __func__, __LINE__);
     }
 }
 
@@ -787,7 +787,7 @@ exit:
     respond_status = scmi_clock_ctx.scmi_api->respond(
         service_id, &return_values, sizeof(return_values));
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-CLK] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-CLK] %s @%d", __func__, __LINE__);
     }
     return status;
 }
@@ -885,7 +885,7 @@ exit:
     respond_status = scmi_clock_ctx.scmi_api->respond(
         service_id, &return_values, response_size);
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-CLK] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-CLK] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -952,7 +952,7 @@ exit:
     respond_status = scmi_clock_ctx.scmi_api->respond(
         service_id, &return_values, response_size);
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-CLK] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-CLK] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -1346,7 +1346,7 @@ exit:
         (return_values.status == SCMI_SUCCESS) ? payload_size :
                                                  sizeof(return_values.status));
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-CLK] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-CLK] %s @%d", __func__, __LINE__);
     }
 
     return status;

--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -479,7 +479,7 @@ void perf_eval_performance(
         (limits->maximum == domain_ctx->level_limits.maximum)) {
         status = find_opp_for_level(domain_ctx, level, true);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
         }
         return;
     }
@@ -499,7 +499,7 @@ void perf_eval_performance(
 
     status = find_opp_for_level(domain_ctx, level, true);
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 }
 #endif
@@ -742,7 +742,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -858,7 +858,7 @@ exit:
         (return_values.status == SCMI_SUCCESS) ? payload_size :
                                                  sizeof(return_values.status));
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -935,7 +935,7 @@ exit:
         (return_values.status == SCMI_SUCCESS) ? sizeof(return_values) :
                                                  sizeof(return_values.status));
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -1034,7 +1034,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -1099,7 +1099,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -1168,7 +1168,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -1238,7 +1238,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -1449,7 +1449,7 @@ static void fast_channels_process(void)
             status = scmi_perf_ctx.dvfs_api->set_level(
                 get_dependency_id(i), 0, tlevel);
             if (status != FWK_SUCCESS) {
-                FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+                FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
             }
 
 #    else
@@ -1478,7 +1478,7 @@ static void fast_channels_process(void)
             if (set_level != NULL && tlevel > 0) {
                 status = perf_set_level(get_dependency_id(i), 0, tlevel);
                 if (status != FWK_SUCCESS) {
-                    FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+                    FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
                 }
             }
             if (set_limit != NULL) {
@@ -1493,7 +1493,7 @@ static void fast_channels_process(void)
                         .maximum = tmax,
                     }));
                 if (status != FWK_SUCCESS) {
-                    FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+                    FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
                 }
             }
 
@@ -1614,7 +1614,7 @@ static void scmi_perf_respond(
         scmi_perf_ctx.scmi_api->respond(service_id, return_values, size);
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 
     /*
@@ -1681,7 +1681,7 @@ static void scmi_perf_notify_limits_updated(
         &limits_changed,
         sizeof(limits_changed));
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 #endif
 }
@@ -1724,10 +1724,10 @@ static void scmi_perf_notify_level_updated(
             FWK_ID_ELEMENT(FWK_MODULE_IDX_SCMI_PERF, idx),
             level_id);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
         }
     } else {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 #endif
 
@@ -1786,7 +1786,7 @@ static void scmi_perf_notify_level_updated(
         &level_changed,
         sizeof(level_changed));
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-PERF] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-PERF] %s @%d", __func__, __LINE__);
     }
 #endif
 

--- a/module/scmi_perf/src/perf_plugins_handler.c
+++ b/module/scmi_perf/src/perf_plugins_handler.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -452,7 +452,7 @@ void perf_plugins_handler_update(
             api = perf_plugins_ctx.plugins_api_table[i];
             status = api->update(&perf_snapshot);
             if (status != FWK_SUCCESS) {
-                FWK_LOG_TRACE(
+                FWK_LOG_DEBUG(
                     "[P-Handler] Update: Plugin%u returned error %i",
                     i,
                     status);
@@ -511,7 +511,7 @@ void perf_plugins_handler_report(struct perf_plugins_perf_report *data)
         if (api->report != NULL) {
             status = api->report(data);
             if (status != FWK_SUCCESS) {
-                FWK_LOG_TRACE(
+                FWK_LOG_DEBUG(
                     "[P-Handler] Report: Plugin%u returned error %i",
                     i,
                     status);

--- a/module/scmi_power_domain/src/mod_scmi_power_domain.c
+++ b/module/scmi_power_domain/src/mod_scmi_power_domain.c
@@ -278,7 +278,7 @@ static int scmi_pd_protocol_version_handler(fwk_id_t service_id,
         service_id, &return_values, sizeof(return_values));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-power] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-power] %s @%d", __func__, __LINE__);
     }
 
     return FWK_SUCCESS;
@@ -403,7 +403,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-power] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-power] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -455,7 +455,7 @@ static void scmi_pd_power_state_notify(
         &message,
         sizeof(message));
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-power] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-power] %s @%d", __func__, __LINE__);
     }
 #endif
 }
@@ -610,7 +610,7 @@ static int scmi_pd_power_state_set_handler(
             service_id, &return_values, sizeof(return_values.status));
 
         if (respond_status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[SCMI-power] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[SCMI-power] %s @%d", __func__, __LINE__);
         }
         return FWK_E_BUSY;
     }
@@ -733,7 +733,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-power] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-power] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -1245,7 +1245,7 @@ static int process_request_event(const struct fwk_event *event)
             state_get ? sizeof(retval_get) : sizeof(retval_set));
 
         if (respond_status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[SCMI-power] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[SCMI-power] %s @%d", __func__, __LINE__);
         }
 
         ops_set_idle(pd_id);
@@ -1284,7 +1284,7 @@ static int process_response_event(const struct fwk_event *event)
             service_id, &retval_set, sizeof(retval_set));
 
         if (respond_status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[SCMI-power] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[SCMI-power] %s @%d", __func__, __LINE__);
         }
 
         ops_set_idle(event->source_id);
@@ -1314,13 +1314,13 @@ static int process_response_event(const struct fwk_event *event)
             respond_status = scmi_pd_ctx.scmi_api->respond(
                 service_id, (void *)&retval_get, sizeof(retval_get));
             if (respond_status != FWK_SUCCESS) {
-                FWK_LOG_TRACE("[SCMI-power] %s @%d", __func__, __LINE__);
+                FWK_LOG_DEBUG("[SCMI-power] %s @%d", __func__, __LINE__);
             }
         } else {
             respond_status = scmi_pd_ctx.scmi_api->respond(
                 service_id, (void *)&retval_set, sizeof(retval_set));
             if (respond_status != FWK_SUCCESS) {
-                FWK_LOG_TRACE("[SCMI-power] %s @%d", __func__, __LINE__);
+                FWK_LOG_DEBUG("[SCMI-power] %s @%d", __func__, __LINE__);
             }
         }
         ops_set_idle(scmi_pd_ctx.debug_pd_id);

--- a/module/scmi_reset_domain/src/mod_scmi_reset_domain.c
+++ b/module/scmi_reset_domain/src/mod_scmi_reset_domain.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2019-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -286,7 +286,7 @@ exit:
         scmi_rd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-RESET] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-RESET] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -422,7 +422,7 @@ exit:
         scmi_rd_ctx.scmi_api->respond(service_id, &outmsg, outmsg_size);
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-RESET] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-RESET] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -483,7 +483,7 @@ exit:
                                           sizeof(outmsg.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-RESET] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-RESET] %s @%d", __func__, __LINE__);
     }
 
     return status;

--- a/module/scmi_sensor/src/mod_scmi_sensor.c
+++ b/module/scmi_sensor/src/mod_scmi_sensor.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -259,7 +259,7 @@ exit:
     respond_status =
         scmi_sensor_ctx.scmi_api->respond(service_id, payload, payload_size);
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-SENS] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-SENS] %s @%d", __func__, __LINE__);
     }
     /*
      * Set the service identifier to 'none' to indicate the sensor is
@@ -482,7 +482,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-SENS] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-SENS] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -539,7 +539,7 @@ exit:
         (return_values.status == SCMI_SUCCESS) ? sizeof(return_values) :
                                                  sizeof(return_values.status));
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-SENS] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-SENS] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -612,7 +612,7 @@ exit:
         (return_values.status == SCMI_SUCCESS) ? sizeof(return_values) :
                                                  sizeof(return_values.status));
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-SENS] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-SENS] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -763,7 +763,7 @@ exit:
         (return_values.status == SCMI_SUCCESS) ? payload_size :
                                                  sizeof(return_values.status));
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-SENS] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-SENS] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -848,7 +848,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-SENS] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-SENS] %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -997,7 +997,7 @@ static void scmi_sensor_notify_trip_point(
         &trip_point_event,
         sizeof(trip_point_event));
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-SENS] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-SENS] %s @%d", __func__, __LINE__);
     }
 #endif
 }

--- a/module/scmi_system_power/src/mod_scmi_system_power.c
+++ b/module/scmi_system_power/src/mod_scmi_system_power.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -186,7 +186,7 @@ static void graceful_timer_callback(uintptr_t mod_scmi_system_state)
         system_shutdown = system_state2system_shutdown[mod_scmi_system_state];
         status = scmi_sys_power_ctx.pd_api->system_shutdown(system_shutdown);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("SCMI_SYS_POWER: %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("SCMI_SYS_POWER: %s @%d", __func__, __LINE__);
         }
     }
 }
@@ -418,7 +418,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("SCMI_SYS_POWER: %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("SCMI_SYS_POWER: %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -476,7 +476,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("SCMI_SYS_POWER: %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("SCMI_SYS_POWER: %s @%d", __func__, __LINE__);
     }
 
     return status;
@@ -524,7 +524,7 @@ exit:
                                                  sizeof(return_values.status));
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("SCMI_SYS_POWER: %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("SCMI_SYS_POWER: %s @%d", __func__, __LINE__);
     }
 
     return FWK_SUCCESS;
@@ -575,7 +575,7 @@ FWK_WEAK int scmi_sys_power_state_set_policy(
                     graceful_timer_callback,
                     *state);
                 if (status != FWK_SUCCESS) {
-                    FWK_LOG_TRACE("SCMI_SYS_POWER: %s @%d", __func__, __LINE__);
+                    FWK_LOG_DEBUG("SCMI_SYS_POWER: %s @%d", __func__, __LINE__);
                 }
             } else {
                 graceful_timer_callback(*state);

--- a/module/scmi_voltage_domain/src/mod_scmi_voltage_domain.c
+++ b/module/scmi_voltage_domain/src/mod_scmi_voltage_domain.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -641,7 +641,7 @@ exit:
     }
 
     if (respond_status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[SCMI-VOLT] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[SCMI-VOLT] %s @%d", __func__, __LINE__);
     }
     // Return status or return FWK_SUCCESS???
     return status;

--- a/module/sp805/src/mod_sp805.c
+++ b/module/sp805/src/mod_sp805.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -25,7 +25,7 @@ static struct mod_sp805_dev_ctx ctx;
 
 static void sp805_isr(uintptr_t unused)
 {
-    FWK_LOG_TRACE(MOD_NAME "SP805 watchdog timer interrupt generated.");
+    FWK_LOG_DEBUG(MOD_NAME "SP805 watchdog timer interrupt generated.");
 
     /* Clear the watchdog Interrupt */
     ctx.reg_base->LOCK = ENABLE_WR_ACCESS;

--- a/module/statistics/src/mod_stats.c
+++ b/module/statistics/src/mod_stats.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -140,8 +140,10 @@ static int allocate_domain_stats(fwk_id_t module_id,
 
     stats->used_mem_size += stats_size;
 
-    FWK_LOG_TRACE("[STATS]: stats addr %lx, stats_size=%luB\n",
-                  (uint32_t)scp_stats_addr, stats_size);
+    FWK_LOG_DEBUG(
+        "[STATS]: stats addr %lx, stats_size=%luB\n",
+        (uint32_t)scp_stats_addr,
+        stats_size);
 
     return FWK_SUCCESS;
 }

--- a/module/system_power/src/mod_system_power.c
+++ b/module/system_power/src/mod_system_power.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -95,7 +95,7 @@ static void ext_ppus_set_state(enum mod_pd_state state)
         status = system_power_ctx.ext_ppu_apis[i]->set_state(
             system_power_ctx.config->ext_ppus[i].ppu_id, state);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[SYS-POW] ext-ppu%i %s @%d", i, __func__, __LINE__);
+            FWK_LOG_DEBUG("[SYS-POW] ext-ppu%i %s @%d", i, __func__, __LINE__);
         }
     }
 }
@@ -118,7 +118,7 @@ static void ext_ppus_shutdown(enum mod_pd_system_shutdown system_shutdown)
             status = api->set_state(ppu_id, MOD_PD_STATE_OFF);
         }
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[SYS-POW] ext-ppu%i %s @%d", i, __func__, __LINE__);
+            FWK_LOG_DEBUG("[SYS-POW] ext-ppu%i %s @%d", i, __func__, __LINE__);
         }
     }
 }

--- a/module/timer/src/mod_timer.c
+++ b/module/timer/src/mod_timer.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -162,12 +162,12 @@ static void _configure_timer_with_next_alarm(struct timer_dev_ctx *ctx)
         status =
             ctx->driver->set_timer(ctx->driver_dev_id, alarm_head->timestamp);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[Timer] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[Timer] %s @%d", __func__, __LINE__);
         }
 
         status = ctx->driver->enable(ctx->driver_dev_id);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[Timer] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[Timer] %s @%d", __func__, __LINE__);
         }
     }
 }
@@ -545,12 +545,12 @@ static void timer_isr(uintptr_t ctx_ptr)
     /* Disable timer interrupts to work with the active queue */
     status = ctx->driver->disable(ctx->driver_dev_id);
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[Timer] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[Timer] %s @%d", __func__, __LINE__);
     }
 
     status = fwk_interrupt_clear_pending(ctx->config->timer_irq);
     if (status != FWK_SUCCESS) {
-        FWK_LOG_TRACE("[Timer] %s @%d", __func__, __LINE__);
+        FWK_LOG_DEBUG("[Timer] %s @%d", __func__, __LINE__);
     }
 
     alarm =

--- a/product/juno/module/juno_xrp7724/src/mod_juno_xrp7724.c
+++ b/product/juno/module/juno_xrp7724/src/mod_juno_xrp7724.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -685,7 +685,7 @@ static int juno_xrp7724_gpio_process_request(fwk_id_t id, int response_status)
         status =
             module_ctx.timer_api->delay(config->timer_hal_id, GPIO_DELAY_US);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[XRP7724] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[XRP7724] %s @%d", __func__, __LINE__);
         }
 
         /* Send the assert command */
@@ -723,7 +723,7 @@ static int juno_xrp7724_gpio_process_request(fwk_id_t id, int response_status)
         status =
             module_ctx.timer_api->delay(config->timer_hal_id, GPIO_DELAY_US);
         if (status != FWK_SUCCESS) {
-            FWK_LOG_TRACE("[XRP7724] %s @%d", __func__, __LINE__);
+            FWK_LOG_DEBUG("[XRP7724] %s @%d", __func__, __LINE__);
         }
 
         /* The board should have been reset or shut down at this point */

--- a/product/juno/src/juno_scmi_clock.c
+++ b/product/juno/src/juno_scmi_clock.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -24,8 +24,8 @@ int mod_scmi_clock_rate_set_policy(
     fwk_id_t service_id,
     uint32_t clock_dev_id)
 {
-#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_TRACE
-    FWK_LOG_TRACE(
+#if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
+    FWK_LOG_DEBUG(
         "[SCMI-CLK] Set Clock Rate Policy Handler agent: %u clock: %" PRIu32
         "\n",
         fwk_id_get_element_idx(service_id),

--- a/product/optee-stm32mp1/module/stm32_pmic_regu/src/mod_stm32_pmic_regu.c
+++ b/product/optee-stm32mp1/module/stm32_pmic_regu/src/mod_stm32_pmic_regu.c
@@ -1,6 +1,7 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Linaro Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Linaro Limited and Contributors. All rights
+ * reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -60,8 +61,10 @@ static int32_t set_regu_voltage(const char *regu_id, int32_t level_uv)
     int rc = 0;
     unsigned int level_mv = level_uv / 1000;
 
-    FWK_LOG_TRACE(MOD_NAME "Set STPMIC1 regulator %s level to %dmV", regu_id,
-         level_uv / 1000);
+    FWK_LOG_DEBUG(
+        MOD_NAME "Set STPMIC1 regulator %s level to %dmV",
+        regu_id,
+        level_uv / 1000);
 
     fwk_assert(level_mv < UINT16_MAX);
 
@@ -89,8 +92,11 @@ static int32_t set_regu_state(const char *regu_id, bool enable)
 
     stm32mp_get_pmic();
 
-    FWK_LOG_TRACE(MOD_NAME "%sable STPMIC1 %s (was %s)", enable ? "En" : "Dis", regu_id,
-         stpmic1_is_regulator_enabled(regu_id) ? "on" : "off");
+    FWK_LOG_DEBUG(
+        MOD_NAME "%sable STPMIC1 %s (was %s)",
+        enable ? "En" : "Dis",
+        regu_id,
+        stpmic1_is_regulator_enabled(regu_id) ? "on" : "off");
 
     if (enable) {
         rc = stpmic1_regulator_enable(regu_id);
@@ -126,9 +132,11 @@ static int pmic_regu_get_config(fwk_id_t dev_id, uint8_t *mode_type,
         *mode_id = MOD_VOLTD_MODE_ID_OFF;
     }
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI voltd %u: get config PMIC %s: %s",
-         fwk_id_get_element_idx(dev_id), ctx->regu_id,
-         *mode_id == MOD_VOLTD_MODE_ID_ON ? "on" : "off");
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: get config PMIC %s: %s",
+        fwk_id_get_element_idx(dev_id),
+        ctx->regu_id,
+        *mode_id == MOD_VOLTD_MODE_ID_ON ? "on" : "off");
 
     return FWK_SUCCESS;
 }
@@ -154,9 +162,11 @@ static int pmic_regu_set_config(fwk_id_t dev_id, uint8_t mode_type,
         return FWK_E_DEVICE;
     }
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI voltd %u: set config PMIC %s to %s",
-         fwk_id_get_element_idx(dev_id), ctx->regu_id,
-         mode_id == MOD_VOLTD_MODE_ID_ON ? "on" : "off");
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: set config PMIC %s to %s",
+        fwk_id_get_element_idx(dev_id),
+        ctx->regu_id,
+        mode_id == MOD_VOLTD_MODE_ID_ON ? "on" : "off");
 
     return FWK_SUCCESS;
 }
@@ -173,8 +183,11 @@ static int pmic_regu_get_level(fwk_id_t dev_id, int *level_uv)
 
     *level_uv = get_regu_voltage(ctx->regu_id);
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI voltd %u: get level PMIC %s = %d",
-         fwk_id_get_element_idx(dev_id), ctx->regu_id, *level_uv);
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: get level PMIC %s = %d",
+        fwk_id_get_element_idx(dev_id),
+        ctx->regu_id,
+        *level_uv);
 
     return FWK_SUCCESS;
 }
@@ -193,8 +206,11 @@ static int pmic_regu_set_level(fwk_id_t dev_id, int level_uv)
         return FWK_E_ACCESS;
     }
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI voltd %u: set level PMIC %s to %d",
-         fwk_id_get_element_idx(dev_id), ctx->regu_id, level_uv);
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: set level PMIC %s to %d",
+        fwk_id_get_element_idx(dev_id),
+        ctx->regu_id,
+        level_uv);
 
     if (set_regu_voltage(ctx->regu_id, level_uv)) {
         return FWK_E_DEVICE;
@@ -248,9 +264,12 @@ static int pmic_regu_get_info(fwk_id_t dev_id, struct mod_voltd_info *info)
     find_bound_uv(levels, full_count,
                   &info->level_range.min_uv, &info->level_range.max_uv);
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI voltd %u: get_info PMIC %s, range [%d %d]",
-         fwk_id_get_element_idx(dev_id), ctx->regu_id,
-         info->level_range.min_uv, info->level_range.max_uv);
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: get_info PMIC %s, range [%d %d]",
+        fwk_id_get_element_idx(dev_id),
+        ctx->regu_id,
+        info->level_range.min_uv,
+        info->level_range.max_uv);
 
     return FWK_SUCCESS;
 }
@@ -275,8 +294,11 @@ static int pmic_regu_level_from_index(fwk_id_t dev_id, unsigned int index,
 
     *level_uv = (int32_t)levels[index] * 1000;
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI voltd %u: get level PMIC %s = %d",
-         fwk_id_get_element_idx(dev_id), ctx->regu_id, *level_uv);
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: get level PMIC %s = %d",
+        fwk_id_get_element_idx(dev_id),
+        ctx->regu_id,
+        *level_uv);
 
     return FWK_SUCCESS;
 }

--- a/product/optee-stm32mp1/module/stm32_pwr_regu/src/mod_stm32_pwr_regu.c
+++ b/product/optee-stm32mp1/module/stm32_pwr_regu/src/mod_stm32_pwr_regu.c
@@ -1,6 +1,7 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Linaro Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Linaro Limited and Contributors. All rights
+ * reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -79,9 +80,11 @@ static int pwr_regu_get_config(fwk_id_t dev_id, uint8_t *mode_type,
         *mode_id = MOD_VOLTD_MODE_ID_OFF;
     }
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI voltd %u: get_config PWR#%u = %s",
-         fwk_id_get_element_idx(dev_id), ctx->pwr_id,
-         *mode_id == MOD_VOLTD_MODE_ID_ON ? "on" : "off");
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: get_config PWR#%u = %s",
+        fwk_id_get_element_idx(dev_id),
+        ctx->pwr_id,
+        *mode_id == MOD_VOLTD_MODE_ID_ON ? "on" : "off");
 
     return FWK_SUCCESS;
 }
@@ -106,9 +109,11 @@ static int pwr_regu_set_config(fwk_id_t dev_id, uint8_t mode_type,
     stm32mp1_pwr_regulator_set_state(ctx->pwr_id,
                                      mode_id == MOD_VOLTD_MODE_ID_ON);
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI voltd %u: set_config PWR#%u %s",
-         fwk_id_get_element_idx(dev_id), ctx->pwr_id,
-         mode_id == MOD_VOLTD_MODE_ID_ON ? "on" : "off");
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: set_config PWR#%u %s",
+        fwk_id_get_element_idx(dev_id),
+        ctx->pwr_id,
+        mode_id == MOD_VOLTD_MODE_ID_ON ? "on" : "off");
 
     return FWK_SUCCESS;
 }
@@ -129,8 +134,11 @@ static int pwr_regu_get_level(fwk_id_t dev_id, int *level_uv)
 
     *level_uv = pwr_regu_level(ctx->pwr_id);
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI voltd %u: get_level PWR#%u = %d",
-         fwk_id_get_element_idx(dev_id), ctx->pwr_id, *level_uv);
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: get_level PWR#%u = %d",
+        fwk_id_get_element_idx(dev_id),
+        ctx->pwr_id,
+        *level_uv);
 
     return FWK_SUCCESS;
 }
@@ -149,8 +157,11 @@ static int pwr_regu_set_level(fwk_id_t dev_id, int level_uv)
         return FWK_E_ACCESS;
     }
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI voltd %u: set_level PWR#%u to %d",
-         fwk_id_get_element_idx(dev_id), ctx->pwr_id, level_uv);
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: set_level PWR#%u to %d",
+        fwk_id_get_element_idx(dev_id),
+        ctx->pwr_id,
+        level_uv);
 
     if (level_uv != pwr_regu_level(ctx->pwr_id)) {
         return FWK_E_RANGE;
@@ -180,8 +191,10 @@ static int pwr_regu_get_info(fwk_id_t dev_id, struct mod_voltd_info *info)
     info->level_range.level_count = 1;
     info->name = ctx->name;
 
-    FWK_LOG_TRACE(MOD_NAME"SCMI voltd %u: get_info PWR#%u",
-         fwk_id_get_element_idx(dev_id), ctx->pwr_id);
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: get_info PWR#%u",
+        fwk_id_get_element_idx(dev_id),
+        ctx->pwr_id);
 
     return FWK_SUCCESS;
 }
@@ -207,8 +220,11 @@ static int pwr_regu_level_from_index(fwk_id_t dev_id, unsigned int index,
 
     *level_uv = pwr_regu_level(ctx->pwr_id);
 
-    FWK_LOG_TRACE(MOD_NAME "SCMI voltd %u: get_level_from_index PWR#%u = %"PRId32,
-         fwk_id_get_element_idx(dev_id), ctx->pwr_id, *level_uv);
+    FWK_LOG_DEBUG(
+        MOD_NAME "SCMI voltd %u: get_level_from_index PWR#%u = %" PRId32,
+        fwk_id_get_element_idx(dev_id),
+        ctx->pwr_id,
+        *level_uv);
 
     return FWK_SUCCESS;
 }


### PR DESCRIPTION
This patchset adds `FWK_TRACE` functionality and includes
an example to use it.

It also renames `TRACE` to `DEBUG` because in further patches
a new functionallity for tracing will be introduced and having
the same name for both could cause confusion.