### PR TITLE
module/power_domain: Update all power state variables upon report

### DIFF
--- a/module/power_domain/src/mod_power_domain.c
+++ b/module/power_domain/src/mod_power_domain.c
@@ -1234,6 +1234,9 @@ static void process_power_state_transition_report(struct pd_ctx *pd,
     }
 #endif
 
+    /* Update the pd states to follow the new transition */
+    pd->requested_state = pd->state_requested_to_driver = pd->current_state;
+
     if (is_deeper_state(new_state, previous_state)) {
         process_power_state_transition_report_deeper_state(pd);
     } else if (is_shallower_state(new_state, previous_state)) {


### PR DESCRIPTION
pd->current_state is updated upon receiving a transition report; other state variables are not. This can be valid when the report results from a request. However, this won't be valid for non-requested transitions such as wakeup. Hence, update all state variables accordingly.
