### PR TITLE
cli: Prepend carriage return to line feed

### DIFF
--- a/debugger/src/cli/cli.c
+++ b/debugger/src/cli/cli.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -524,9 +524,16 @@ uint32_t cli_print(const char *string)
     int32_t status = FWK_SUCCESS;
 
     for (index = 0; string[index] != 0; index++) {
+        if (string[index] == '\n') {
+            status = fwk_io_putch(fwk_io_stdout, '\r');
+            if (status != FWK_SUCCESS) {
+                return status;
+            }
+        }
         status = fwk_io_putch(fwk_io_stdout, string[index]);
-        if (status != FWK_SUCCESS)
+        if (status != FWK_SUCCESS) {
             return status;
+        }
     }
     return status;
 }


### PR DESCRIPTION
After c15ff7e9505e3544daa4ac5329f302e536fe7acf
which removes the prepending carriage return from the drivers. It moves the responsibility of prepending carriage return to the user of the driver. This patch is adding this logic to the cli.