### PR TITLE
cmn700: use offset adjusted address for remote chips

### DIFF
--- a/module/cmn700/src/mod_cmn700.c
+++ b/module/cmn700/src/mod_cmn700.c
@@ -751,7 +751,7 @@ static int cmn700_program_rnsam(const struct mod_cmn700_mem_region_map *region)
             configure_region(
                 rnsam,
                 region_idx,
-                region->base,
+                base,
                 region->size,
                 SAM_NODE_TYPE_HN_F,
                 SAM_TYPE_SYS_CACHE_GRP_REGION);


### PR DESCRIPTION
Adjust the address of SYSCACHE type region with chip address space offset while mapping the regions in CMN.

This change fixed the bug introduced in the previous change which wrongly maps local system cache address in remote chip's without adjusting it with chip address space.


Change-Id: Ic3b47200b1d1646b8d0e746f0ba55caf7b616c5f