### PR TITLE
power_domain: Fix return status for notify_warm_reset

### DIFF
--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -1404,7 +1404,7 @@ static int notify_warm_reset(void)
 
     return fwk_notification_notify(&notification, &count);
 #else
-    return false;
+    return FWK_SUCCESS;
 #endif
 }
 


### PR DESCRIPTION
notify_warm_reset returns `false` when notifications are not enabled, while it should return an integer and not a boolean.

Return FWK_SUCCESS when framework notifications are not available instead.

Change-Id: Ib2519e07e9dcd648a8b608c5bcc77d0a81986e57
Signed-off-by: Nicola Mazzucato <nicola.mazzucato@arm.com>