### PR TITLE
platform/rdn2: Enable soc expansion block on RD-N2-Cfg2

### DIFF
--- a/product/rdn2/scp_ramfw/config_cmn700.c
+++ b/product/rdn2/scp_ramfw/config_cmn700.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -90,6 +90,8 @@ enum rdn2cfg2_cmn700_ccg_port {
 #    define NODE_ID_HNP2 0x15c
 #    define NODE_ID_HNP3 0x16a
 #    define NODE_ID_SBSX 196
+
+#    define NODE_ID_NON_PCIE_IO_MACRO NODE_ID_HNP1
 
 #    define MESH_SIZE_X 6
 #    define MESH_SIZE_Y 6
@@ -484,7 +486,6 @@ static const struct mod_cmn700_mem_region_map mmap[] = {
         .type = MOD_CMN700_MEM_REGION_TYPE_IO,
         .node_id = NODE_ID_HND,
     },
-#if (PLATFORM_VARIANT != 2)
     {
         /*
          * Non-PCIe IO Macro
@@ -495,7 +496,6 @@ static const struct mod_cmn700_mem_region_map mmap[] = {
         .type = MOD_CMN700_MEM_REGION_TYPE_IO,
         .node_id = NODE_ID_NON_PCIE_IO_MACRO,
     },
-#endif
 };
 
 #if (PLATFORM_VARIANT == 2)

--- a/product/rdn2/scp_ramfw/config_pcie_integ_ctrl.c
+++ b/product/rdn2/scp_ramfw/config_pcie_integ_ctrl.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -49,7 +49,7 @@
 
 #if (PLATFORM_VARIANT == 0 || PLATFORM_VARIANT == 3)
 #    define NON_PCIE_IO_MACRO_REG_BASE PCIE_INTEG_CTRL_REG_BASE(4)
-#elif (PLATFORM_VARIANT == 1) /* RD-N2-Cfg1 */
+#elif (PLATFORM_VARIANT == 1) || (PLATFORM_VARIANT == 2)
 #    define NON_PCIE_IO_MACRO_REG_BASE PCIE_INTEG_CTRL_REG_BASE(1)
 #endif
 
@@ -83,7 +83,6 @@ static const struct fwk_element pcie_integ_ctrl_element_table[] = {
         AP_PCIE_MMIOL_SIZE_PER_RC,
         AP_PCIE_MMIOH_SIZE_PER_RC),
 #endif
-#if (PLATFORM_VARIANT != 2)
     {
         .name = "Non-PCIe IO Macro",
         .data = &((struct mod_pcie_integ_ctrl_config) {
@@ -120,7 +119,6 @@ static const struct fwk_element pcie_integ_ctrl_element_table[] = {
                 CLOCK_IDX_INTERCONNECT),
         }),
     },
-#endif
 
     { 0 }
 };


### PR DESCRIPTION
Enable CMN and PCIe integration control configurations for memory regions of SoC expansion block that is connected to IO virtualization block #1 on RD-N2-Cfg2 platform. This will allow to enumerate the devices present in SoC expansion block on RD-N2-Cfg2 platform.