### PR TITLE
Add "disabled" log level

### DIFF
--- a/Makefile.cmake
+++ b/Makefile.cmake
@@ -249,7 +249,7 @@ help:
 	@echo "        Include the debugger library."
 	@echo ""
 	@echo "    LOG_LEVEL"
-	@echo "        Value: <DEBUG|INFO|WARN|ERROR|CRIT>"
+	@echo "        Value: <DEBUG|INFO|WARN|ERROR|CRIT|DISABLED>"
 	@echo "        Default: $(LOG_LEVEL)"
 	@echo "        Filter log messages less important than this level."
 	@echo ""

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -120,7 +120,7 @@ if(NOT DEFINED SCP_LOG_LEVEL)
         CACHE STRING "Minimum logging level.")
 
     set_property(CACHE SCP_LOG_LEVEL PROPERTY STRINGS "DEBUG" "INFO" "WARN"
-                                                      "ERROR" "CRIT")
+                                                      "ERROR" "CRIT" "DISABLED")
 endif()
 
 target_compile_definitions(framework

--- a/framework/include/fwk_log.h
+++ b/framework/include/fwk_log.h
@@ -183,6 +183,14 @@
  * \brief *Critical* log level.
  *
  * \details Messages assigned this filter level represent fatal errors.
+ *
+ * \def FWK_LOG_LEVEL_DISABLED
+ *
+ * \brief *Disabled* log level.
+ *
+ * \details If a build sets log level to FWK_LOG_LEVEL_DISABLED,
+ *      all logs are disabled.
+ *
  */
 
 #define FWK_LOG_LEVEL_DEBUG 0
@@ -190,6 +198,7 @@
 #define FWK_LOG_LEVEL_WARN 2
 #define FWK_LOG_LEVEL_ERROR 3
 #define FWK_LOG_LEVEL_CRIT 4
+#define FWK_LOG_LEVEL_DISABLED 5
 
 /*!
  * \}

--- a/framework/src/fwk_core.c
+++ b/framework/src/fwk_core.c
@@ -31,8 +31,10 @@
 
 static struct __fwk_ctx ctx;
 
+#if (FWK_LOG_LEVEL < FWK_LOG_LEVEL_DISABLED)
 static const char err_msg_line[] = "[FWK] Error %d in %s @%d";
 static const char err_msg_func[] = "[FWK] Error %d in %s";
+#endif
 
 enum interrupt_states {
     UNKNOWN_STATE = 0,

--- a/framework/src/fwk_delayed_resp.c
+++ b/framework/src/fwk_delayed_resp.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2019-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -19,7 +19,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if (FWK_LOG_LEVEL < FWK_LOG_LEVEL_DISABLED)
 static const char err_msg_func[] = "[FWK] Error %d in %s";
+#endif
 
 /*
  * Static functions

--- a/framework/src/fwk_module.c
+++ b/framework/src/fwk_module.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -61,8 +61,10 @@ extern const struct fwk_module *module_table[FWK_MODULE_IDX_COUNT];
 extern const struct fwk_module_config
     *module_config_table[FWK_MODULE_IDX_COUNT];
 
+#if (FWK_LOG_LEVEL < FWK_LOG_LEVEL_DISABLED)
 static const char fwk_module_err_msg_line[] = "[MOD] Error %d in %s @%d";
 static const char fwk_module_err_msg_func[] = "[MOD] Error %d in %s";
+#endif
 
 static size_t fwk_module_count_elements(const struct fwk_element *elements)
 {

--- a/framework/src/fwk_notification.c
+++ b/framework/src/fwk_notification.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -37,7 +37,9 @@ struct notification_ctx {
 
 static struct notification_ctx ctx;
 
+#if (FWK_LOG_LEVEL < FWK_LOG_LEVEL_DISABLED)
 static const char err_msg_func[] = "[NOT] Error %d in %s";
+#endif
 
 /*
  * Static functions

--- a/module/isys_rom/src/mod_isys_rom.c
+++ b/module/isys_rom/src/mod_isys_rom.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -68,6 +68,10 @@ static int mod_isys_rom_process_event(
     int status;
 
     status = ctx.bootloader_api->load_image();
+
+#if !(FWK_LOG_LEVEL < FWK_LOG_LEVEL_DISABLED)
+    (void)status;
+#endif
 
     FWK_LOG_CRIT(
         "[ISYS-ROM] Failed to load RAM firmware image: %s",

--- a/product/morello/module/morello_mcp_system/src/mod_morello_mcp_system.c
+++ b/product/morello/module/morello_mcp_system/src/mod_morello_mcp_system.c
@@ -66,7 +66,9 @@ static int put_self_event(enum mcp_system_event event_type)
 
 static void alarm_callback(uintptr_t param)
 {
+#if FWK_LOG_LEVEL < FWK_LOG_LEVEL_CRIT
     enum mcp_system_event event_id_type = (enum mcp_system_event)param;
+#endif
     FWK_LOG_ERR(
         "[MCP SYSTEM] For event ID - %d, No response received. Timing Out!",
         (int)event_id_type);

--- a/product/morello/module/morello_sensor/src/mod_morello_sensor.c
+++ b/product/morello/module/morello_sensor/src/mod_morello_sensor.c
@@ -29,6 +29,7 @@
 static struct morello_sensor_ctx sensor_ctx;
 
 /* Morello Sensor names */
+#if FWK_LOG_LEVEL < FWK_LOG_LEVEL_DISABLED
 static const char *const sensor_type_name[MOD_MORELLO_VOLT_SENSOR_COUNT] = {
     [MOD_MORELLO_TEMP_SENSOR_IDX_CLUSTER0] = "T-CLUS0",
     [MOD_MORELLO_TEMP_SENSOR_IDX_CLUSTER1] = "T-CLUS1",
@@ -38,6 +39,7 @@ static const char *const sensor_type_name[MOD_MORELLO_VOLT_SENSOR_COUNT] = {
     [MOD_MORELLO_VOLT_SENSOR_IDX_CLUS1CORE0] = "V-CLUS1CORE0",
     [MOD_MORELLO_VOLT_SENSOR_IDX_CLUS1CORE1] = "V-CLUS1CORE1",
 };
+#endif
 
 static void morello_sensor_timer_callback(uintptr_t unused)
 {
@@ -63,7 +65,6 @@ static void morello_sensor_timer_callback(uintptr_t unused)
                     "%s temperature (%d) reached shutdown threshold!",
                     sensor_type_name[count],
                     (int)value);
-
                 status = sensor_ctx.scp2pcc_api->send(
                     MOD_SCP2PCC_SEND_SHUTDOWN, NULL, 0, NULL, NULL);
                 if (status != FWK_SUCCESS) {

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -95,7 +95,7 @@ zerodivcond:*product/juno/module/juno_cdcel937/src/mod_juno_cdcel937.c:414
 syntaxError:*arch/arm/armv8-a/include/arch_system.h:19
 
 // Cppcheck is not able to parse returned boolean values inside if conditions
-internalAstError:*framework/src/fwk_core.c:295
+internalAstError:*framework/src/fwk_core.c:297
 
 // These assignments are used for testing
 constArgument:*framework/test/test_fwk_macros.c


### PR DESCRIPTION
Add a new 'disabled' log level to the framework that allows for the framework to be ran without producing log messages. Includes fixes for the Morello platform that prevents CppCheck from flagging unused variables when log level is set to 'CRIT' and 'DISABLED' respectively.