### PR TITLE
morello: Remove unused multichip info struct

### DIFF
--- a/product/morello/module/morello_system/src/mod_morello_system.c
+++ b/product/morello/module/morello_system/src/mod_morello_system.c
@@ -71,16 +71,6 @@ struct FWK_PACKED morello_platform_info {
 #endif
 };
 
-/* MultiChip information */
-struct morello_multichip_info {
-    /* If multichip mode */
-    bool mode;
-    /* Total number of remote chips  */
-    uint8_t remote_chip_count;
-    /* Remote ddr size in GB */
-    uint8_t remote_ddr_size;
-};
-
 /* Coresight counter register definitions */
 struct cs_cnt_ctrl_reg {
     FWK_RW uint32_t CS_CNTCR;


### PR DESCRIPTION
Commit ee56f02cadf70726b2f2e869485a7b1bd2cec48e added the Morello system module, based on the N1SDP system module. This included a declaration of the struct morello_multichip_info, which was not used. This commit removes this unused declaration.


Change-Id: I24aebb19a138137c433dcafd5dff25ae8f187b8a