### PR TITLE
Fix buffered log output behaviour

### DIFF
--- a/framework/src/fwk_arch.c
+++ b/framework/src/fwk_arch.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -97,7 +97,7 @@ int fwk_arch_init(const struct fwk_arch_init_driver *driver)
      */
 #if defined(BUILD_HAS_SUB_SYSTEM_MODE)
     fwk_process_event_queue();
-    (void)fwk_log_unbuffer();
+    fwk_log_flush();
 #else
     __fwk_run_main_loop();
 #endif

--- a/framework/src/fwk_core.c
+++ b/framework/src/fwk_core.c
@@ -306,8 +306,9 @@ noreturn void __fwk_run_main_loop(void)
 {
     for (;;) {
         fwk_process_event_queue();
-        (void)fwk_log_unbuffer();
-        fwk_arch_suspend();
+        if (fwk_log_unbuffer() == FWK_SUCCESS) {
+            fwk_arch_suspend();
+        }
     }
 }
 


### PR DESCRIPTION
This PR contains two patches to fix buffered logging issues. The first patch resolves incomplete logging when `SCP_ENABLE_SUB_SYSTEM_MODE` is enabled, while the second patch prevents the system from being suspended when there are elements in the output log buffer ready to be printed.