### PR TITLE
dockerfile: fix missing dependency for LLVM compiler

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,7 +68,7 @@ RUN apt-get update && \
         'deb http://apt.llvm.org/focal/   llvm-toolchain-focal-13  main' && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        clang-tidy-13 clang-13 llvm-13 libclang-13-dev llvm-13-dev
+        clang-tidy-13 clang-13 llvm-13 libclang-13-dev llvm-13-dev lld-13
 
 COPY rootfs/usr/local/bin/prepare_llvm /usr/local/bin/prepare_llvm
 RUN  chmod 755 "/usr/local/bin/prepare_llvm"


### PR DESCRIPTION
There is a missing dependency for LLVM compiler that prevent the build to be linked. This patch fix this.


Change-Id: I9f3da99e243e2bd05f008d35e6a6c155192f4a15