### PR TITLE
pl011: incorrect assert when fractional divisor is zero

### DIFF
--- a/module/pl011/src/mod_pl011.c
+++ b/module/pl011/src/mod_pl011.c
@@ -130,7 +130,7 @@ static void mod_pl011_set_baud_rate(const struct mod_pl011_element_cfg *cfg)
      * When the integer divisor equals 0xFFFF, the fractional divisor can only
      * be 0.
      */
-    fwk_assert((divisor_integer == 0xFFFF) == (divisor_fractional == 0));
+    fwk_assert(!((divisor_integer == 0xFFFF) && (divisor_fractional != 0)));
 
     reg->IBRD = (uint16_t)divisor_integer;
     reg->FBRD = divisor_fractional;


### PR DESCRIPTION
During some refactoring, a2ab9889bab9 introduced a logical bug in the sanity check of the integer and fractional divisors. This can be seen with the trivial case of int divisor = 2 and frac divisor = 0 causing an assert.  Update the check to correctly reflect the comment, and HW spec/TRM.