### PR TITLE
scp: Update change_log for v2.12.0

### DIFF
--- a/change_log.md
+++ b/change_log.md
@@ -84,6 +84,13 @@ Deprecated
 - Platforms:
     - tc0: Deprecate platform
 
+Known issues
+------------
+
+- RDN2 fails to boot. Refer to the following github issue for more details and
+  the available temporary workaround:
+  https://github.com/ARM-software/SCP-firmware/issues/781
+
 SCP-firmware - version 2.11
 ============================
 


### PR DESCRIPTION
RDN2 platform fails to boot. As a consequence, a github issue is raised and a temporary workaround provided. This is mentioned in change_log.md within this patch.
