### PR TITLE
Fix "all-log-level" defect

### DIFF
--- a/module/msys_rom/src/mod_msys_rom.c
+++ b/module/msys_rom/src/mod_msys_rom.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -53,6 +53,10 @@ static int msys_deferred_setup(void)
     ctx.ppu_boot_api->power_mode_on(ctx.rom_config->id_primary_core);
 
     status = ctx.bootloader_api->load_image();
+
+#if !(FWK_LOG_LEVEL < FWK_LOG_LEVEL_DISABLED)
+    (void)status;
+#endif
 
     FWK_LOG_CRIT(
         "[MSYS-ROM] Failed to load RAM firmware image: %s",

--- a/product/n1sdp/module/n1sdp_mcp_system/src/mod_n1sdp_mcp_system.c
+++ b/product/n1sdp/module/n1sdp_mcp_system/src/mod_n1sdp_mcp_system.c
@@ -66,8 +66,9 @@ static int put_self_event(enum mcp_system_event event_type)
 
 static void alarm_callback(uintptr_t param)
 {
+#if FWK_LOG_LEVEL < FWK_LOG_LEVEL_CRIT
     enum mcp_system_event event_id_type = (enum mcp_system_event)param;
-
+#endif
     FWK_LOG_ERR(
         "[MCP SYSTEM] For event ID - %d, No response received. Timing Out!",
         (int)event_id_type);

--- a/product/tc2/module/tc2_bl1/src/mod_tc2_bl1.c
+++ b/product/tc2/module/tc2_bl1/src/mod_tc2_bl1.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -178,6 +178,10 @@ static int tc2_bl1_process_event(
         ctx.ppu_boot_api->power_mode_on(ctx.bl1_config->id_primary_core);
 
         status = ctx.bootloader_api->load_image();
+
+#if !(FWK_LOG_LEVEL < FWK_LOG_LEVEL_DISABLED)
+        (void)status;
+#endif
 
         FWK_LOG_CRIT(
             "[TC2_BL1] Failed to load RAM firmware image: %s",


### PR DESCRIPTION
Fix defects raised by the 'scp-tests-ci-all-log-levels' Jenkins Job in product/n1sdp, product/tc2, and morello when CPPcheck raises unused variable warnings when log level parameter is set to either 'DISABLED' or 'CRIT'.