### PR TITLE
n1sdp: remove unused multichip info structure

### DIFF
--- a/product/n1sdp/module/n1sdp_system/src/mod_n1sdp_system.c
+++ b/product/n1sdp/module/n1sdp_system/src/mod_n1sdp_system.c
@@ -70,16 +70,6 @@ struct n1sdp_platform_info {
     uint8_t remote_ddr_size;
 };
 
-/* MultiChip information */
-struct n1sdp_multichip_info {
-    /* If multichip mode */
-    bool mode;
-    /* Total number of secondary chips  */
-    uint8_t secondary_count;
-    /* Remote ddr size in GB */
-    uint8_t remote_ddr_size;
-};
-
 /* Coresight counter register definitions */
 struct cs_cnt_ctrl_reg {
     FWK_RW uint32_t CS_CNTCR;


### PR DESCRIPTION
Commit 3980808137cf80f5be6a96b453ac9d3ed0f3c752 added support for N1SDP multichip configurations, using the struct n1sdp_multichip_info. Commit d2efba33e3b82398eea6b2ef344196b48940228c merged multichip information into a new structure, but did not remove the declaration of n1sdp_multichip_info. This commit removes the declaration.


Change-Id: I3b14f568c7884ea3cb140fb7f2052c4e4dfe0673