### PR TITLE
scmi_clock: add UT test cases

### DIFF
--- a/module/scmi_clock/test/CMakeLists.txt
+++ b/module/scmi_clock/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -27,6 +27,7 @@ set(MODULE_UT_INC ${CMAKE_CURRENT_LIST_DIR})
 set(MODULE_UT_MOCK_SRC ${CMAKE_CURRENT_LIST_DIR}/mocks)
 
 list(APPEND MOCK_REPLACEMENTS fwk_module)
+list(APPEND MOCK_REPLACEMENTS fwk_mm)
 list(APPEND MOCK_REPLACEMENTS fwk_id)
 list(APPEND MOCK_REPLACEMENTS fwk_core)
 
@@ -53,6 +54,7 @@ set(MODULE_UT_SRC ${CMAKE_CURRENT_LIST_DIR})
 set(MODULE_UT_INC ${CMAKE_CURRENT_LIST_DIR})
 set(MODULE_UT_MOCK_SRC ${CMAKE_CURRENT_LIST_DIR}/mocks)
 
+list(APPEND MOCK_REPLACEMENTS fwk_mm)
 list(APPEND MOCK_REPLACEMENTS fwk_module)
 list(APPEND MOCK_REPLACEMENTS fwk_id)
 list(APPEND MOCK_REPLACEMENTS fwk_core)

--- a/module/scmi_clock/test/config_scmi_clock.h
+++ b/module/scmi_clock/test/config_scmi_clock.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -13,53 +13,93 @@
 #include <fwk_module_idx.h>
 
 #define FAKE_MODULE_IDX 0x5
-#define FAKE_SCMI_AGENT_IDX_PSCI 0x1
-#define FAKE_SCMI_AGENT_IDX_OSPM 0x2
-#define FAKE_SCMI_AGENT_IDX_COUNT 0x3
+
+enum fake_scmi_agent {
+    FAKE_SCMI_AGENT_IDX_PSCI = 1,
+    FAKE_SCMI_AGENT_IDX_OSPM0,
+    FAKE_SCMI_AGENT_IDX_OSPM1,
+    FAKE_SCMI_AGENT_IDX_COUNT,
+};
 
 /*!
  * \brief Clock device indexes.
  */
 enum clock_dev_idx {
-    CLOCK_DEV_IDX_VPU,
-    CLOCK_DEV_IDX_DPU,
-    CLOCK_DEV_IDX_PIXEL_0,
-    CLOCK_DEV_IDX_PIXEL_1,
+    CLOCK_DEV_IDX_FAKE0,
+    CLOCK_DEV_IDX_FAKE1,
+    CLOCK_DEV_IDX_FAKE2,
+    CLOCK_DEV_IDX_FAKE3,
     CLOCK_DEV_IDX_COUNT
 };
 
