### PR TITLE
unit_test: Add template for Quick Start

### DIFF
--- a/unit_test/template/test/CMakeLists.txt
+++ b/unit_test/template/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# CMakeLists.txt Template file
+#
+
+set(TEST_SRC mod_template)
+set(TEST_FILE mod_template)
+
+set(UNIT_TEST_TARGET mod_${TEST_MODULE}_unit_test)
+
+set(MODULE_SRC ${MODULE_ROOT}/${TEST_MODULE}/src)
+set(MODULE_INC ${MODULE_ROOT}/${TEST_MODULE}/include)
+list(APPEND OTHER_MODULE_INC ${MODULE_ROOT}/<dependencies>/include)
+set(MODULE_UT_SRC ${CMAKE_CURRENT_LIST_DIR})
+set(MODULE_UT_INC ${CMAKE_CURRENT_LIST_DIR})
+set(MODULE_UT_MOCK_SRC ${CMAKE_CURRENT_LIST_DIR}/mocks)
+
+list(APPEND MOCK_REPLACEMENTS fwk_xxx)
+list(APPEND MOCK_REPLACEMENTS fwk_yyy)
+
+include(${SCP_ROOT}/unit_test/module_common.cmake)

--- a/unit_test/template/test/config_template.h
+++ b/unit_test/template/test/config_template.h
@@ -1,0 +1,18 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * config_template.h Template file
+ */
+
+#include <Mockfwk_module.h>
+
+#include <mod_template.h>
+
+#include <fwk_xxx.h>
+#include <fwk_yyy.h>
+#include <fwk_zzz.h>
+
+/* Add here the configurations for your test cases */

--- a/unit_test/template/test/fwk_module_idx.h
+++ b/unit_test/template/test/fwk_module_idx.h
@@ -1,0 +1,31 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * fwk_module_idx Template file
+ */
+
+#ifndef TEST_FWK_MODULE_IDX_H
+#define TEST_FWK_MODULE_IDX_H
+
+#include <fwk_id.h>
+
+enum fwk_module_idx {
+    FWK_MODULE_IDX_MODULE1,
+    FWK_MODULE_IDX_MODULE2,
+    FWK_MODULE_IDX_MODULE3,
+    FWK_MODULE_IDX_COUNT,
+};
+
+static const fwk_id_t fwk_module_id_module1 =
+    FWK_ID_MODULE_INIT(FWK_MODULE_IDX_MODULE1);
+
+static const fwk_id_t fwk_module_id_module2 =
+    FWK_ID_MODULE_INIT(FWK_MODULE_IDX_MODULE2);
+
+static const fwk_id_t fwk_module_id_module3 =
+    FWK_ID_MODULE_INIT(FWK_MODULE_IDX_MODULE3);
+
+#endif /* TEST_FWK_MODULE_IDX_H */

--- a/unit_test/template/test/mod_template_unit_test.c
+++ b/unit_test/template/test/mod_template_unit_test.c
@@ -1,0 +1,47 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * mod_template_unit_test.c Template file
+ * This is the minimum file setup you need to get started with Unit Testing
+ */
+
+#include "scp_unity.h"
+#include "unity.h"
+
+/*
+ * You may need to include mocked fwk support, for example for identifiers:
+ * #include <Mockfwk_id.h>
+ * and so on.
+ */
+
+#include <config_template.h>
+
+#include <fwk_aaa.h>
+#include <fwk_bbb.h>
+
+#include UNIT_TEST_SRC
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+int template_test_main(void)
+{
+    UNITY_BEGIN();
+
+    return UNITY_END();
+}
+
+#if !defined(TEST_ON_TARGET)
+int main(void)
+{
+    return template_test_main();
+}
+#endif

--- a/unit_test/user_guide.md
+++ b/unit_test/user_guide.md
@@ -262,11 +262,11 @@ from hand-written code.
 
 ## Adding test for new modules
 
-The ```scmi``` and ```scmi_clock``` test directories are provided
-as a reference for new modules. The following process is intended
-as a general guide, and will vary on a case-by-case basis.
+A template of minimum required files is provided as a reference for new modules.
 
-1. Duplicate existing reference test directories as a starting point.
+See unit_test/template/test
+
+1. Duplicate existing reference test directory as a starting point.
 
 2. Modify *.cmake file for our specific test case:
     a. Change TEST_MODULE to name of module

--- a/unit_test/user_guide.md
+++ b/unit_test/user_guide.md
@@ -312,9 +312,6 @@ the guidelines below:
 - One test scenario for each test case. For example, if testing one case for a
   function, have a test function for that case only.
 - Name the test functions according to the test being performed.
-- When an addition or change is made to a module that did not have unit testing
-  before, it is recommended that the enclosing functions affected by the change
-  should then be added for unit testing.
 
 ### Executing Tests on target hardware or FVP models
 
@@ -334,3 +331,15 @@ to understand setup needed building test that can be executed on target
 
 4. Platform must provide definition for plat_execute_all_tests which
 is called by module/ut. See example product/juno/scp_ut/tests_entry.c
+
+## Unit testing requirement guidelines
+
+Unit Testing (UT) has been introduced with the aim of improving the quality and
+reliability of the code.
+In this introductory phase, we suggest that contributors become familiar with
+the unit testing in SCP-firmware.
+In the meantime, while we are not enforcing contibutors to add unit testing on
+their additions or modifications, we encourage them to attempt adding UT
+whenever compatible with their development.
+We foresee that UT will become a mandatory requirement later in the future for
+contributions into SCP-firmware project.


### PR DESCRIPTION
It's been some time since we introduced unit testing in the SCP-firmware project.
Even though the guidelines are pretty useful to get started, we want to simplify even further the adoption of unit testing for the contributors who may still not familiar with it.
Thus, we provide a template that can be used as a first copy-paste example which, along with the instructions, can provide a quick starter into unit testing development.