### PR TITLE
docker: fix dependencies and broken links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,10 +51,11 @@ cscope.*
 # Visual Studio Code IDE
 .vscode/
 
-# Vagrant
+# Docker
 
 # General
 .vagrant/
+.bundle/
 
 ### Vagrant Patch ###
 *.box

--- a/doc/cmake_readme.md
+++ b/doc/cmake_readme.md
@@ -354,6 +354,11 @@ $ docker run -v $(pwd):/scp-firmware -v ~/.gitconfig:/home/user/.gitconfig \
 
 [`Dockerfile`]: ./docker/Dockerfile
 
+## Arm Compiler 6 support for Docker
+
+To use Arm compiler 6 in the container it will be necessary to mount the
+directory into `/opt/arm-compiler-6`.
+
 # Getting Started {#getting-started}
 
 ## Prerequisites {#prerequisites}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,19 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-FROM ubuntu:20.04 as ci
+FROM ubuntu:20.04@sha256:9fa30fcef427e5e88c76bc41ad37b7cc573e1d79cecb23035e413c4be6e476ab as ci
 
-ARG ARM_GNU_RM_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2"
-ARG ARM_COMPILER_6_URL="https://developer.arm.com/-/media/Files/downloads/compiler/DS500-BN-00026-r5p0-16rel1.tgz"
+ARG ARM_GNU_RM_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2"
 ARG DOXYGEN_URL="https://sourceforge.net/projects/doxygen/files/rel-1.8.20/doxygen-1.8.20.linux.bin.tar.gz"
-ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3-Linux-x86_64.tar.gz"
-ARG AARCH64_GCC_URL="https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-a/9.2-2019.12/binrel/gcc-arm-9.2-2019.12-x86_64-aarch64-none-elf.tar.xz"
-ARG CPPCHECK_SRC_URL="git://github.com/danmar/cppcheck.git"
+ARG CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-x86_64.tar.gz"
+ARG AARCH64_GCC_URL="https://developer.arm.com/-/media/Files/downloads/gnu-a/10.2-2020.11/binrel/gcc-arm-10.2-2020.11-x86_64-aarch64-none-elf.tar.xz"
+ARG CPPCHECK_SRC_URL="https://github.com/danmar/cppcheck.git"
 ARG CPPCHECK_CHECKOUT_TAG="1.90"
 ARG IWYU_SRC_URL="https://github.com/include-what-you-use/include-what-you-use.git"
-
 
 ENV ARMLMD_LICENSE_FILE=
 
@@ -23,17 +21,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get dist-upgrade -y && \
-    apt-get install -y --no-install-recommends \
-        bundler gcc g++ gpg-agent git gosu lsb-release make ninja-build \
-        xz-utils python3 python3-pip software-properties-common wget && \
-    wget -nv -O - -c "https://apt.llvm.org/llvm.sh" | bash && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        clang-format libclang-cpp9 libclang1-9 \
-        clang-tidy-10 libclang-9-dev \
-        clang-10 llvm-10 libclang-10-dev \
-        llvm-10-dev && \
-    python3 -m pip install --upgrade pip
+        bundler gcc g++ gpg-agent git gosu lsb-release make ninja-build \
+        xz-utils python3 python3-pip software-properties-common wget lcov && \
+    apt-get update && \
+    python3 -m pip install --upgrade pip && \
+    gem install bundler
 
 ENV DEBIAN_FRONTEND=
 
@@ -45,18 +39,13 @@ RUN mkdir "/opt/arm-gnu-rm" && \
 
 ENV PATH="/opt/arm-gnu-rm/bin:${PATH}"
 
