### PR TITLE
module/mhu3: fix bind function

### DIFF
--- a/module/mhu3/src/mod_mhu3.c
+++ b/module/mhu3/src/mod_mhu3.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -462,7 +462,7 @@ static int mhu3_bind(fwk_id_t id, unsigned int round)
                     FWK_ID_API(
                         FWK_MODULE_IDX_TRANSPORT,
                         MOD_TRANSPORT_API_IDX_DRIVER_INPUT),
-                    channel_ctx->transport_api);
+                    &channel_ctx->transport_api);
 
                 if (status != FWK_SUCCESS) {
                     /* Unable to bind back to TRANSPORT channel */


### PR DESCRIPTION
In the mhu3_bind() function, the transport_api pointer variable is passed to the fwk_module_bind() instead of the pointer address. This causes an error when the framework bind function checks if the API pointer is NULL. This patch fixes this error.


Change-Id: I774b0ec5104232918b73602b54ce74a86617b185