### PR TITLE
fwk_log: Add option for custom banner

### DIFF
--- a/framework/src/fwk_log.c
+++ b/framework/src/fwk_log.c
@@ -165,7 +165,9 @@ static bool fwk_log_banner(void)
 {
     char buffer[FMW_LOG_COLUMNS];
 
-#ifndef FMW_LOG_MINIMAL_BANNER
+#if defined(FMW_LOG_CUSTOM_BANNER)
+    const char *banner[] = { FMW_LOG_CUSTOM_BANNER_STRING };
+#elif !defined(FMW_LOG_MINIMAL_BANNER)
     const char *banner[] = {
         " ___  ___ ___      __ _",
         "/ __|/ __| _ \\___ / _(_)_ _ _ ____ __ ____ _ _ _ ___",

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -34,8 +34,9 @@ nullPointerRedundantCheck:*product/juno/*
 syntaxError:*product/synquacer/module/synquacer_system/src/mmu500.c:34
 
 // Cppcheck seems to get confused with macro substitution
-syntaxError:*framework/src/fwk_log.c:175
-syntaxError:*framework/src/fwk_log.c:179
+syntaxError:*framework/src/fwk_log.c:169
+syntaxError:*framework/src/fwk_log.c:177
+syntaxError:*framework/src/fwk_log.c:181
 
 // Cppcheck doesn't like include directives that use macros
 preprocessorErrorDirective:*framework/test/fwk_module_idx.h:14


### PR DESCRIPTION
This allows creating a custom banner instead of the default ones provided by the log framework.
Usage is by adding the following in fmw_log.h:
```
#define FMW_LOG_CUSTOM_BANNER
#define FMW_LOG_CUSTOM_BANNER_STRING "custom banner string"
```