### PR TITLE
ci_cmake: Warn users when script runs w/o docker support

### DIFF
--- a/tools/ci_cmake.py
+++ b/tools/ci_cmake.py
@@ -171,6 +171,7 @@ def main(ignore_errors: bool, skip_container: bool, log_level: str,
                 return 1
 
         except DockerException:
+            banner("Script running out of docker")
             pass
     else:
         banner("Skipping spawning container")


### PR DESCRIPTION
While running ci_cmake.py in case the host machine does not support docker inform the user.


Change-Id: I7ddd14b4074ca6d93c75f614e5fc474fe9c0494a