### PR TITLE
fwk: fix missing references for `FWK_LOG_LEVEL_TRACE`

### DIFF
--- a/Makefile.cmake
+++ b/Makefile.cmake
@@ -249,7 +249,7 @@ help:
 	@echo "        Include the debugger library."
 	@echo ""
 	@echo "    LOG_LEVEL"
-	@echo "        Value: <TRACE|INFO|WARN|ERROR|CRIT>"
+	@echo "        Value: <DEBUG|INFO|WARN|ERROR|CRIT>"
 	@echo "        Default: $(LOG_LEVEL)"
 	@echo "        Filter log messages less important than this level."
 	@echo ""


### PR DESCRIPTION
This patch addresses an issue where a reference was missing after renaming from `FWK_LOG_LEVEL_DEBUG` to `FWK_LOG_LEVEL_TRACE`. The fix ensures all references are properly updated.


Change-Id: Icf1ea1386bb9cbaf4f04b875d3194c5b18cda2bd