### PR TITLE
fwk_log: remove '\n' character from log prints

### DIFF
--- a/framework/src/fwk_core.c
+++ b/framework/src/fwk_core.c
@@ -183,7 +183,7 @@ static void process_next_event(void)
 
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
     FWK_LOG_DEBUG(
-        "[FWK] Processing %" PRIu32 ": %s @ %s -> %s\n",
+        "[FWK] Processing %" PRIu32 ": %s @ %s -> %s",
         event->cookie,
         FWK_ID_STR(event->id),
         FWK_ID_STR(event->source_id),
@@ -225,7 +225,7 @@ static void process_next_event(void)
         status = process_event(event, &async_response_event);
         if ((status != FWK_SUCCESS) && (status != FWK_PENDING)) {
             FWK_LOG_CRIT(
-                "[FWK] Process event (%s: %s -> %s) (%d)\n",
+                "[FWK] Process event (%s: %s -> %s) (%d)",
                 FWK_ID_STR(event->id),
                 FWK_ID_STR(event->source_id),
                 FWK_ID_STR(event->target_id),
@@ -254,7 +254,7 @@ static bool process_isr(void)
 
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
     FWK_LOG_DEBUG(
-        "[FWK] Pulled ISR event (%s: %s -> %s)\n",
+        "[FWK] Pulled ISR event (%s: %s -> %s)",
         FWK_ID_STR(isr_event->id),
         FWK_ID_STR(isr_event->source_id),
         FWK_ID_STR(isr_event->target_id));

--- a/framework/src/fwk_log.c
+++ b/framework/src/fwk_log.c
@@ -99,9 +99,7 @@ static void fwk_log_vsnprintf(
 
     size_t length = 0;
 
-    char *newline;
-
-    buffer_size -= strlen(FWK_LOG_TERMINATOR);
+    buffer_size -= FWK_ARRAY_SIZE(FWK_LOG_TERMINATOR);
 
     /*
      * We start by generating a timestamp for the message using the number of
@@ -142,25 +140,12 @@ static void fwk_log_vsnprintf(
     length = FWK_MIN(length, buffer_size - 1);
 
     /*
-     * Figure out if the user has included a newline, in which case we consider
-     * that to be the end of the message. This stops us from being able to
-     * create multi-line messages, but means we can properly generate timestamps
-     * on a line-by-line basis.
+     * Lastly, we follow through on the termination defined by
+     * `FWK_LOG_TERMINATOR`.
      */
 
-    newline = strstr(buffer, FWK_LOG_TERMINATOR);
-    if (newline == NULL) {
-        newline = buffer + length;
-    }
-
-    /*
-     * Lastly, we follow through on the termination with a proper carriage
-     * return and newline. Terminals that don't care about the carriage return
-     * will generally ignore it, but most terminals require it in order to start
-     * the next line at the first column.
-     */
-
-    (void)memcpy(newline, FWK_LOG_TERMINATOR, sizeof(FWK_LOG_TERMINATOR));
+    (void)memcpy(
+        buffer + length, FWK_LOG_TERMINATOR, sizeof(FWK_LOG_TERMINATOR));
 }
 
 static void fwk_log_snprintf(
@@ -178,7 +163,7 @@ static void fwk_log_snprintf(
 
 static bool fwk_log_banner(void)
 {
-    char buffer[FMW_LOG_COLUMNS + sizeof(FWK_LOG_TERMINATOR)];
+    char buffer[FMW_LOG_COLUMNS];
 
 #ifndef FMW_LOG_MINIMAL_BANNER
     const char *banner[] = {
@@ -195,8 +180,7 @@ static bool fwk_log_banner(void)
                              "" };
 #endif
     for (unsigned int i = 0; i < FWK_ARRAY_SIZE(banner); i++) {
-        fwk_log_snprintf(
-            sizeof(buffer), buffer, "%s%s", banner[i], FWK_LOG_TERMINATOR);
+        fwk_log_snprintf(sizeof(buffer), buffer, "%s", banner[i]);
         if (fwk_io_puts(fwk_log_stream, buffer) != FWK_SUCCESS) {
             return false;
         }

--- a/module/cmn650/src/mod_cmn650.c
+++ b/module/cmn650/src/mod_cmn650.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -244,7 +244,7 @@ static int cmn650_discovery(void)
                 case NODE_TYPE_RN_D:
                     if ((ctx->rnd_count) >= MAX_RND_COUNT) {
                         FWK_LOG_ERR(
-                            MOD_NAME "  rnd count %d >= max limit (%d)\n",
+                            MOD_NAME "  rnd count %d >= max limit (%d)",
                             ctx->rnd_count,
                             MAX_RND_COUNT);
                         return FWK_E_DATA;
@@ -255,7 +255,7 @@ static int cmn650_discovery(void)
                 case NODE_TYPE_RN_I:
                     if ((ctx->rni_count) >= MAX_RNI_COUNT) {
                         FWK_LOG_ERR(
-                            MOD_NAME "  rni count %d >= max limit (%d)\n",
+                            MOD_NAME "  rni count %d >= max limit (%d)",
                             ctx->rni_count,
                             MAX_RNI_COUNT);
                         return FWK_E_DATA;
@@ -304,15 +304,12 @@ static int cmn650_discovery(void)
     /* Total number of CXG_RA, CXG_HA and CXLA nodes should be equal */
     if ((cxg_ra_reg_count != cxg_ha_reg_count) ||
         (cxg_ha_reg_count != cxla_reg_count)) {
-        FWK_LOG_ERR(
-            MOD_NAME
-            "Inconsistent count of CXG components detected, discovery failed.\n"
-            " CXG_RA count: %d\n"
-            " CXG_HA count: %d\n"
-            " CXLA   count: %d\n",
-            cxg_ra_reg_count,
-            cxg_ha_reg_count,
-            cxla_reg_count);
+        FWK_LOG_ERR(MOD_NAME
+                    " Inconsistent count of CXG components detected, discovery "
+                    "failed.");
+        FWK_LOG_ERR(MOD_NAME " CXG_RA count: %d", cxg_ra_reg_count);
+        FWK_LOG_ERR(MOD_NAME " CXG_HA count: %d", cxg_ha_reg_count);
+        FWK_LOG_ERR(MOD_NAME " CXLA   count: %d", cxla_reg_count);
         return FWK_E_DEVICE;
     }
 
@@ -320,7 +317,7 @@ static int cmn650_discovery(void)
 
     if (ctx->rnf_count > MAX_RNF_COUNT) {
         FWK_LOG_ERR(
-            MOD_NAME "rnf count %d > max limit (%d)\n",
+            MOD_NAME "rnf count %d > max limit (%d)",
             ctx->rnf_count,
             MAX_RNF_COUNT);
         return FWK_E_RANGE;
@@ -331,9 +328,9 @@ static int cmn650_discovery(void)
     FWK_LOG_INFO(
         MOD_NAME "Total external RN-SAM nodes: %d", ctx->external_rnsam_count);
     FWK_LOG_INFO(MOD_NAME "Total HN-F nodes: %d", ctx->hnf_count);
-    FWK_LOG_INFO(MOD_NAME "Total RN-D nodes: %d\n", ctx->rnd_count);
-    FWK_LOG_INFO(MOD_NAME "Total RN-F nodes: %d\n", ctx->rnf_count);
-    FWK_LOG_INFO(MOD_NAME "Total RN-I nodes: %d\n", ctx->rni_count);
+    FWK_LOG_INFO(MOD_NAME "Total RN-D nodes: %d", ctx->rnd_count);
+    FWK_LOG_INFO(MOD_NAME "Total RN-F nodes: %d", ctx->rnf_count);
+    FWK_LOG_INFO(MOD_NAME "Total RN-I nodes: %d", ctx->rni_count);
     FWK_LOG_INFO(
         MOD_NAME "Total CCIX Request Agent nodes: %d", cxg_ra_reg_count);
     FWK_LOG_INFO(MOD_NAME "Total CCIX Home Agent nodes: %d", cxg_ha_reg_count);
@@ -935,7 +932,7 @@ int cmn650_start(fwk_id_t id)
     ctx = ctx + fwk_id_get_element_idx(id);
 
     FWK_LOG_INFO(
-        MOD_NAME "Multichip mode: %d Chip ID: %d\n", multi_chip_mode, chip_id);
+        MOD_NAME "Multichip mode: %d Chip ID: %d", multi_chip_mode, chip_id);
 
     if (fwk_id_is_equal(ctx->config->clock_id, FWK_ID_NONE)) {
         cmn650_setup();

--- a/module/cmn700/src/mod_cmn700.c
+++ b/module/cmn700/src/mod_cmn700.c
@@ -301,7 +301,7 @@ static int cmn700_discovery(void)
                 case NODE_TYPE_RN_D:
                     if ((ctx->rnd_count) >= MAX_RND_COUNT) {
                         FWK_LOG_ERR(
-                            MOD_NAME "  rnd count %d >= max limit (%d)\n",
+                            MOD_NAME "  rnd count %d >= max limit (%d)",
                             ctx->rnd_count,
                             MAX_RND_COUNT);
                         return FWK_E_DATA;
@@ -312,7 +312,7 @@ static int cmn700_discovery(void)
                 case NODE_TYPE_RN_I:
                     if ((ctx->rni_count) >= MAX_RNI_COUNT) {
                         FWK_LOG_ERR(
-                            MOD_NAME "  rni count %d >= max limit (%d)\n",
+                            MOD_NAME "  rni count %d >= max limit (%d)",
                             ctx->rni_count,
                             MAX_RNI_COUNT);
                         return FWK_E_DATA;
@@ -374,7 +374,7 @@ static int cmn700_discovery(void)
 
     if (ctx->rnf_count > MAX_RNF_COUNT) {
         FWK_LOG_ERR(
-            MOD_NAME "rnf count %d > max limit (%d)\n",
+            MOD_NAME "rnf count %d > max limit (%d)",
             ctx->rnf_count,
             MAX_RNF_COUNT);
         return FWK_E_RANGE;
@@ -385,9 +385,9 @@ static int cmn700_discovery(void)
     FWK_LOG_INFO(
         MOD_NAME "Total external RN-SAM nodes: %d", ctx->external_rnsam_count);
     FWK_LOG_INFO(MOD_NAME "Total HN-F nodes: %d", ctx->hnf_count);
-    FWK_LOG_INFO(MOD_NAME "Total RN-D nodes: %d\n", ctx->rnd_count);
-    FWK_LOG_INFO(MOD_NAME "Total RN-F nodes: %d\n", ctx->rnf_count);
-    FWK_LOG_INFO(MOD_NAME "Total RN-I nodes: %d\n", ctx->rni_count);
+    FWK_LOG_INFO(MOD_NAME "Total RN-D nodes: %d", ctx->rnd_count);
+    FWK_LOG_INFO(MOD_NAME "Total RN-F nodes: %d", ctx->rnf_count);
+    FWK_LOG_INFO(MOD_NAME "Total RN-I nodes: %d", ctx->rni_count);
     FWK_LOG_INFO(
         MOD_NAME "Total CCIX Request Agent nodes: %d", cxg_ra_reg_count);
     FWK_LOG_INFO(MOD_NAME "Total CCIX Home Agent nodes: %d", cxg_ha_reg_count);

--- a/module/mhu2/src/mod_mhu2.c
+++ b/module/mhu2/src/mod_mhu2.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -170,7 +170,7 @@ static int mhu2_send_message(
     if (channel_count < (min_channels_required + channels_used_for_payload)) {
         FWK_LOG_INFO(
             "[MHUv2] ERROR! Message length exceeds the number of MHUv2"
-            "channels available\n");
+            "channels available");
         return FWK_E_SUPPORT;
     }
 

--- a/module/mock_ppu/src/mod_mock_ppu.c
+++ b/module/mock_ppu/src/mod_mock_ppu.c
@@ -71,7 +71,7 @@ static int pd_set_state(fwk_id_t pd_id, unsigned int state)
         break;
 
     default:
-        FWK_LOG_ERR("[PD] Requested power state (%i) is not supported.\n", state);
+        FWK_LOG_ERR("[PD] Requested power state (%i) is not supported.", state);
         return FWK_E_PARAM;
     }
 

--- a/module/msg_smt/src/mod_msg_smt.c
+++ b/module/msg_smt/src/mod_msg_smt.c
@@ -1,6 +1,7 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Linaro Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Linaro Limited and Contributors. All rights
+ * reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -284,7 +285,7 @@ int msg_signal_message(fwk_id_t channel_id, void *msg_in, size_t in_len, void *m
 
     if (!channel_ctx->msg_smt_mailbox_ready) {
         /* Discard any message in the mailbox when not ready */
-        FWK_LOG_ERR("[MSG_SMT] Message not valid\n");
+        FWK_LOG_ERR("[MSG_SMT] Message not valid");
 
         return FWK_SUCCESS;
     }

--- a/module/optee/smt/src/mod_optee_smt.c
+++ b/module/optee/smt/src/mod_optee_smt.c
@@ -1,6 +1,7 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Linaro Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Linaro Limited and Contributors. All rights
+ * reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -339,7 +340,7 @@ static int smt_signal_message(fwk_id_t channel_id)
 
     if (!channel_ctx->optee_smt_mailbox_ready) {
         /* Discard any message in the mailbox when not ready */
-        FWK_LOG_ERR("[OPTEE_SMT] Message not valid\n");
+        FWK_LOG_ERR("[OPTEE_SMT] Message not valid");
 
         return FWK_SUCCESS;
     }

--- a/module/resource_perms/src/mod_resource_perms.c
+++ b/module/resource_perms/src/mod_resource_perms.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -1206,7 +1206,7 @@ static int mod_res_agent_set_permissions(
 
     if (status != FWK_SUCCESS) {
         FWK_LOG_WARN(
-            "[perms] set_permissions for agent %d type %d device %d failed\n",
+            "[perms] set_permissions for agent %d type %d device %d failed",
             (int)agent_id,
             (int)type,
             (int)resource_id);
@@ -1266,7 +1266,7 @@ static int mod_res_agent_set_device_permission(
 
         if (status != FWK_SUCCESS) {
             FWK_LOG_WARN(
-                "[perms] set_permissions for agent %d device %d failed\n",
+                "[perms] set_permissions for agent %d device %d failed",
                 (int)agent_id,
                 (int)i);
         }
@@ -1364,7 +1364,7 @@ static int mod_res_agent_set_device_protocol_permission(
 
         if (status != FWK_SUCCESS) {
             FWK_LOG_WARN(
-                "[perms] set_permissions for agent %d device %d failed\n",
+                "[perms] set_permissions for agent %d device %d failed",
                 (int)agent_id,
                 (int)i);
         }

--- a/module/scmi_clock/src/mod_scmi_clock.c
+++ b/module/scmi_clock/src/mod_scmi_clock.c
@@ -317,7 +317,7 @@ static enum mod_scmi_clock_policy_status scmi_clock_ref_count_table_check(
             /* Error trying to stop a stopped clock */
             FWK_LOG_WARN(
                 "[SCMI-CLK] Invalid STOP request agent:"
-                " %d scmi_clock_id: %d state:%d\n",
+                " %d scmi_clock_id: %d state:%d",
                 (int)agent_id,
                 (int)scmi_clock_idx,
                 (int)requested_state);

--- a/module/statistics/src/mod_stats.c
+++ b/module/statistics/src/mod_stats.c
@@ -116,7 +116,7 @@ static int allocate_domain_stats(fwk_id_t module_id,
 
     if (stats_size > (stats_ctx.config->stats_region_size -
         stats_ctx.avail_mem_offset)) {
-        FWK_LOG_ERR("[STATS]: Error, size of statistics region too small\n");
+        FWK_LOG_ERR("[STATS]: Error, size of statistics region too small");
         stats->mode = STATS_INTERNAL_ERROR;
         return FWK_E_NOMEM;
     }
@@ -141,7 +141,7 @@ static int allocate_domain_stats(fwk_id_t module_id,
     stats->used_mem_size += stats_size;
 
     FWK_LOG_DEBUG(
-        "[STATS]: stats addr %lx, stats_size=%luB\n",
+        "[STATS]: stats addr %lx, stats_size=%luB",
         (uint32_t)scp_stats_addr,
         stats_size);
 
@@ -155,7 +155,7 @@ static int _allocate_header(struct mod_stats_info *stats, int domain_count)
 
     if (stats->desc_header_size > (stats_ctx.config->stats_region_size -
         stats_ctx.avail_mem_offset)) {
-        FWK_LOG_ERR("[STATS]: Error, size of statistics region too small\n");
+        FWK_LOG_ERR("[STATS]: Error, size of statistics region too small");
         stats->mode = STATS_INTERNAL_ERROR;
         return FWK_E_NOMEM;
     }
@@ -221,8 +221,10 @@ static int stats_init_module(fwk_id_t module_id,
     struct mod_stats_info *stats;
     int ret;
 
-    FWK_LOG_INFO("[STATS]: init module, total_domains=%d used=%d\n",
-                 domain_count, used_domains);
+    FWK_LOG_INFO(
+        "[STATS]: init module, total_domains=%d used=%d",
+        domain_count,
+        used_domains);
 
     stats = _allocate_stats_context(domain_count, used_domains);
     ret = set_module_stats_info(module_id, stats);
@@ -499,7 +501,7 @@ static int stats_init(fwk_id_t module_id, unsigned int element_count,
     const struct mod_stats_config_info *config = data;
 
     if (config == NULL || config->stats_region_size == 0) {
-        FWK_LOG_INFO("STATS: statistics are not configured\n");
+        FWK_LOG_INFO("STATS: statistics are not configured");
         return FWK_E_SUPPORT;
     }
 
@@ -543,7 +545,7 @@ static int stats_start(fwk_id_t id)
             return status;
         }
     } else {
-        FWK_LOG_ERR("[STATS]: failed to start period updates\n");
+        FWK_LOG_ERR("[STATS]: failed to start period updates");
         return FWK_E_SUPPORT;
     }
 

--- a/module/thermal_mgmt/src/mod_thermal_mgmt.c
+++ b/module/thermal_mgmt/src/mod_thermal_mgmt.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -90,7 +90,7 @@ static void thermal_protection(struct mod_thermal_mgmt_dev_ctx *dev_ctx)
     if (dev_ctx->cur_temp >=
         dev_ctx->config->temp_protection->crit_temp_threshold) {
         FWK_LOG_CRIT(
-            "[THERMAL][%s] temp (%u) reached critical threshold!\n",
+            "[THERMAL][%s] temp (%u) reached critical threshold!",
             fwk_module_get_element_name(dev_ctx->id),
             (unsigned int)dev_ctx->cur_temp);
 
@@ -102,7 +102,7 @@ static void thermal_protection(struct mod_thermal_mgmt_dev_ctx *dev_ctx)
         dev_ctx->cur_temp >=
         dev_ctx->config->temp_protection->warn_temp_threshold) {
         FWK_LOG_WARN(
-            "[THERMAL][%s] temp (%u) reached warning threshold!\n",
+            "[THERMAL][%s] temp (%u) reached warning threshold!",
             fwk_module_get_element_name(dev_ctx->id),
             (unsigned int)dev_ctx->cur_temp);
 
@@ -155,7 +155,7 @@ static int control_update(fwk_id_t id)
 
         if (dev_ctx->control_needs_update) {
             /* The last reading was not processed */
-            FWK_LOG_WARN("[TPM] Failed to process last reading\n");
+            FWK_LOG_WARN("[TPM] Failed to process last reading");
 
             return FWK_E_PANIC;
         }

--- a/module/transport/src/mod_transport.c
+++ b/module/transport/src/mod_transport.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -256,7 +256,7 @@ static int transport_respond(
             fwk_str_memcpy(buffer->payload, payload, size);
         }
 #else
-        FWK_LOG_ERR("%s ERROR. IN-BAND MESSAGE NOT SUPPORTED!\n", MOD_NAME);
+        FWK_LOG_ERR("%s ERROR. IN-BAND MESSAGE NOT SUPPORTED!", MOD_NAME);
         return FWK_E_SUPPORT;
 #endif
     }
@@ -340,7 +340,7 @@ static int transport_transmit(
         buffer->reserved0 = 0;
         buffer->reserved1 = 0;
 #else
-        FWK_LOG_ERR("%s ERROR. IN-BAND MESSAGES NOT SUPPORTED!\n", MOD_NAME);
+        FWK_LOG_ERR("%s ERROR. IN-BAND MESSAGES NOT SUPPORTED!", MOD_NAME);
         return FWK_E_SUPPORT;
 #endif
     }
@@ -593,7 +593,7 @@ static int transport_message_handler(struct transport_channel_ctx *channel_ctx)
                     channel_ctx->service_id);
 #else
             FWK_LOG_INFO(
-                "%s Error! SCMI module not included in the build\n", MOD_NAME);
+                "%s Error! SCMI module not included in the build", MOD_NAME);
             return FWK_E_SUPPORT;
 #endif
         } else {
@@ -622,7 +622,7 @@ static int transport_message_handler(struct transport_channel_ctx *channel_ctx)
             channel_ctx->service_id);
 #else
         FWK_LOG_INFO(
-            "%s Error! SCMI module not included in the build\n", MOD_NAME);
+            "%s Error! SCMI module not included in the build", MOD_NAME);
         return FWK_E_SUPPORT;
 #endif
     } else {

--- a/product/juno/src/juno_scmi_clock.c
+++ b/product/juno/src/juno_scmi_clock.c
@@ -26,8 +26,7 @@ int mod_scmi_clock_rate_set_policy(
 {
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
     FWK_LOG_DEBUG(
-        "[SCMI-CLK] Set Clock Rate Policy Handler agent: %u clock: %" PRIu32
-        "\n",
+        "[SCMI-CLK] Set Clock Rate Policy Handler agent: %u clock: %" PRIu32,
         fwk_id_get_element_idx(service_id),
         clock_dev_id);
 #endif

--- a/product/morello/module/morello_rom/src/mod_morello_rom.c
+++ b/product/morello/module/morello_rom/src/mod_morello_rom.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -145,7 +145,7 @@ static int morello_rom_process_event(
         fip_size = morello_rom_ctx.rom_config->fip_nvm_size;
     }
 
-    FWK_LOG_INFO("[ROM] Trying to identify FIP at 0x%X\n", fip_base);
+    FWK_LOG_INFO("[ROM] Trying to identify FIP at 0x%X", fip_base);
 
     status = morello_rom_ctx.fip_api->get_entry(
         morello_rom_ctx.rom_config->image_type, &entry, fip_base, fip_size);
@@ -155,24 +155,24 @@ static int morello_rom_process_event(
 
     if (status != FWK_SUCCESS) {
         FWK_LOG_INFO(
-            "[ROM] Failed to locate %s_BL2, error: %d\n", image_type, status);
+            "[ROM] Failed to locate %s_BL2, error: %d", image_type, status);
         return status;
     }
 
-    FWK_LOG_INFO("[ROM] Located %s_BL2:\n", image_type);
-    FWK_LOG_INFO("[ROM]   address: %p\n", entry.base);
-    FWK_LOG_INFO("[ROM]   size   : %u\n", entry.size);
+    FWK_LOG_INFO("[ROM] Located %s_BL2:", image_type);
+    FWK_LOG_INFO("[ROM]   address: %p", entry.base);
+    FWK_LOG_INFO("[ROM]   size   : %u", entry.size);
     FWK_LOG_INFO(
-        "[ROM]   flags  : 0x%08" PRIX32 "%08" PRIX32 "\n",
+        "[ROM]   flags  : 0x%08" PRIX32 "%08" PRIX32,
         (uint32_t)(entry.flags >> 32),
         (uint32_t)entry.flags);
-    FWK_LOG_INFO("[ROM] Copying %s_BL2 to ITCRAM...!\n", image_type);
+    FWK_LOG_INFO("[ROM] Copying %s_BL2 to ITCRAM...!", image_type);
 
     memcpy(
         (void *)morello_rom_ctx.rom_config->ramfw_base, entry.base, entry.size);
     FWK_LOG_INFO("[ROM] Done!");
 
-    FWK_LOG_INFO("[ROM] Jumping to %s_BL2\n", image_type);
+    FWK_LOG_INFO("[ROM] Jumping to %s_BL2", image_type);
     jump_to_ramfw();
 
     return FWK_SUCCESS;

--- a/product/morello/module/morello_sensor/src/mod_morello_sensor.c
+++ b/product/morello/module/morello_sensor/src/mod_morello_sensor.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -55,12 +55,12 @@ static void morello_sensor_timer_callback(uintptr_t unused)
             if (value >= t_dev_ctx->config->alarm_threshold &&
                 value < t_dev_ctx->config->shutdown_threshold) {
                 FWK_LOG_CRIT(
-                    "%s temperature (%d) reached alarm threshold!\n",
+                    "%s temperature (%d) reached alarm threshold!",
                     sensor_type_name[count],
                     (int)value);
             } else if (value >= t_dev_ctx->config->shutdown_threshold) {
                 FWK_LOG_CRIT(
-                    "%s temperature (%d) reached shutdown threshold!\n",
+                    "%s temperature (%d) reached shutdown threshold!",
                     sensor_type_name[count],
                     (int)value);
 
@@ -260,16 +260,16 @@ static int morello_sensor_start(fwk_id_t id)
 
         switch (status) {
         case FWK_E_DEVICE:
-            FWK_LOG_ERR("[PVT] ID invalid: 0x%08X\n", (unsigned int)error_reg);
+            FWK_LOG_ERR("[PVT] ID invalid: 0x%08X", (unsigned int)error_reg);
             exit_status = FWK_E_DEVICE;
             break;
         case FWK_E_DATA:
             FWK_LOG_ERR(
-                "[PVT] Scratch test failed: 0x%08X\n", (unsigned int)error_reg);
+                "[PVT] Scratch test failed: 0x%08X", (unsigned int)error_reg);
             exit_status = FWK_E_DEVICE;
             break;
         case FWK_E_TIMEOUT:
-            FWK_LOG_ERR("[PVT] Timeout waiting for sensor initialization!\n");
+            FWK_LOG_ERR("[PVT] Timeout waiting for sensor initialization!");
             exit_status = FWK_E_TIMEOUT;
             break;
         default:
@@ -295,7 +295,7 @@ static int morello_sensor_start(fwk_id_t id)
         }
 
         FWK_LOG_INFO(
-            "[PVT] Started driver version %d.%d\n",
+            "[PVT] Started driver version %d.%d",
             MORELLO_SENSOR_VERSION_MAJOR,
             MORELLO_SENSOR_VERSION_MINOR);
     }

--- a/product/n1sdp/module/n1sdp_rom/src/mod_n1sdp_rom.c
+++ b/product/n1sdp/module/n1sdp_rom/src/mod_n1sdp_rom.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -135,7 +135,7 @@ static int n1sdp_rom_process_event(const struct fwk_event *event,
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_INFO
     if (status != FWK_SUCCESS) {
         FWK_LOG_INFO(
-            "[ROM] Failed to locate %s_BL2, error: %d\n", image_type, status);
+            "[ROM] Failed to locate %s_BL2, error: %d", image_type, status);
         return status;
     }
 #else
@@ -143,18 +143,20 @@ static int n1sdp_rom_process_event(const struct fwk_event *event,
     (void)image_type;
 #endif
 
-    FWK_LOG_INFO("[ROM] Located %s_BL2:\n", image_type);
-    FWK_LOG_INFO("[ROM]   address: %p\n", entry.base);
-    FWK_LOG_INFO("[ROM]   size   : %u\n", entry.size);
-    FWK_LOG_INFO("[ROM]   flags  : 0x%08" PRIX32 "%08" PRIX32"\n",
-        (uint32_t)(entry.flags >> 32),  (uint32_t)entry.flags);
-    FWK_LOG_INFO("[ROM] Copying %s_BL2 to ITCRAM...!\n", image_type);
+    FWK_LOG_INFO("[ROM] Located %s_BL2:", image_type);
+    FWK_LOG_INFO("[ROM]   address: %p", entry.base);
+    FWK_LOG_INFO("[ROM]   size   : %u", entry.size);
+    FWK_LOG_INFO(
+        "[ROM]   flags  : 0x%08" PRIX32 "%08" PRIX32 "",
+        (uint32_t)(entry.flags >> 32),
+        (uint32_t)entry.flags);
+    FWK_LOG_INFO("[ROM] Copying %s_BL2 to ITCRAM...!", image_type);
 
     memcpy(
         (void *)n1sdp_rom_ctx.rom_config->ramfw_base, entry.base, entry.size);
     FWK_LOG_INFO("[ROM] Done!");
 
-    FWK_LOG_INFO("[ROM] Jumping to %s_BL2\n", image_type);
+    FWK_LOG_INFO("[ROM] Jumping to %s_BL2", image_type);
 
     jump_to_ramfw();
     return FWK_SUCCESS;

--- a/product/n1sdp/module/n1sdp_sensor/src/mod_n1sdp_sensor.c
+++ b/product/n1sdp/module/n1sdp_sensor/src/mod_n1sdp_sensor.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -43,12 +43,12 @@ static void n1sdp_sensor_timer_callback(uintptr_t unused)
             if (value >= t_dev_ctx->config->alarm_threshold &&
                 value < t_dev_ctx->config->shutdown_threshold) {
                 FWK_LOG_CRIT(
-                    "%s temperature (%d) reached alarm threshold!\n",
+                    "%s temperature (%d) reached alarm threshold!",
                     sensor_type_name[count],
                     (int)value);
             } else if (value >= t_dev_ctx->config->shutdown_threshold) {
                 FWK_LOG_CRIT(
-                    "%s temperature (%d) reached shutdown threshold!\n",
+                    "%s temperature (%d) reached shutdown threshold!",
                     sensor_type_name[count],
                     (int)value);
 
@@ -295,14 +295,14 @@ static int n1sdp_sensor_start(fwk_id_t id)
         status = n1sdp_sensor_lib_init(&error_reg);
         switch (status) {
         case FWK_E_DEVICE:
-            FWK_LOG_INFO("[PVT] ID invalid: 0x%08X\n", (unsigned int)error_reg);
+            FWK_LOG_INFO("[PVT] ID invalid: 0x%08X", (unsigned int)error_reg);
             return FWK_E_DEVICE;
         case FWK_E_DATA:
             FWK_LOG_INFO(
-                "[PVT] Scratch test failed: 0x%08X\n", (unsigned int)error_reg);
+                "[PVT] Scratch test failed: 0x%08X", (unsigned int)error_reg);
             return FWK_E_DEVICE;
         case FWK_E_TIMEOUT:
-            FWK_LOG_INFO("[PVT] Timeout waiting for sensor initialization!\n");
+            FWK_LOG_INFO("[PVT] Timeout waiting for sensor initialization!");
             return FWK_E_TIMEOUT;
         }
 
@@ -318,7 +318,7 @@ static int n1sdp_sensor_start(fwk_id_t id)
         }
 
         FWK_LOG_INFO(
-            "[PVT] Started driver version %d.%d\n",
+            "[PVT] Started driver version %d.%d",
             N1SDP_SENSOR_VERSION_MAJOR,
             N1SDP_SENSOR_VERSION_MINOR);
     }

--- a/product/n1sdp/module/n1sdp_system/src/mod_n1sdp_system.c
+++ b/product/n1sdp/module/n1sdp_system/src/mod_n1sdp_system.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -392,18 +392,19 @@ static int n1sdp_system_init_primary_core(void)
             SCP_QSPI_FLASH_SIZE);
         if (status != FWK_SUCCESS) {
             FWK_LOG_INFO(
-                "[N1SDP SYSTEM] Failed to locate AP TF_BL1, error: %d\n",
-                status);
+                "[N1SDP SYSTEM] Failed to locate AP TF_BL1, error: %d", status);
             return FWK_E_PANIC;
         }
 
-        FWK_LOG_INFO("[N1SDP SYSTEM] Located AP TF_BL1:\n");
-        FWK_LOG_INFO("[N1SDP SYSTEM]   address: %p\n", entry.base);
-        FWK_LOG_INFO("[N1SDP SYSTEM]   size   : %u\n", entry.size);
-        FWK_LOG_INFO("[N1SDP SYSTEM]   flags  : 0x%08" PRIX32 "%08" PRIX32"\n",
-            (uint32_t)(entry.flags >> 32),  (uint32_t)entry.flags);
+        FWK_LOG_INFO("[N1SDP SYSTEM] Located AP TF_BL1:");
+        FWK_LOG_INFO("[N1SDP SYSTEM]   address: %p", entry.base);
+        FWK_LOG_INFO("[N1SDP SYSTEM]   size   : %u", entry.size);
         FWK_LOG_INFO(
-            "[N1SDP SYSTEM] Copying AP TF_BL1 to address 0x%" PRIx32 "...\n",
+            "[N1SDP SYSTEM]   flags  : 0x%08" PRIX32 "%08" PRIX32 "",
+            (uint32_t)(entry.flags >> 32),
+            (uint32_t)entry.flags);
+        FWK_LOG_INFO(
+            "[N1SDP SYSTEM] Copying AP TF_BL1 to address 0x%" PRIx32 "...",
             AP_CORE_RESET_ADDR);
 
         status = n1sdp_system_copy_to_ap_sram(

--- a/product/rdfremont/module/mod_lcp_platform/src/mod_lcp_platform.c
+++ b/product/rdfremont/module/mod_lcp_platform/src/mod_lcp_platform.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -55,7 +55,7 @@ static int mod_lcp_platform_start(fwk_id_t id)
 
     mod_lcp_config_timer();
 
-    FWK_LOG_INFO(MOD_NAME "LCP RAM firmware initialized\n");
+    FWK_LOG_INFO(MOD_NAME "LCP RAM firmware initialized");
 
     return FWK_SUCCESS;
 }

--- a/product/rdn1e1/module/mcp_platform/src/mod_mcp_platform.c
+++ b/product/rdn1e1/module/mcp_platform/src/mod_mcp_platform.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -28,7 +28,7 @@ static int mod_mcp_platform_init(
 
 static int mod_mcp_platform_start(fwk_id_t id)
 {
-    FWK_LOG_INFO(MOD_NAME "MCP RAM firmware initialized\n");
+    FWK_LOG_INFO(MOD_NAME "MCP RAM firmware initialized");
     return FWK_SUCCESS;
 }
 

--- a/product/rdn2/module/mcp_platform/src/mod_mcp_platform.c
+++ b/product/rdn2/module/mcp_platform/src/mod_mcp_platform.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -27,7 +27,7 @@ static int mod_mcp_platform_init(
 
 static int mod_mcp_platform_start(fwk_id_t id)
 {
-    FWK_LOG_INFO("MCP RAM firmware initialized\n");
+    FWK_LOG_INFO("MCP RAM firmware initialized");
     return FWK_SUCCESS;
 }
 

--- a/product/rdn2/module/platform_system/src/mod_platform_system.c
+++ b/product/rdn2/module/platform_system/src/mod_platform_system.c
@@ -510,7 +510,7 @@ static int platform_system_start(fwk_id_t id)
     if (status != FWK_SUCCESS) {
         FWK_LOG_WARN(
             "[PLATFORM SYSTEM] failed to subscribe to warm reset "
-            "notification\n");
+            "notification");
     }
 
     /*
@@ -562,7 +562,7 @@ static void power_off_all_cores(void)
 
     for (pd_idx = 0; pd_idx < core_count; pd_idx++) {
         FWK_LOG_INFO(
-            "[PLATFORM SYSTEM] Powering down %s\n",
+            "[PLATFORM SYSTEM] Powering down %s",
             fwk_module_get_element_name(
                 FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, pd_idx)));
 
@@ -573,7 +573,7 @@ static void power_off_all_cores(void)
 
         if (status != FWK_SUCCESS) {
             FWK_LOG_ERR(
-                "[PLATFORM SYSTEM] Power down of %s failed\n",
+                "[PLATFORM SYSTEM] Power down of %s failed",
                 fwk_module_get_element_name(
                     FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, pd_idx)));
         }
@@ -598,7 +598,7 @@ static int check_power_off_all_cores(void)
             FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, pd_idx), &power_state);
         if (status != FWK_SUCCESS) {
             FWK_LOG_ERR(
-                "[PLATFORM_SYSTEM] failed to get state of %s\n",
+                "[PLATFORM_SYSTEM] failed to get state of %s",
                 fwk_module_get_element_name(
                     FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, pd_idx)));
             return status;
@@ -609,7 +609,7 @@ static int check_power_off_all_cores(void)
              (MOD_PD_CS_STATE_MASK << MOD_PD_CS_LEVEL_0_STATE_SHIFT)) !=
             MOD_PD_STATE_OFF) {
             FWK_LOG_INFO(
-                "[PLATFORM_SYSTEM] %s not yet powered down\n",
+                "[PLATFORM_SYSTEM] %s not yet powered down",
                 fwk_module_get_element_name(
                     FWK_ID_ELEMENT(FWK_MODULE_IDX_POWER_DOMAIN, pd_idx)));
             return FWK_PENDING;
@@ -629,7 +629,7 @@ static void boot_primary_core(void)
     if (status != FWK_SUCCESS) {
         FWK_LOG_WARN(
             "[PLATFORM_SYSTEM] Failed to update SDS feature "
-            "availability\n");
+            "availability");
     }
     fwk_assert(status == FWK_SUCCESS);
 
@@ -637,13 +637,13 @@ static void boot_primary_core(void)
     if (status != FWK_SUCCESS) {
         FWK_LOG_WARN(
             "[PLATFORM_SYSTEM] Failed to update SDS reset "
-            "syndrome\n");
+            "syndrome");
     }
     fwk_assert(status == FWK_SUCCESS);
 
     FWK_LOG_INFO(
         "[PLATFORM SYSTEM] Warm reset complete. Powering up "
-        "boot cpu...\n");
+        "boot cpu...");
 
     /*
      * All cores were powered down. Now power up the primary core to
@@ -667,7 +667,7 @@ static void boot_primary_core(void)
     if (status != FWK_SUCCESS) {
         FWK_LOG_ERR(
             "[PLATFORM_SYSTEM] Failed to power up boot cpu,"
-            " issuing cold reset to recover\n");
+            " issuing cold reset to recover");
         /*
          * The power up request of boot cpu power domain has failed.
          * The warm reset cannot be completed and the system is now in
@@ -706,7 +706,7 @@ static int platform_system_process_event(
                 WARM_RESET_MAX_RETRIES) {
                 FWK_LOG_ERR(
                     "[PLATFORM_SYSTEM] warm reset retries reached "
-                    "maximum attempts and failed!\n");
+                    "maximum attempts and failed!");
                 fwk_assert(
                     platform_system_ctx.warm_reset_check_cnt <
                     WARM_RESET_MAX_RETRIES);
@@ -719,8 +719,7 @@ static int platform_system_process_event(
             status = fwk_put_event(&check_pd_off_event);
             if (status != FWK_SUCCESS) {
                 FWK_LOG_ERR(
-                    "[PLATFORM_SYSTEM] Failed to send event, returned "
-                    "%d\n",
+                    "[PLATFORM_SYSTEM] Failed to send event, returned %d",
                     status);
             }
             fwk_assert(status == FWK_SUCCESS);
@@ -736,7 +735,7 @@ static int platform_system_process_event(
         break; /* MOD_PLATFORM_SYSTEM_CHECK_PD_OFF */
     default:
         FWK_LOG_WARN(
-            "[PLATFORM_SYSTEM] unrecognized event received, event ignored\n");
+            "[PLATFORM_SYSTEM] unrecognized event received, event ignored");
         status = FWK_E_PARAM;
     }
 
@@ -824,9 +823,9 @@ int platform_system_process_notification(
         if (status != FWK_SUCCESS) {
             FWK_LOG_ERR(
                 "[PLATFORM_SYSTEM] Failed to send PD power off check "
-                "event, returned %d\n",
+                "event, returned %d",
                 status);
-            FWK_LOG_ERR("[PLATFORM_SYSTEM] Issuing cold reboot to recover.\n");
+            FWK_LOG_ERR("[PLATFORM_SYSTEM] Issuing cold reboot to recover.");
             status = mod_pd_restricted_api->system_shutdown(
                 MOD_PD_SYSTEM_COLD_RESET);
             fwk_assert(status == FWK_SUCCESS);

--- a/product/rdv1/module/mcp_platform/src/mod_mcp_platform.c
+++ b/product/rdv1/module/mcp_platform/src/mod_mcp_platform.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -28,7 +28,7 @@ static int mod_mcp_platform_init(
 
 static int mod_mcp_platform_start(fwk_id_t id)
 {
-    FWK_LOG_INFO(MOD_NAME "MCP RAM firmware initialized\n");
+    FWK_LOG_INFO(MOD_NAME "MCP RAM firmware initialized");
     return FWK_SUCCESS;
 }
 

--- a/product/rdv1mc/module/mcp_platform/src/mod_mcp_platform.c
+++ b/product/rdv1mc/module/mcp_platform/src/mod_mcp_platform.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -27,7 +27,7 @@ static int mod_mcp_platform_init(
 
 static int mod_mcp_platform_start(fwk_id_t id)
 {
-    FWK_LOG_INFO(MOD_NAME "MCP RAM firmware initialized\n");
+    FWK_LOG_INFO(MOD_NAME "MCP RAM firmware initialized");
     return FWK_SUCCESS;
 }
 

--- a/product/rdv1mc/module/platform_system/src/mod_platform_system.c
+++ b/product/rdv1mc/module/platform_system/src/mod_platform_system.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -330,8 +330,7 @@ int platform_system_process_notification(
          * time only
          */
         if (params->new_state == MOD_CLOCK_STATE_RUNNING && chip_id == 0) {
-            FWK_LOG_INFO(
-                "[PLATFORM SYSTEM] Initializing the primary core...\n");
+            FWK_LOG_INFO("[PLATFORM SYSTEM] Initializing the primary core...");
 
             mod_pd_restricted_api = platform_system_ctx.mod_pd_restricted_api;
 
@@ -353,7 +352,7 @@ int platform_system_process_notification(
         } else {
             FWK_LOG_INFO(
                 "[PLATFORM SYSTEM] Detected as secondary chip: %d, "
-                "wait for SCMI\n",
+                "wait for SCMI",
                 chip_id);
         }
 

--- a/product/sgi575/module/mcp_platform/src/mod_mcp_platform.c
+++ b/product/sgi575/module/mcp_platform/src/mod_mcp_platform.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -28,7 +28,7 @@ static int mod_mcp_platform_init(
 
 static int mod_mcp_platform_start(fwk_id_t id)
 {
-    FWK_LOG_INFO(MOD_NAME "MCP RAM firmware initialized\n");
+    FWK_LOG_INFO(MOD_NAME "MCP RAM firmware initialized");
     return FWK_SUCCESS;
 }
 

--- a/product/synquacer/module/synquacer_memc/src/synquacer_ddr.c
+++ b/product/synquacer/module/synquacer_memc/src/synquacer_ddr.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -826,7 +826,8 @@ static void dram_init_for_ecc(void)
 
     dram_size = (uint64_t)config_ddr4_sdram_total_size * 1024 * 1024;
 
-    FWK_LOG_INFO("[DDR] Initializing DRAM for ECC\nNow Initializing[");
+    FWK_LOG_INFO("[DDR] Initializing DRAM for ECC");
+    FWK_LOG_INFO("Now Initializing[");
 
     dma330_wrapper_init();
 

--- a/product/synquacer/module/synquacer_system/src/mod_synquacer_system.c
+++ b/product/synquacer/module/synquacer_system/src/mod_synquacer_system.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -123,7 +123,7 @@ static int synquacer_system_bind(fwk_id_t id, unsigned int round)
         }
     }
 
-    FWK_LOG_INFO("[SYNQUACER SYSTEM] bind success\n");
+    FWK_LOG_INFO("[SYNQUACER SYSTEM] bind success");
 
     return FWK_SUCCESS;
 }

--- a/product/synquacer/module/synquacer_system/src/synquacer_main.c
+++ b/product/synquacer/module/synquacer_system/src/synquacer_main.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -403,7 +403,7 @@ static void update_platform_metadata(struct fwu_synquacer_metadata *platdata)
                                        CONFIG_SCB_PLAT_METADATA_OFFS,
                                        &buf, sizeof(buf));
     if (memcmp(platdata, &buf, sizeof(buf))) {
-        FWK_LOG_ERR("[FWU] Failed to update boot-index!\n");
+        FWK_LOG_ERR("[FWU] Failed to update boot-index!");
     }
 }
 
@@ -427,13 +427,15 @@ static uint32_t fwu_plat_get_boot_index(void)
     if (metadata.version != 1 ||
         metadata.active_index > CONFIG_FWU_NUM_BANKS) {
             platdata.boot_index = 0;
-            FWK_LOG_ERR("[FWU] FWU metadata is broken. Use default boot indx 0\n");
+            FWK_LOG_ERR(
+                "[FWU] FWU metadata is broken. Use default boot indx 0");
     } else if (metadata.active_index != platdata.boot_index) {
         /* Switch to new active bank as a trial. */
         platdata.boot_index = metadata.active_index;
         platdata.boot_count = 1;
-        FWK_LOG_INFO("[FWU] New firmware will boot. New index is %d\n",
-        (int)platdata.boot_index);
+        FWK_LOG_INFO(
+            "[FWU] New firmware will boot. New index is %d",
+            (int)platdata.boot_index);
     } else if (platdata.boot_count) {
         /* BL33 will clear the boot_count when boot. */
         if (platdata.boot_count < CONFIG_FWU_MAX_COUNT) {
@@ -441,8 +443,9 @@ static uint32_t fwu_plat_get_boot_index(void)
     } else {
             platdata.boot_index = metadata.previous_active_index;
             platdata.boot_count = 0;
-            FWK_LOG_ERR("[FWU] New firmware boot trial failed. Rollback index is %d\n",
-                        (int)platdata.boot_index);
+            FWK_LOG_ERR(
+                "[FWU] New firmware boot trial failed. Rollback index is %d",
+                (int)platdata.boot_index);
         }
     }
 

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -34,8 +34,8 @@ nullPointerRedundantCheck:*product/juno/*
 syntaxError:*product/synquacer/module/synquacer_system/src/mmu500.c:34
 
 // Cppcheck seems to get confused with macro substitution
-syntaxError:*framework/src/fwk_log.c:190
-syntaxError:*framework/src/fwk_log.c:194
+syntaxError:*framework/src/fwk_log.c:175
+syntaxError:*framework/src/fwk_log.c:179
 
 // Cppcheck doesn't like include directives that use macros
 preprocessorErrorDirective:*framework/test/fwk_module_idx.h:14


### PR DESCRIPTION
Currently, newline characters are optionally added to log messages even though `fwk_log` appends its own `FWK_LOG_TERMINATOR` string. This change removes the redundant newlines, improving the efficiency of log output and simplifying the logging code by eliminating the need for newline search functions.


Change-Id: Ifc46ffe3e2e8d7da5fa7a095c7122706806fe8e1