-RUN mkdir "/tmp/arm-compiler-6" && \
-    wget -nv -O - -c "${ARM_COMPILER_6_URL}" | \
-    tar -zxf - -C "/tmp/arm-compiler-6" && \
-    sh "/tmp/arm-compiler-6/install_x86_64.sh" -d "/opt/arm-compiler-6" \
-        --no-interactive --i-agree-to-the-contained-eula && \
-    rm -rf "/tmp/arm-compiler-6" && \
-    echo 'export PATH=/opt/arm-compiler-6/bin:${PATH}' >> \
-        "/etc/profile.d/50-scp-firmware-env.sh"
-
+VOLUME "/opt/arm-compiler-6"
 ENV PATH="/opt/arm-compiler-6/bin:${PATH}"
 
 RUN mkdir "/opt/doxygen" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libclang1-9 libclang-9-dev libclang-cpp9 && \
     wget -nv -O - -c "${DOXYGEN_URL}" | \
     tar -zxf - -C "/opt/doxygen" --strip-components=1 && \
     echo 'export PATH=/opt/doxygen/bin:${PATH}' >> \
@@ -71,6 +60,19 @@ RUN mkdir "/opt/cmake" && \
         "/etc/profile.d/50-scp-firmware-env.sh"
 
 ENV PATH="/opt/cmake/bin:${PATH}"
+
+RUN apt-get update && \
+    wget --no-check-certificate -O - \
+        https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    add-apt-repository \
+        'deb http://apt.llvm.org/focal/   llvm-toolchain-focal-13  main' && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        clang-tidy-13 clang-13 llvm-13 libclang-13-dev llvm-13-dev
+
+COPY rootfs/usr/local/bin/prepare_llvm /usr/local/bin/prepare_llvm
+RUN  chmod 755 "/usr/local/bin/prepare_llvm"
+RUN  prepare_llvm
 
 RUN mkdir "/opt/aarch64-gcc" && \
     wget -nv -O - -c "${AARCH64_GCC_URL}" | \
@@ -92,9 +94,9 @@ RUN cwd=$PWD && mkdir "/opt/cppcheck" && cd "/opt/cppcheck" && \
 ENV PATH="/opt/cppcheck/bin:${PATH}"
 
 RUN cwd=$PWD && mkdir "/opt/iwyu" && cd "/opt/iwyu" && \
-    git clone "${IWYU_SRC_URL}" -b clang_10 --single-branch iwyu-10 && \
-    cmake -G "Ninja" -DCMAKE_PREFIX_PATH=/usr/lib/llvm-10 \
-    ./iwyu-10 && cmake --build . && \
+    git clone "${IWYU_SRC_URL}" -b clang_13 --single-branch iwyu-13 && \
+    cmake -G "Ninja" -DCMAKE_PREFIX_PATH=/usr/lib/llvm-13g \
+    ./iwyu-13 && cmake --build . && \
     cd bin && ln -s include-what-you-use iwyu && cd $cwd && \
     echo 'export PATH=/opt/iwyu/bin:${PATH}' >> \
         "/etc/profile.d/50-scp-firmware-env.sh"
@@ -104,7 +106,10 @@ ENV PATH="/opt/iwyu/bin:${PATH}"
 COPY rootfs/usr/local/bin/init /usr/local/bin/init
 RUN  chmod 755 "/usr/local/bin/init"
 
-ENTRYPOINT [ "sh", "/usr/local/bin/init" ]
+COPY rootfs/usr/local/bin/dependencies /usr/local/bin/dependencies
+RUN  chmod 755 "/usr/local/bin/dependencies"
+
+ENTRYPOINT [ "sh", "/usr/local/bin/dependencies", "/usr/local/bin/init" ]
 
 FROM ci as jenkins
 
@@ -129,6 +134,19 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends nano sudo
 
 ENV DEBIAN_FRONTEND=
+
+RUN adduser --disabled-password --gecos "" user && \
+    usermod -aG sudo user && \
+    passwd -d user
+
+ENV NOTVISIBLE="in users profile"
+RUN echo "export VISIBLE=now" >> "/etc/profile"
+
+RUN echo "\nexport USER=user" >> "/home/user/.bashrc"
+RUN echo "\n/usr/local/bin/dependencies" >> "/home/user/.bashrc"
+ENV PATH="/home/user/.local/bin:${PATH}"
+
+ENTRYPOINT [ "sh", "/usr/local/bin/init" ]
 
 FROM dev as vagrant
 
@@ -160,5 +178,9 @@ COPY rootfs/home/vagrant/.ssh/authorized_keys /home/vagrant/.ssh/authorized_keys
 RUN  chmod 644 "/home/vagrant/.ssh/authorized_keys"
 
 RUN printf "\ncd /vagrant" >> "/home/vagrant/.bashrc"
