### PR TITLE
The platform variants for juno platform is updated for CI.

### DIFF
--- a/tools/ci_cmake.py
+++ b/tools/ci_cmake.py
@@ -37,7 +37,7 @@ code_validations = [
 
 products = [
     Product('host', toolchains=[Parameter('GNU')]),
-    Product('juno'),
+    Product('juno', variants=[Parameter('BOARD'), Parameter('FVP')]),
     Product('morello'),
     Product('n1sdp'),
     Product('rdv1'),


### PR DESCRIPTION
Juno has two `PLATFORM_VARIANTS`, i.e. `BOARD` and `FVP`. These are updated in the ci_cmake.py file.