### PR TITLE
Enhanced `pl011` driver with simplification and extended functionality for `fwk_io` module

### DIFF
--- a/framework/include/fwk_io.h
+++ b/framework/include/fwk_io.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -176,7 +176,9 @@ struct fwk_io_adapter {
      *
      * \return Status code representing the result of the operation.
      *
-     * \retval ::FWK_SUCCESS A character was successfully read.
+     * \retval ::FWK_SUCCESS A character was successfully written.
+     * \retval ::FWK_E_BUSY The resource is currently unavailable and it cannot
+     *      accept new characters.
      */
     int (*putch)(const struct fwk_io_stream *stream, char ch);
 

--- a/framework/include/fwk_io.h
+++ b/framework/include/fwk_io.h
@@ -268,7 +268,7 @@ struct fwk_io_stream {
  *      - The `id` parameter was not a valid system entity identifier.
  *      - The `mode` parameter was not a valid access mode.
  * \retval ::FWK_E_SUPPORT The system entity does not support this access mode.
- * \retval ::FWK_E_HANDLER The stream adapter encountered an error.
+ * \retval ::FWK_E_HANDLER The `stream` adapter encountered an error.
  */
 int fwk_io_open(
     struct fwk_io_stream *restrict stream,
@@ -291,9 +291,9 @@ int fwk_io_open(
  * \retval ::FWK_E_PARAM An invalid parameter was encountered:
  *      - The `stream` parameter was a null pointer value.
  *      - The `ch` parameter was a null pointer value.
- * \retval ::FWK_E_STATE The stream has already been closed.
- * \retval ::FWK_E_SUPPORT The stream was not opened with read access.
- * \retval ::FWK_E_HANDLER The stream adapter encountered an error.
+ * \retval ::FWK_E_STATE The `stream` has already been closed.
+ * \retval ::FWK_E_SUPPORT The `stream` was not opened with read access.
+ * \retval ::FWK_E_HANDLER The `stream` adapter encountered an error.
  */
 int fwk_io_getch(
     const struct fwk_io_stream *restrict stream,
@@ -302,7 +302,9 @@ int fwk_io_getch(
 /*!
  * \brief Write a character to a stream.
  *
- * \details Writes a character `ch` to the output stream `stream`.
+ * \details Writes a character `ch` to the output stream `stream`. If the driver
+ *      is busy, it waits until the resource is freed and available to receive
+ *      new characters.
  *
  * \param[in] stream Stream to write to.
  * \param[in] ch Character to write.
@@ -311,11 +313,31 @@ int fwk_io_getch(
  *
  * \retval ::FWK_SUCCESS The character was successfully written.
  * \retval ::FWK_E_PARAM The `stream` parameter was a null pointer value.
- * \retval ::FWK_E_STATE The stream has already been closed.
- * \retval ::FWK_E_SUPPORT The stream was not opened with write access.
- * \retval ::FWK_E_HANDLER The stream adapter encountered an error.
+ * \retval ::FWK_E_STATE The `stream` has already been closed.
+ * \retval ::FWK_E_SUPPORT The `stream` was not opened with write access.
+ * \retval ::FWK_E_HANDLER The `stream` adapter encountered an error.
  */
 int fwk_io_putch(const struct fwk_io_stream *stream, char ch);
+
+/*!
+ * \brief Write a character to a stream.
+ *
+ * \details Writes a character `ch` to the output stream `stream`. If the driver
+ *      is busy `FWK_E_BUSY` will be returned.
+ *
+ * \param[in] stream Stream to write to.
+ * \param[in] ch Character to write.
+ *
+ * \return Status code representing the result of the operation.
+ *
+ * \retval ::FWK_SUCCESS The character was successfully written.
+ * \retval ::FWK_E_BUSY The `stream` resource is currently busy.
+ * \retval ::FWK_E_PARAM The `stream` parameter was a null pointer value.
+ * \retval ::FWK_E_STATE The `stream` has already been closed.
+ * \retval ::FWK_E_SUPPORT The `stream` was not opened with write access.
+ * \retval ::FWK_E_HANDLER The `stream` adapter encountered an error.
+ */
+int fwk_io_putch_nowait(const struct fwk_io_stream *stream, char ch);
 
 /*!
  * \brief Read data from a stream.
@@ -343,10 +365,10 @@ int fwk_io_putch(const struct fwk_io_stream *stream, char ch);
  * \retval ::FWK_E_PARAM An invalid parameter was encountered:
  *      - The `stream` parameter was a null pointer value.
  *      - The `buffer` parameter was a null pointer value.
- * \retval ::FWK_E_STATE The stream has already been closed.
- * \retval ::FWK_E_SUPPORT The stream was not opened with read access.
+ * \retval ::FWK_E_STATE The `stream` has already been closed.
+ * \retval ::FWK_E_SUPPORT The `stream` was not opened with read access.
  * \retval ::FWK_E_DATA The read succeeded but the buffer was not filled.
- * \retval ::FWK_E_HANDLER The stream adapter encountered an error.
+ * \retval ::FWK_E_HANDLER The `stream` adapter encountered an error.
  */
 int fwk_io_read(
     const struct fwk_io_stream *restrict stream,
@@ -376,9 +398,9 @@ int fwk_io_read(
  * \retval ::FWK_E_PARAM An invalid parameter was encountered:
  *      - The `stream` parameter was a null pointer value.
  *      - The `buffer` parameter was a null pointer value.
- * \retval ::FWK_E_STATE The stream has already been closed.
- * \retval ::FWK_E_SUPPORT The stream was not opened with write access.
- * \retval ::FWK_E_HANDLER The stream adapter encountered an error.
+ * \retval ::FWK_E_STATE The `stream` has already been closed.
+ * \retval ::FWK_E_SUPPORT The `stream` was not opened with write access.
+ * \retval ::FWK_E_HANDLER The `stream` adapter encountered an error.
  */
 int fwk_io_write(
     const struct fwk_io_stream *restrict stream,
@@ -401,9 +423,9 @@ int fwk_io_write(
  * \retval ::FWK_E_PARAM An invalid parameter was encountered:
  *      - The `stream` parameter was a null pointer value.
  *      - The `str` parameter was a null pointer value.
- * \retval ::FWK_E_STATE The stream has already been closed.
- * \retval ::FWK_E_SUPPORT The stream was not opened with write access.
- * \retval ::FWK_E_HANDLER The stream adapter encountered an error.
+ * \retval ::FWK_E_STATE The `stream` has already been closed.
+ * \retval ::FWK_E_SUPPORT The `stream` was not opened with write access.
+ * \retval ::FWK_E_HANDLER The `stream` adapter encountered an error.
  */
 int fwk_io_puts(
     const struct fwk_io_stream *restrict stream,
@@ -431,9 +453,9 @@ int fwk_io_puts(
  * \retval ::FWK_E_NOMEM There is not enough memory to format the string.
  * \retval ::FWK_E_STATE An internal error occurred:
  *      - An error occurred attempting to format the string.
- *      - The stream has already been closed.
- * \retval ::FWK_E_SUPPORT The stream was not opened with write access.
- * \retval ::FWK_E_HANDLER The stream adapter encountered an error.
+ *      - The `stream` has already been closed.
+ * \retval ::FWK_E_SUPPORT The `stream` was not opened with write access.
+ * \retval ::FWK_E_HANDLER The `stream` adapter encountered an error.
  */
 int fwk_io_vprintf(
     const struct fwk_io_stream *restrict stream,
@@ -462,9 +484,9 @@ int fwk_io_vprintf(
  * \retval ::FWK_E_NOMEM There is not enough memory to format the string.
  * \retval ::FWK_E_STATE An internal error occurred:
  *      - An error occurred attempting to format the string.
- *      - The stream has already been closed.
- * \retval ::FWK_E_SUPPORT The stream was not opened with write access.
- * \retval ::FWK_E_HANDLER The stream adapter encountered an error.
+ *      - The `stream` has already been closed.
+ * \retval ::FWK_E_SUPPORT The `stream` was not opened with write access.
+ * \retval ::FWK_E_HANDLER The `stream` adapter encountered an error.
  */
 int fwk_io_printf(
     const struct fwk_io_stream *restrict stream,
@@ -483,9 +505,9 @@ int fwk_io_printf(
  *
  * \return Status code representing the result of the operation.
  *
- * \retval ::FWK_SUCCESS The stream was successfully closed.
+ * \retval ::FWK_SUCCESS The `stream` was successfully closed.
  * \retval ::FWK_E_PARAM The `stream` parameter was a null pointer value.
- * \retval ::FWK_E_HANDLER The stream adapter encountered an error.
+ * \retval ::FWK_E_HANDLER The `stream` adapter encountered an error.
  */
 int fwk_io_close(struct fwk_io_stream *stream);
 

--- a/framework/src/fwk_io.c
+++ b/framework/src/fwk_io.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -210,12 +210,16 @@ int fwk_io_putch(const struct fwk_io_stream *stream, char ch)
 
     fwk_assert(stream->adapter->putch != NULL);
 
-    status = stream->adapter->putch(stream, ch);
+    do {
+        /* Wait for the adapter to accept new characters */
+        status = stream->adapter->putch(stream, ch);
+    } while (status == FWK_E_BUSY);
+
     if (status != FWK_SUCCESS) {
         return FWK_E_HANDLER;
     }
 
-    return FWK_SUCCESS;
+    return status;
 }
 
 int fwk_io_read(

--- a/framework/src/fwk_io.c
+++ b/framework/src/fwk_io.c
@@ -222,6 +222,34 @@ int fwk_io_putch(const struct fwk_io_stream *stream, char ch)
     return status;
 }
 
+int fwk_io_putch_nowait(const struct fwk_io_stream *stream, char ch)
+{
+    int status;
+
+    if (stream == NULL) {
+        return FWK_E_PARAM;
+    }
+
+    if (stream->adapter == NULL) {
+        return FWK_E_STATE; /* The stream is not open */
+    }
+
+    if ((((unsigned int)stream->mode) & ((unsigned int)FWK_IO_MODE_WRITE)) ==
+        0U) {
+        return FWK_E_SUPPORT; /* Stream not open for write operations */
+    }
+
+    fwk_assert(stream->adapter->putch != NULL);
+
+    status = stream->adapter->putch(stream, ch);
+
+    if ((status != FWK_SUCCESS) && (status != FWK_E_BUSY)) {
+        return FWK_E_HANDLER;
+    }
+
+    return status;
+}
+
 int fwk_io_read(
     const struct fwk_io_stream *restrict stream,
     size_t *restrict read,

--- a/module/pl011/src/mod_pl011.c
+++ b/module/pl011/src/mod_pl011.c
@@ -65,9 +65,6 @@ static int mod_pl011_init_ctx(struct mod_pl011_ctx *ctx)
     }
 
     ctx->elements = fwk_mm_alloc(element_count, sizeof(ctx->elements[0]));
-    if (!fwk_expect(ctx->elements != NULL)) {
-        return FWK_E_NOMEM;
-    }
 
     for (size_t i = 0; i < element_count; i++) {
         const struct mod_pl011_element_cfg *cfg =

--- a/module/pl011/src/mod_pl011.c
+++ b/module/pl011/src/mod_pl011.c
@@ -49,9 +49,7 @@ static struct mod_pl011_ctx {
     bool initialized; /* Whether the context has been initialized */
 
     struct mod_pl011_element_ctx *elements; /* Element context table */
-} pl011_ctx = {
-    .initialized = false,
-};
+} pl011_ctx;
 
 static int mod_pl011_init_ctx(struct mod_pl011_ctx *ctx)
 {

--- a/module/pl011/test/CMakeLists.txt
+++ b/module/pl011/test/CMakeLists.txt
@@ -1,0 +1,26 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(TEST_SRC mod_pl011)
+set(TEST_FILE mod_pl011)
+
+set(UNIT_TEST_TARGET mod_${TEST_MODULE}_unit_test)
+
+set(MODULE_SRC ${MODULE_ROOT}/${TEST_MODULE}/src)
+set(MODULE_INC ${MODULE_ROOT}/${TEST_MODULE}/include)
+list(APPEND OTHER_MODULE_INC ${MODULE_ROOT}/system_power/include)
+list(APPEND OTHER_MODULE_INC ${MODULE_ROOT}/power_domain/include)
+list(APPEND OTHER_MODULE_INC ${MODULE_ROOT}/clock/include)
+set(MODULE_UT_SRC ${CMAKE_CURRENT_LIST_DIR})
+set(MODULE_UT_INC ${CMAKE_CURRENT_LIST_DIR})
+set(MODULE_UT_MOCK_SRC ${CMAKE_CURRENT_LIST_DIR}/mocks)
+
+list(APPEND MOCK_REPLACEMENTS fwk_module)
+list(APPEND MOCK_REPLACEMENTS fwk_notification)
+list(APPEND MOCK_REPLACEMENTS fwk_id)
+
+include(${SCP_ROOT}/unit_test/module_common.cmake)

--- a/module/pl011/test/config_pl011.h
+++ b/module/pl011/test/config_pl011.h
@@ -1,0 +1,36 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+static struct pl011_reg mod_reg;
+
+#include <mod_pl011.h>
+
+#include <fwk_element.h>
+#include <fwk_id.h>
+#include <fwk_macros.h>
+#include <fwk_module.h>
+
+enum mhu3_fake_device_idx {
+    PL011_FAKE_ELEMENT_IDX_0,
+    PL011_FAKE_ELEMENT_IDX_COUNT,
+};
+
+struct fwk_module_config config_pl011_ut = {
+    .elements = FWK_MODULE_STATIC_ELEMENTS({
+        [0] = {
+            .name = "UART OUTPUT",
+            .data =
+                &(struct mod_pl011_element_cfg){
+                    .reg_base = (uintptr_t)&mod_reg,
+                    .baud_rate_bps = 115200,
+                    .clock_rate_hz = 24 * FWK_MHZ,
+                },
+        },
+
+        [1] = { 0 },
+    }),
+};

--- a/module/pl011/test/fwk_module_idx.h
+++ b/module/pl011/test/fwk_module_idx.h
@@ -1,0 +1,21 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TEST_FWK_MODULE_MODULE_IDX_H
+#define TEST_FWK_MODULE_MODULE_IDX_H
+
+#include <fwk_id.h>
+
+enum fwk_module_idx {
+    FWK_MODULE_IDX_PL011,
+    FWK_MODULE_IDX_COUNT,
+};
+
+static const fwk_id_t fwk_module_id_pl011 =
+    FWK_ID_MODULE_INIT(FWK_MODULE_IDX_PL011);
+
+#endif /* TEST_FWK_MODULE_MODULE_IDX_H */

--- a/module/pl011/test/mocks/.clang-format
+++ b/module/pl011/test/mocks/.clang-format
@@ -1,0 +1,4 @@
+{
+ "DisableFormat": true,
+ "SortIncludes": false,
+}

--- a/module/pl011/test/mod_pl011_unit_test.c
+++ b/module/pl011/test/mod_pl011_unit_test.c
@@ -1,0 +1,265 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "scp_unity.h"
+#include "unity.h"
+
+#include <Mockfwk_id.h>
+#include <Mockfwk_module.h>
+#include <pl011.h>
+
+#include <mod_pl011.h>
+
+#include <fwk_element.h>
+#include <fwk_macros.h>
+
+#include UNIT_TEST_SRC
+#include "config_pl011.h"
+
+struct fwk_io_stream stream;
+struct mod_pl011_element_cfg *cfg_ut;
+
+void setUp(void)
+{
+    memset(&pl011_ctx, 0, sizeof(pl011_ctx));
+
+    cfg_ut =
+        (struct mod_pl011_element_cfg *)config_pl011_ut.elements.table[0].data;
+
+    pl011_ctx.elements = fwk_mm_alloc(1, sizeof(pl011_ctx.elements[0]));
+    pl011_ctx.elements[0] = (struct mod_pl011_element_ctx){
+        .powered = true, /* Assume the device is always powered */
+        .clocked = true, /* Assume the device is always clocked  */
+        .open = false,
+    };
+}
+
+void tearDown(void)
+{
+}
+
+void test_mod_pl011_putch_true(void)
+{
+    bool status;
+    char ch = 64;
+    fwk_id_t id;
+
+    fwk_module_get_data_ExpectAnyArgsAndReturn(cfg_ut);
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+
+    status = mod_pl011_putch(id, ch);
+    TEST_ASSERT_EQUAL(status, true);
+    TEST_ASSERT_EQUAL(mod_reg.DR, ch);
+}
+
+void test_mod_pl011_io_putch_success(void)
+{
+    int status;
+    char ch = 64;
+    struct fwk_io_stream stream;
+
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+
+    pl011_ctx.elements[0].open = true;
+
+    fwk_module_get_data_ExpectAnyArgsAndReturn(cfg_ut);
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+
+    status = mod_pl011_io_putch(&stream, ch);
+    TEST_ASSERT_EQUAL(status, FWK_SUCCESS);
+    TEST_ASSERT_EQUAL(mod_reg.DR, ch);
+}
+
+void test_mod_pl011_io_putch_fail_powered(void)
+{
+    int status;
+    char ch = 0;
+    struct fwk_io_stream stream;
+
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+
+    pl011_ctx.elements[0].open = true;
+    pl011_ctx.elements[0].powered = false;
+
+    fwk_module_get_data_ExpectAnyArgsAndReturn(cfg_ut);
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+
+    status = mod_pl011_io_putch(&stream, ch);
+    TEST_ASSERT_EQUAL(status, FWK_E_PWRSTATE);
+}
+
+void test_mod_pl011_io_putch_fail_clocked(void)
+{
+    int status;
+    char ch = 0;
+    struct fwk_io_stream stream;
+
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+
+    pl011_ctx.elements[0].open = true;
+    pl011_ctx.elements[0].clocked = false;
+
+    fwk_module_get_data_ExpectAnyArgsAndReturn(cfg_ut);
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+
+    status = mod_pl011_io_putch(&stream, ch);
+    TEST_ASSERT_EQUAL(status, FWK_E_PWRSTATE);
+}
+
+void test_mod_pl011_init_ctx(void)
+{
+    /* Clear module context to ensure it is properly initialized */
+    memset(&pl011_ctx, 0, sizeof(pl011_ctx));
+
+    fwk_module_get_element_count_ExpectAnyArgsAndReturn(1);
+    fwk_module_get_data_ExpectAnyArgsAndReturn(cfg_ut);
+    fwk_id_is_equal_ExpectAnyArgsAndReturn(true);
+    fwk_id_is_equal_ExpectAnyArgsAndReturn(true);
+
+    mod_pl011_init_ctx();
+    TEST_ASSERT_EQUAL(pl011_ctx.initialized, true);
+    TEST_ASSERT_EQUAL(pl011_ctx.elements[0].powered, true);
+    TEST_ASSERT_EQUAL(pl011_ctx.elements[0].clocked, true);
+    TEST_ASSERT_EQUAL(pl011_ctx.elements[0].open, false);
+}
+
+void test_mod_pl011_init_initialised(void)
+{
+    int status;
+    fwk_id_t module_id;
+
+    pl011_ctx.initialized = true;
+
+    status = mod_pl011_init(module_id, 1, NULL);
+    TEST_ASSERT_EQUAL(status, FWK_SUCCESS);
+}
+
+void test_mod_pl011_init(void)
+{
+    int status;
+    fwk_id_t module_id;
+
+    /* Clear module context to ensure it is properly initialized */
+    memset(&pl011_ctx, 0, sizeof(pl011_ctx));
+
+    pl011_ctx.initialized = false;
+
+    /* Set up the mock calls for the context initialisation */
+    fwk_module_get_element_count_ExpectAnyArgsAndReturn(1);
+    fwk_module_get_data_ExpectAnyArgsAndReturn(cfg_ut);
+    fwk_id_is_equal_ExpectAnyArgsAndReturn(true);
+    fwk_id_is_equal_ExpectAnyArgsAndReturn(true);
+
+    status = mod_pl011_init(module_id, 1, NULL);
+    TEST_ASSERT_EQUAL(status, FWK_SUCCESS);
+    TEST_ASSERT_EQUAL(pl011_ctx.initialized, true);
+    TEST_ASSERT_EQUAL(pl011_ctx.elements[0].powered, true);
+    TEST_ASSERT_EQUAL(pl011_ctx.elements[0].clocked, true);
+    TEST_ASSERT_EQUAL(pl011_ctx.elements[0].open, false);
+}
+
+void test_mod_pl011_io_open_support(void)
+{
+    int status;
+    struct fwk_io_stream stream;
+
+    fwk_id_is_type_ExpectAnyArgsAndReturn(false);
+
+    status = mod_pl011_io_open(&stream);
+    TEST_ASSERT_EQUAL(status, FWK_E_SUPPORT);
+}
+
+void test_mod_pl011_io_open_busy(void)
+{
+    int status;
+    struct fwk_io_stream stream;
+
+    fwk_id_is_type_ExpectAnyArgsAndReturn(true);
+
+    pl011_ctx.initialized = true;
+    pl011_ctx.elements[0].open = true;
+
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+    status = mod_pl011_io_open(&stream);
+    TEST_ASSERT_EQUAL(status, FWK_E_BUSY);
+}
+
+void test_mod_pl011_io_open_success(void)
+{
+    int status;
+    struct fwk_io_stream stream;
+
+    pl011_ctx.initialized = true;
+    pl011_ctx.elements[0].clocked = true;
+    pl011_ctx.elements[0].powered = true;
+    pl011_ctx.elements[0].open = false;
+
+    fwk_id_is_type_ExpectAnyArgsAndReturn(true);
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+    fwk_module_get_data_ExpectAnyArgsAndReturn(cfg_ut);
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+
+    status = mod_pl011_io_open(&stream);
+    TEST_ASSERT_EQUAL(status, FWK_SUCCESS);
+    TEST_ASSERT_EQUAL(pl011_ctx.elements[0].open, true);
+    TEST_ASSERT_EQUAL(mod_reg.ECR, PL011_ECR_CLR);
+    TEST_ASSERT_EQUAL(mod_reg.LCR_H, PL011_LCR_H_WLEN_8BITS | PL011_LCR_H_FEN);
+    TEST_ASSERT_EQUAL(
+        mod_reg.CR, PL011_CR_UARTEN | PL011_CR_RXE | PL011_CR_TXE);
+}
+
+void test_mod_pl011_io_getch(void)
+{
+    bool status;
+    char ch = 0;
+    fwk_id_t id;
+
+    mod_reg.DR = 64;
+
+    fwk_module_get_data_ExpectAnyArgsAndReturn(cfg_ut);
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+
+    status = mod_pl011_getch(id, &ch);
+    TEST_ASSERT_EQUAL(status, true);
+    TEST_ASSERT_EQUAL(ch, 64);
+}
+
+void test_mod_pl011_flush(void)
+{
+    fwk_id_t id;
+
+    fwk_module_get_data_ExpectAnyArgsAndReturn(cfg_ut);
+    fwk_id_get_element_idx_ExpectAnyArgsAndReturn(0);
+
+    /* The PL011_FR_BUSY is zeroed so the flush should take place silently */
+    mod_pl011_flush(id);
+}
+
+int pl011_test_main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_mod_pl011_putch_true);
+    RUN_TEST(test_mod_pl011_io_putch_success);
+    RUN_TEST(test_mod_pl011_io_putch_fail_powered);
+    RUN_TEST(test_mod_pl011_io_putch_fail_clocked);
+    RUN_TEST(test_mod_pl011_io_open_busy);
+    RUN_TEST(test_mod_pl011_init_ctx);
+    RUN_TEST(test_mod_pl011_init_initialised);
+    RUN_TEST(test_mod_pl011_init);
+    RUN_TEST(test_mod_pl011_io_open_support);
+    RUN_TEST(test_mod_pl011_io_open_success);
+    RUN_TEST(test_mod_pl011_io_getch);
+    RUN_TEST(test_mod_pl011_flush);
+    return UNITY_END();
+}
+
+#if !defined(TEST_ON_TARGET)
+int main(void)
+{
+    return pl011_test_main();
+}
+#endif

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -63,8 +63,8 @@ nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:60
 nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:61
 nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:65
 nullPointerRedundantCheck:*module/mhu2/src/mod_mhu2.c:90
-nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:134
 nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:135
+nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:136
 nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:609
 nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:620
 nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:642

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -63,8 +63,8 @@ nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:60
 nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:61
 nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:65
 nullPointerRedundantCheck:*module/mhu2/src/mod_mhu2.c:90
-nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:136
-nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:137
+nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:134
+nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:135
 nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:609
 nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:620
 nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:642

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -63,8 +63,8 @@ nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:60
 nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:61
 nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:65
 nullPointerRedundantCheck:*module/mhu2/src/mod_mhu2.c:90
-nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:139
-nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:140
+nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:136
+nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:137
 nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:609
 nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:620
 nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:642

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -107,6 +107,7 @@ list(APPEND SCP_UNITY_SRC ${TEST_ROOT}/unity_mocks/scp_unity.c)
 
 #Append common unit tests below here
 list(APPEND UNIT_MODULE mhu3)
+list(APPEND UNIT_MODULE pl011)
 list(APPEND UNIT_MODULE scmi)
 list(APPEND UNIT_MODULE scmi_clock)
 list(APPEND UNIT_MODULE scmi_perf)


### PR DESCRIPTION
This PR introduces several improvements:

- Initial unit tests for `pl011` driver
- Simplified `mod_pl011_init_ctx` function
- Removed redundant code in `pl011` driver
- Enhanced handling of TX buffer full condition
- Introducing `fwk_io_putch_nowait` function in `fwk_io` module