+
+RUN echo "\nexport USER=vagrant" >> "/home/user/.bashrc"
+RUN echo "\n/usr/local/bin/dependencies" >> "/home/vagrant/.bashrc"
+ENV PATH="/home/vagrant/.local/bin:${PATH}"
 
 EXPOSE 22

--- a/docker/rootfs/usr/local/bin/dependencies
+++ b/docker/rootfs/usr/local/bin/dependencies
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+if [ -f "requirements.txt" ]; then
+    python3 -m pip install --user -r "requirements.txt" > /dev/null
+fi
+
+if [ -f "Gemfile" ]; then
+    if [ "$(id -u)" -ne 0 ]; then
+        bundle config set --local path "/home/${USER}/.local/bin"
+    fi
+    bundle install > /dev/null
+fi

--- a/docker/rootfs/usr/local/bin/init
+++ b/docker/rootfs/usr/local/bin/init
@@ -2,18 +2,10 @@
 
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
-
-if [ -f "requirements.txt" ]; then
-    python3 -m pip install -r "requirements.txt" > /dev/null
-fi
-
-if [ -f "Gemfile" ]; then
-    bundle install
-fi
 
 if id vagrant > /dev/null 2>&1; then
     user=vagrant

--- a/docker/rootfs/usr/local/bin/prepare_llvm
+++ b/docker/rootfs/usr/local/bin/prepare_llvm
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+STEPS=4
+
+SCRIPT_NAME=$(basename $0)
+TMP_FOLDER=/tmp/${SCRIPT_NAME}
+LOG_OUTPUT_FILE=${TMP_FOLDER}/out.log
+
+# helper functions
+error() {
+    >&2 echo "error: $@"
+    echo "error: $@" >> $LOG_OUTPUT_FILE
+}
+log() { echo -n "$@" >> $LOG_OUTPUT_FILE; }
+logln() { echo "$@" >> $LOG_OUTPUT_FILE; }
+lindent() { log "  $@"; }
+lindentln() { logln "  $@"; }
+println() { logln "$@"; echo "$@"; }
+indentln() { lindentln "$@"; echo "  $@"; }
+indent() { lindent "$@"; echo -n "  $@"; }
+input() { read -p $1 $2; logln "$1$$2"; }
+step() {
+    STEP=$1;
+    shift;
+    println "[$STEP/$STEPS] $@"
+}
+eexit() {
+    >&2 echo
+    >&2 echo "error: please find the complete logs in ${LOG_OUTPUT_FILE}. Aborting..."
+    exit 1
+}
+cmd() {
+    logln "$ $@"
+    eval "$@" >> $LOG_OUTPUT_FILE 2>&1
+    [[ $? -ne 0 ]] && echo "error!" && eexit
+}
+cmdp() { logln $1; echo -n "  $1..."; shift; cmd $@; echo "ok!"; }
+
+echo "Setting up temporary directory"
+mkdir -p $TMP_FOLDER
+echo -n "" > $LOG_OUTPUT_FILE
+
+# Step 1 : obtaining the GNU Arm Embedded Toolchain sysroot for later...
+
+step 1 "Obtaining the sysroot of the GNU Arm Embedded Toolchain..."
+SYSROOT=""
+
+if [[ -n $GCC_TOOLCHAIN ]]; then
+    lindentln "\$GCC_TOOLCHAIN was found set, using it..."
+    SYSROOT=${GCC_TOOLCHAIN}/arm-none-eabi
+elif command -v arm-none-eabi-gcc &> /dev/null; then
+    lindentln "arm-none-eabi-gcc was found! Fetching the sysroot..."
+    SYSROOT=$(arm-none-eabi-gcc -print-sysroot)
+else
+    indentln "Could not find the GNU Arm Embedded Toolchain!"
+    indentln
+    indentln "Please enter the path to the GNU Arm Embedded Toolchain:"
+    input "> " GCC_TOOLCHAIN
+
+    SYSROOT=${GCC_TOOLCHAIN}/arm-none-eabi
+fi
+
+if [[ ! -d $SYSROOT ]]; then
+    error "${GCC_TOOLCHAIN} is not a valid GNU Arm Embedded Toolchain path!"
+    eexit
+fi
+
+step 1 "Toolchain sysroot found at: ${SYSROOT}"
+
+# Step 2: retrieve LLVM 13
+step 2 "Installing the LLVM 13 toolchain..."
+lindentln "Checking if clang-13 is present in the path..."
+if command -v clang-13 &> /dev/null; then
+    indentln "LLVM 13 is already installed! Skipping..."
+else
+    lindentln "clang-13 was not found in the PATH. Proceeding to installation..."
+    cmdp "Downloading the LLVM installation script" wget https://apt.llvm.org/llvm.sh -O $TMP_FOLDER/install-llvm.sh
+    cmd chmod +x $TMP_FOLDER/install-llvm.sh
+    cmdp "Downloading and installing LLVM 13 (this will take a while)" $TMP_FOLDER/install-llvm.sh 13
+fi
+
+# Step 3: Retrieving Compiler-RT source code
+step 3 "Installing the Compiler-RT Arm builtins..."
+cmdp "Downloading the source code" wget https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/compiler-rt-13.0.1.src.tar.xz -O ${TMP_FOLDER}/rt-src.tar.xz
+cmdp "Extracting the source code" tar -xf ${TMP_FOLDER}/rt-src.tar.xz -C ${TMP_FOLDER}
+cmd cd ${TMP_FOLDER}/compiler-rt-13.0.1.src
+
+BAREMETAL_PATH=$(clang-13 -print-resource-dir)/lib/baremetal
+cmd mkdir -p $BAREMETAL_PATH
+
+for ARCH in armv7m armv7em armv8m.main armv8.1m.main; do
+    cmdp "Preparing Compiler-RT builtins for target ${ARCH}" cmake -GNinja \
+        -DLLVM_CONFIG_PATH=$(command -v llvm-config-13) \
+        -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY \
+        -DCOMPILER_RT_OS_DIR="baremetal" \
+        -DCOMPILER_RT_BUILD_BUILTINS=ON \
+        -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+        -DCOMPILER_RT_BUILD_XRAY=OFF \
+        -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+        -DCOMPILER_RT_BUILD_PROFILE=OFF \
+        -DCMAKE_C_COMPILER=$(command -v clang-13) \
+        -DCMAKE_C_COMPILER_TARGET="${ARCH}-none-eabi" \
+        -DCMAKE_ASM_COMPILER_TARGET="${ARCH}-none-eabi" \
+        -DCMAKE_AR=$(command -v llvm-ar-13) \
+        -DCMAKE_NM=$(command -v llvm-nm-13) \
+        -DCMAKE_RANLIB=$(command -v llvm-ranlib-13) \
+        -DCOMPILER_RT_BAREMETAL_BUILD=ON \
+        -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON \
+        -DCOMPILER_RT_INCLUDE_TESTS=OFF \
+        -DCMAKE_C_FLAGS=\"-march=${ARCH} -mthumb -mfpu=none -mfloat-abi=soft -I${SYSROOT}/include\" \
+        -DCMAKE_ASM_FLAGS=\"-march=${ARCH} -mthumb -mfpu=none -mfloat-abi=soft -I${SYSROOT}/include\"
+    cmdp "Building builtins for target ${ARCH}" ninja builtins
+    cmdp "Installing the builtins" cp ./lib/baremetal/libclang_rt.builtins-arm.a ${BAREMETAL_PATH}/libclang_rt.builtins-${ARCH}.a
+done
+
+echo
+rm -rf ${TMP_FOLDER}


### PR DESCRIPTION
This patch fixes all outdated dependencies and broken links.

ArmClang compiler 6 is not longer provided in the Docker image, if it is required the compiler directory should be mounted as a volumen in the specified location in the documentation.

LLVM was updated to the latest supported version by the firmware with the instalation script that build the compiler-rt assets.

For the `dev` taget an user was created following the recomendations from Docker documentation.


Change-Id: I28bc940fefa754796e98f473bdb1f85bd13cc683