-static const struct mod_scmi_clock_device agent_device_table_ospm[] = {
-    {
-        /* VPU */
+/*!
+ * \brief OSPM0 SCMI Clock indexes.
+ */
+enum scmi_clock_ospm0_idx {
+    SCMI_CLOCK_OSPM0_IDX0,
+    SCMI_CLOCK_OSPM0_IDX1,
+    SCMI_CLOCK_OSPM0_IDX2,
+    SCMI_CLOCK_OSPM0_IDX3,
+    SCMI_CLOCK_OSPM0_COUNT
+};
+
+/*!
+ * \brief OSPM1 SCMI Clock indexes.
+ */
+enum scmi_clock_ospm1_idx {
+    SCMI_CLOCK_OSPM1_IDX0,
+    SCMI_CLOCK_OSPM1_COUNT
+};
+
+
+static const struct mod_scmi_clock_device agent_device_table_ospm0
+    [SCMI_CLOCK_OSPM0_COUNT] = {
+    [SCMI_CLOCK_OSPM0_IDX0] = {
+        /* FAKE0 */
         .element_id =
-            FWK_ID_ELEMENT_INIT(FAKE_MODULE_IDX, CLOCK_DEV_IDX_VPU),
+            FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_DEV_IDX_FAKE0),
         .starts_enabled = true,
     },
-    {
-        /* DPU */
+    [SCMI_CLOCK_OSPM0_IDX1] = {
+        /* FAKE1 */
         .element_id =
-            FWK_ID_ELEMENT_INIT(FAKE_MODULE_IDX, CLOCK_DEV_IDX_DPU),
+            FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_DEV_IDX_FAKE1),
         .starts_enabled = true,
     },
-    {
-        /* PIXEL_0 */
+    [SCMI_CLOCK_OSPM0_IDX2] = {
+        /* FAKE2 */
         .element_id =
-            FWK_ID_ELEMENT_INIT(FAKE_MODULE_IDX, CLOCK_DEV_IDX_PIXEL_0),
+            FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_DEV_IDX_FAKE2),
         .starts_enabled = true,
     },
-    {
-        /* PIXEL_1 */
+    [SCMI_CLOCK_OSPM0_IDX3] = {
+        /* FAKE3 */
         .element_id =
-            FWK_ID_ELEMENT_INIT(FAKE_MODULE_IDX, CLOCK_DEV_IDX_PIXEL_1),
+            FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_DEV_IDX_FAKE3),
         .starts_enabled = true,
     },
 };
 
-static const struct mod_scmi_clock_agent agent_table[FAKE_SCMI_AGENT_IDX_COUNT] = {
+static const struct mod_scmi_clock_device agent_device_table_ospm1
+    [SCMI_CLOCK_OSPM1_COUNT] = {
+    [SCMI_CLOCK_OSPM1_IDX0] = {
+        /* FAKE3 */
+        .element_id =
+            FWK_ID_ELEMENT_INIT(FWK_MODULE_IDX_CLOCK, CLOCK_DEV_IDX_FAKE3),
+        .starts_enabled = true,
+    },
+};
+
+static const struct mod_scmi_clock_agent agent_table
+        [FAKE_SCMI_AGENT_IDX_COUNT] = {
     [FAKE_SCMI_AGENT_IDX_PSCI] = { 0 /* No access */ },
-    [FAKE_SCMI_AGENT_IDX_OSPM] = {
-        .device_table = agent_device_table_ospm,
-        .device_count = FWK_ARRAY_SIZE(agent_device_table_ospm),
+    [FAKE_SCMI_AGENT_IDX_OSPM0] = {
+        .device_table = agent_device_table_ospm0,
+        .device_count = FWK_ARRAY_SIZE(agent_device_table_ospm0),
+    },
+    [FAKE_SCMI_AGENT_IDX_OSPM1] = {
+        .device_table = agent_device_table_ospm1,
+        .device_count = FWK_ARRAY_SIZE(agent_device_table_ospm1),
     },
 };
 
@@ -69,4 +109,47 @@ struct fwk_module_config config_scmi_clock = {
         .agent_table = agent_table,
         .agent_count = FWK_ARRAY_SIZE(agent_table),
     }),
+};
+
+static struct clock_operations clock_ops_table[CLOCK_DEV_IDX_COUNT];
+
+static uint8_t agent_clock_state_table
+    [FAKE_SCMI_AGENT_IDX_COUNT * CLOCK_DEV_IDX_COUNT];
+
+static uint8_t dev_clock_ref_count_table[CLOCK_DEV_IDX_COUNT];
+
+static uint8_t agent_clock_state_table_expected
+    [FAKE_SCMI_AGENT_IDX_COUNT * CLOCK_DEV_IDX_COUNT];
+
+static uint8_t dev_clock_ref_count_table_expected[CLOCK_DEV_IDX_COUNT];
+
+static const uint8_t agent_clock_state_table_default
+    [FAKE_SCMI_AGENT_IDX_COUNT * CLOCK_DEV_IDX_COUNT] = {
+        /* INVALID AGENT */
+        MOD_CLOCK_STATE_STOPPED,
+        MOD_CLOCK_STATE_STOPPED,
+        MOD_CLOCK_STATE_STOPPED,
+        MOD_CLOCK_STATE_STOPPED,
+        /* FAKE_SCMI_AGENT_IDX_PSCI */
+        MOD_CLOCK_STATE_STOPPED,
+        MOD_CLOCK_STATE_STOPPED,
+        MOD_CLOCK_STATE_STOPPED,
+        MOD_CLOCK_STATE_STOPPED,
+        /* FAKE_SCMI_AGENT_IDX_OSPM0 */
+        MOD_CLOCK_STATE_RUNNING,
+        MOD_CLOCK_STATE_RUNNING,
+        MOD_CLOCK_STATE_RUNNING,
+        MOD_CLOCK_STATE_RUNNING,
+        /* FAKE_SCMI_AGENT_IDX_OSPM1 */
+        MOD_CLOCK_STATE_RUNNING,
+        MOD_CLOCK_STATE_STOPPED,
+        MOD_CLOCK_STATE_STOPPED,
+        MOD_CLOCK_STATE_STOPPED,
+    };
+
+static const uint8_t dev_clock_ref_count_table_default[CLOCK_DEV_IDX_COUNT] = {
+    1,
+    1,
+    1,
+    2,
 };

--- a/module/scmi_clock/test/mod_scmi_clock_unit_test.c
+++ b/module/scmi_clock/test/mod_scmi_clock_unit_test.c
@@ -13,6 +13,7 @@
 #    include <fwk_module.h>
 #else
 #    include <Mockfwk_id.h>
+#    include <Mockfwk_mm.h>
 #    include <Mockfwk_module.h>
 #    include <internal/Mockfwk_core_internal.h>
 #endif
@@ -20,7 +21,6 @@
 #include <mod_clock.h>
 
 #include <mod_scmi.h>
-#include <config_scmi_clock.h>
 
 #include <fwk_element.h>
 #include <fwk_macros.h>
@@ -30,6 +30,7 @@
 #endif
 
 #include UNIT_TEST_SRC
+#include <config_scmi_clock.h>
 
 static struct mod_scmi_clock_ctx scmi_clock_ctx;
 
@@ -54,18 +55,65 @@ struct mod_res_permissions_api perm_api = {
 };
 #endif
 
+void assert_clock_state_and_ref_count_meets_expectations(void)
+{
+    TEST_ASSERT_EQUAL_INT8_ARRAY(
+        agent_clock_state_table_expected,
+        agent_clock_state_table,
+        FAKE_SCMI_AGENT_IDX_COUNT * CLOCK_DEV_IDX_COUNT);
+    TEST_ASSERT_EQUAL_INT8_ARRAY(
+        dev_clock_ref_count_table_expected,
+        dev_clock_ref_count_table,
+        CLOCK_DEV_IDX_COUNT);
+}
+
+void setup_agent_state_table(
+    unsigned int agent_id,
+    unsigned int scmi_clock_idx,
+    enum mod_clock_state state)
+{
+    agent_clock_state_table
+        [agent_id * scmi_clock_ctx.clock_devices + scmi_clock_idx] =
+        (unsigned int)state;
+}
+
+void setup_ref_count_table(
+    unsigned int clock_idx,
+    unsigned int ref_count)
+{
+    dev_clock_ref_count_table[clock_idx] = ref_count;
+}
+
+void setup_expected_agent_state_table(
+    unsigned int agent_id,
+    unsigned int scmi_clock_idx,
+    enum mod_clock_state state)
+{
+    agent_clock_state_table_expected
+        [agent_id * scmi_clock_ctx.clock_devices + scmi_clock_idx] =
+        (unsigned int)state;
+}
+
+void setup_expected_ref_count_table(
+    unsigned int clock_idx,
+    unsigned int ref_count)
+{
+    dev_clock_ref_count_table_expected[clock_idx] = ref_count;
+}
+
+
 void setUp(void)
 {
     scmi_clock_ctx.config = config_scmi_clock.data;
     scmi_clock_ctx.max_pending_transactions = scmi_clock_ctx.config->max_pending_transactions;
     scmi_clock_ctx.agent_table = scmi_clock_ctx.config->agent_table;
 
-    scmi_clock_ctx.clock_devices = FWK_ARRAY_SIZE(agent_device_table_ospm);
+    scmi_clock_ctx.clock_devices = CLOCK_DEV_IDX_COUNT;
 
     /* Allocate a table of clock operations */
-    scmi_clock_ctx.clock_ops =
-        fwk_mm_calloc((unsigned int)scmi_clock_ctx.clock_devices,
-        sizeof(struct clock_operations));
+    scmi_clock_ctx.clock_ops = clock_ops_table;
+    memset(clock_ops_table, 0,
+           CLOCK_DEV_IDX_COUNT * sizeof(struct clock_operations));
 
     /* Initialize table */
     for (unsigned int i = 0; i < (unsigned int)scmi_clock_ctx.clock_devices; i++) {
@@ -76,6 +124,26 @@ void setUp(void)
     #if defined(BUILD_HAS_MOD_RESOURCE_PERMS)
         scmi_clock_ctx.res_perms_api = &perm_api;
     #endif
+
+    scmi_clock_ctx.dev_clock_ref_count_table = dev_clock_ref_count_table;
+    scmi_clock_ctx.agent_clock_state_table = agent_clock_state_table;
+    memcpy(
+        dev_clock_ref_count_table,
+        dev_clock_ref_count_table_default,
+        FWK_ARRAY_SIZE(dev_clock_ref_count_table));
+    memcpy(
+        agent_clock_state_table,
+        agent_clock_state_table_default,
+        FWK_ARRAY_SIZE(agent_clock_state_table));
+    memcpy(
+        dev_clock_ref_count_table_expected,
+        dev_clock_ref_count_table_default,
+        FWK_ARRAY_SIZE(dev_clock_ref_count_table));
+    memcpy(
+        agent_clock_state_table_expected,
+        agent_clock_state_table_default,
+        FWK_ARRAY_SIZE(agent_clock_state_table));
+
 }
 
 void tearDown(void)
@@ -100,13 +168,13 @@ void test_function_set_rate(void)
     int status;
 
     fwk_id_t service_id =
-        FWK_ID_ELEMENT_INIT(FAKE_MODULE_IDX, FAKE_SCMI_AGENT_IDX_OSPM);
+        FWK_ID_ELEMENT_INIT(FAKE_MODULE_IDX, FAKE_SCMI_AGENT_IDX_OSPM0);
 
-    unsigned int agent_id = FAKE_SCMI_AGENT_IDX_OSPM;
+    unsigned int agent_id = FAKE_SCMI_AGENT_IDX_OSPM0;
 
     struct scmi_clock_rate_set_a2p payload = {
         .flags = SCMI_CLOCK_RATE_SET_ROUND_AUTO_MASK,
-        .clock_id = CLOCK_DEV_IDX_VPU,
+        .clock_id = CLOCK_DEV_IDX_FAKE0,
         .rate[0] = 0x00000001,
         .rate[1] = 0x00000001,
     };
@@ -124,7 +192,7 @@ void test_function_set_rate(void)
     mod_scmi_from_protocol_api_get_agent_id_ExpectAnyArgsAndReturn(FWK_SUCCESS);
     mod_scmi_from_protocol_api_get_agent_id_ReturnThruPtr_agent_id(&agent_id);
 
-    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(CLOCK_DEV_IDX_VPU);
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(CLOCK_DEV_IDX_FAKE0);
     fwk_id_is_equal_ExpectAnyArgsAndReturn(true);
 
     __fwk_put_event_Stub(fwk_put_event_callback);
@@ -139,6 +207,415 @@ void test_function_set_rate(void)
     TEST_ASSERT_EQUAL(FWK_SUCCESS, status);
 }
 
+void test_clock_ref_count_allocate(void)
+{
+    uint8_t *agent_clock_state_table_return = (uint8_t *)0xAAAAAAAA;
+    uint8_t *dev_clock_ref_count_table_return = (uint8_t *)0xAAAAAAAA;
+
+    scmi_clock_ctx.dev_clock_ref_count_table = NULL;
+    scmi_clock_ctx.agent_clock_state_table = NULL;
+
+    fwk_mm_calloc_ExpectAndReturn(
+            (unsigned int)scmi_clock_ctx.config->agent_count *
+                (unsigned int)scmi_clock_ctx.clock_devices,
+            sizeof(*scmi_clock_ctx.agent_clock_state_table),
+            agent_clock_state_table_return);
+    fwk_mm_calloc_ExpectAndReturn(
+            (unsigned int)scmi_clock_ctx.clock_devices,
+            sizeof(*scmi_clock_ctx.dev_clock_ref_count_table),
+            dev_clock_ref_count_table_return);
+
+    clock_ref_count_allocate();
+    TEST_ASSERT_EQUAL_PTR(
+        scmi_clock_ctx.agent_clock_state_table,
+        agent_clock_state_table_return);
+    TEST_ASSERT_EQUAL_PTR(
+        scmi_clock_ctx.dev_clock_ref_count_table,
+        dev_clock_ref_count_table_return);
+}
+
+void test_clock_ref_count_init(void)
+{
+    /* Make sure that the tables are cleared before running tests. */
+    memset(agent_clock_state_table, 0,
+        FAKE_SCMI_AGENT_IDX_COUNT * CLOCK_DEV_IDX_COUNT);
+    memset(dev_clock_ref_count_table, 0, CLOCK_DEV_IDX_COUNT);
+
+    /* OSPM0 */
+    for (unsigned int i = 0; i < CLOCK_DEV_IDX_COUNT; i++) {
+        fwk_id_get_element_idx_ExpectAndReturn(
+            FWK_ID_ELEMENT(FWK_MODULE_IDX_CLOCK, i),
+            i);
+    }
+    /* OSPM1 */
+    fwk_id_get_element_idx_ExpectAndReturn(
+            FWK_ID_ELEMENT(FWK_MODULE_IDX_CLOCK, CLOCK_DEV_IDX_FAKE3),
+            CLOCK_DEV_IDX_FAKE3);
+
+    clock_ref_count_init();
+    TEST_ASSERT_EQUAL_INT8_ARRAY(
+        agent_clock_state_table_default,
+        agent_clock_state_table,
+        FAKE_SCMI_AGENT_IDX_COUNT * CLOCK_DEV_IDX_COUNT);
+    TEST_ASSERT_EQUAL_INT8_ARRAY(
+        dev_clock_ref_count_table_default,
+        dev_clock_ref_count_table,
+        CLOCK_DEV_IDX_COUNT);
+}
+
+void test_mod_scmi_clock_request_state_check_no_change_running(void)
+{
+    enum mod_scmi_clock_policy_status status;
+
+    /* Set `SCMI_CLOCK_OSPM0_IDX0` as RUNNING and ref_count == 1 */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE0, 1);
+
+    status = mod_scmi_clock_request_state_check(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        CLOCK_DEV_IDX_FAKE0,
+        MOD_CLOCK_STATE_RUNNING);
+    TEST_ASSERT_EQUAL(MOD_SCMI_CLOCK_SKIP_MESSAGE_HANDLER, status);
+}
+
+void test_mod_scmi_clock_request_state_check_no_change_stopped(void)
+{
+    enum mod_scmi_clock_policy_status status;
+
+    /* Set `SCMI_CLOCK_OSPM0_IDX0` as STOPPED and ref_count == 0  */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_STOPPED);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE0, 0);
+
+    status = mod_scmi_clock_request_state_check(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        CLOCK_DEV_IDX_FAKE0,
+        MOD_CLOCK_STATE_STOPPED);
+    TEST_ASSERT_EQUAL(MOD_SCMI_CLOCK_SKIP_MESSAGE_HANDLER, status);
+}
+
+void test_mod_scmi_clock_request_state_check_ref_count_0_running(void)
+{
+    enum mod_scmi_clock_policy_status status;
+
+    /* Set `SCMI_CLOCK_OSPM0_IDX0` as STOPPED and ref_count == 0 */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_STOPPED);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE0, 0);
+
+    status = mod_scmi_clock_request_state_check(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        CLOCK_DEV_IDX_FAKE0,
+        MOD_CLOCK_STATE_RUNNING);
+    TEST_ASSERT_EQUAL(MOD_SCMI_CLOCK_EXECUTE_MESSAGE_HANDLER, status);
+}
+
+void test_mod_scmi_clock_request_state_check_ref_count_1_stopped(void)
+{
+
+    enum mod_scmi_clock_policy_status status;
+
+    /* Set `SCMI_CLOCK_OSPM0_IDX0` as RUNNING and ref_count == 1 */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE0, 1);
+
+    status = mod_scmi_clock_request_state_check(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        CLOCK_DEV_IDX_FAKE0,
+        MOD_CLOCK_STATE_STOPPED);
+    TEST_ASSERT_EQUAL(MOD_SCMI_CLOCK_EXECUTE_MESSAGE_HANDLER, status);
+}
+
+void test_mod_scmi_clock_request_state_check_ref_count_0_stopped(void)
+{
+    enum mod_scmi_clock_policy_status status;
+
+    /*
+     * Create an invalid situation where it is set `SCMI_CLOCK_OSPM0_IDX0`
+     * as RUNNING and ref_count == 0
+     */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE0, 0);
+
+    status = mod_scmi_clock_request_state_check(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        CLOCK_DEV_IDX_FAKE0,
+        MOD_CLOCK_STATE_STOPPED);
+    TEST_ASSERT_EQUAL(MOD_SCMI_CLOCK_SKIP_MESSAGE_HANDLER, status);
+}
+
+void test_mod_scmi_clock_request_state_check_ref_count_1_running(void)
+{
+    enum mod_scmi_clock_policy_status status;
+
+    /*
+     * Set `SCMI_CLOCK_OSPM0_IDX3` as RUNNING,
+     * set `SCMI_CLOCK_OSPM1_IDX0` as STOPPED and
+     * ref_count == 1
+     */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX3,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM1,
+        SCMI_CLOCK_OSPM1_IDX0,
+        MOD_CLOCK_STATE_STOPPED);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE3, 1);
+
+    status = mod_scmi_clock_request_state_check(
+        FAKE_SCMI_AGENT_IDX_OSPM1,
+        SCMI_CLOCK_OSPM1_IDX0,
+        CLOCK_DEV_IDX_FAKE3,
+        MOD_CLOCK_STATE_RUNNING);
+    TEST_ASSERT_EQUAL(MOD_SCMI_CLOCK_SKIP_MESSAGE_HANDLER, status);
+}
+
+void test_mod_scmi_clock_request_state_check_ref_count_2_stopped(void)
+{
+    enum mod_scmi_clock_policy_status status;
+
+    /*
+     * Set `SCMI_CLOCK_OSPM0_IDX3` as RUNNING,
+     * set `SCMI_CLOCK_OSPM1_IDX0` as RUNNING and
+     * ref_count == 2
+     */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX3,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM1,
+        SCMI_CLOCK_OSPM1_IDX0,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE3, 2);
+
+    status = mod_scmi_clock_request_state_check(
+        FAKE_SCMI_AGENT_IDX_OSPM1,
+        SCMI_CLOCK_OSPM1_IDX0,
+        CLOCK_DEV_IDX_FAKE3,
+        MOD_CLOCK_STATE_STOPPED);
+    TEST_ASSERT_EQUAL(MOD_SCMI_CLOCK_SKIP_MESSAGE_HANDLER, status);
+}
+
+void test_mod_scmi_clock_state_update_no_change_running(void)
+{
+    int status;
+
+    /*
+     * Set `SCMI_CLOCK_OSPM0_IDX0` as RUNNING,
+     * set expected `SCMI_CLOCK_OSPM0_IDX0` as RUNNING and
+     * ref_count == 1 and expected ref_count == 1
+     */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE0, 1);
+
+    setup_expected_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_expected_ref_count_table(CLOCK_DEV_IDX_FAKE0, 1);
+
+    status = mod_scmi_clock_state_update(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        CLOCK_DEV_IDX_FAKE0,
+        MOD_CLOCK_STATE_RUNNING);
+    TEST_ASSERT_EQUAL(FWK_SUCCESS, status);
+    assert_clock_state_and_ref_count_meets_expectations();
+}
+
+void test_mod_scmi_clock_state_update_no_change_stopped(void)
+{
+    int status;
+
+    /*
+     * Set `SCMI_CLOCK_OSPM0_IDX0` as STOPPED,
+     * set expected `SCMI_CLOCK_OSPM0_IDX0` as STOPPED,
+     * ref_count == 0 and expected ref_count == 0
+     */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_STOPPED);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE0, 0);
+
+    setup_expected_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_STOPPED);
+    setup_expected_ref_count_table(CLOCK_DEV_IDX_FAKE0, 0);
+
+    status = mod_scmi_clock_state_update(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        CLOCK_DEV_IDX_FAKE0,
+        MOD_CLOCK_STATE_STOPPED);
+    TEST_ASSERT_EQUAL(FWK_SUCCESS, status);
+    assert_clock_state_and_ref_count_meets_expectations();
+}
+
+void test_mod_scmi_clock_state_update_ref_count_0_running(void)
+{
+    int status;
+
+    /*
+     * Set SCMI clock 0 from `FAKE_SCMI_AGENT_IDX_OSPM0` as STOPPED,
+     * set expected SCMI clock 0 from `FAKE_SCMI_AGENT_IDX_OSPM0` as RUNNING,
+     * ref_count == 0 and expected ref_count == 1
+     */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_STOPPED);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE0, 0);
+
+    setup_expected_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_expected_ref_count_table(CLOCK_DEV_IDX_FAKE0, 1);
+
+    status = mod_scmi_clock_state_update(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        CLOCK_DEV_IDX_FAKE0,
+        MOD_CLOCK_STATE_RUNNING);
+    TEST_ASSERT_EQUAL(FWK_SUCCESS, status);
+    assert_clock_state_and_ref_count_meets_expectations();
+}
+
+void test_mod_scmi_clock_state_update_ref_count_1_running(void)
+{
+    int status;
+
+    /*
+     * Set `SCMI_CLOCK_OSPM0_IDX3` as RUNNING,
+     * set `SCMI_CLOCK_OSPM1_IDX0` as STOPPED,
+     * set expected `SCMI_CLOCK_OSPM0_IDX3` as RUNNING,
+     * set expected `SCMI_CLOCK_OSPM1_IDX0` as RUNNING,
+     * ref_count == 2 and expected ref_count == 1
+     */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX3,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM1,
+        SCMI_CLOCK_OSPM1_IDX0,
+        MOD_CLOCK_STATE_STOPPED);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE3, 1);
+
+    setup_expected_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX3,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_expected_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM1,
+        SCMI_CLOCK_OSPM1_IDX0,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_expected_ref_count_table(CLOCK_DEV_IDX_FAKE3, 2);
+
+    status = mod_scmi_clock_state_update(
+        FAKE_SCMI_AGENT_IDX_OSPM1,
+        SCMI_CLOCK_OSPM1_IDX0,
+        CLOCK_DEV_IDX_FAKE3,
+        MOD_CLOCK_STATE_RUNNING);
+    TEST_ASSERT_EQUAL(FWK_SUCCESS, status);
+    assert_clock_state_and_ref_count_meets_expectations();
+}
+
+void test_mod_scmi_clock_state_update_ref_count_2_stopped(void)
+{
+    int status;
+
+    /*
+     * Set `SCMI_CLOCK_OSPM0_IDX3` as RUNNING,
+     * set `SCMI_CLOCK_OSPM1_IDX0` as RUNNING,
+     * set expected `SCMI_CLOCK_OSPM0_IDX3` as RUNNING,
+     * set expected `SCMI_CLOCK_OSPM1_IDX0` as STOPPED,
+     * ref_count == 2 and expected ref_count == 1
+     */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX3,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM1,
+        SCMI_CLOCK_OSPM1_IDX0,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE3, 2);
+
+    setup_expected_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX3,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_expected_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM1,
+        SCMI_CLOCK_OSPM1_IDX0,
+        MOD_CLOCK_STATE_STOPPED);
+    setup_expected_ref_count_table(CLOCK_DEV_IDX_FAKE3, 1);
+
+    status = mod_scmi_clock_state_update(
+        FAKE_SCMI_AGENT_IDX_OSPM1,
+        SCMI_CLOCK_OSPM1_IDX0,
+        CLOCK_DEV_IDX_FAKE3,
+        MOD_CLOCK_STATE_STOPPED);
+    TEST_ASSERT_EQUAL(FWK_SUCCESS, status);
+    assert_clock_state_and_ref_count_meets_expectations();
+}
+
+void test_mod_scmi_clock_state_update_ref_count_1_stopped(void)
+{
+    int status;
+
+    /*
+     * Set SCMI clock 0 from `FAKE_SCMI_AGENT_IDX_OSPM0` as RUNNING,
+     * set expected SCMI clock 0 from `FAKE_SCMI_AGENT_IDX_OSPM0` as STOPPED,
+     * ref_count == 1 and expected ref_count == 0
+     */
+    setup_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_RUNNING);
+    setup_expected_ref_count_table(CLOCK_DEV_IDX_FAKE0, 0);
+
+    setup_expected_agent_state_table(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        MOD_CLOCK_STATE_STOPPED);
+    setup_ref_count_table(CLOCK_DEV_IDX_FAKE0, 1);
+
+    status = mod_scmi_clock_state_update(
+        FAKE_SCMI_AGENT_IDX_OSPM0,
+        SCMI_CLOCK_OSPM0_IDX0,
+        CLOCK_DEV_IDX_FAKE0,
+        MOD_CLOCK_STATE_STOPPED);
+    TEST_ASSERT_EQUAL(FWK_SUCCESS, status);
+    assert_clock_state_and_ref_count_meets_expectations();
+}
+
 int scmi_test_main(void)
 {
     UNITY_BEGIN();
@@ -146,6 +623,22 @@ int scmi_test_main(void)
         RUN_TEST(test_function_set_rate);
     #else
         RUN_TEST(test_function_set_rate);
+        RUN_TEST(test_clock_ref_count_allocate);
+        RUN_TEST(test_clock_ref_count_init);
+        RUN_TEST(test_mod_scmi_clock_request_state_check_no_change_running);
+        RUN_TEST(test_mod_scmi_clock_request_state_check_no_change_stopped);
+        RUN_TEST(test_mod_scmi_clock_request_state_check_ref_count_0_running);
+        RUN_TEST(test_mod_scmi_clock_request_state_check_ref_count_1_stopped);
+        RUN_TEST(test_mod_scmi_clock_request_state_check_ref_count_0_stopped);
+        RUN_TEST(test_mod_scmi_clock_request_state_check_ref_count_1_running);
+        RUN_TEST(test_mod_scmi_clock_request_state_check_ref_count_2_stopped);
+        RUN_TEST(test_mod_scmi_clock_state_update_no_change_running);
+        RUN_TEST(test_mod_scmi_clock_state_update_no_change_stopped);
+        RUN_TEST(test_mod_scmi_clock_state_update_ref_count_0_running);
+        RUN_TEST(test_mod_scmi_clock_state_update_ref_count_1_running);
+        RUN_TEST(test_mod_scmi_clock_state_update_ref_count_2_stopped);
+        RUN_TEST(test_mod_scmi_clock_state_update_ref_count_1_stopped);
+
     #endif
     return UNITY_END();
 }

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #


### PR DESCRIPTION
This patch adds unit test for the state and reference counting check and update functions.