### PR TITLE
Doxygen trivial fixes (SMCF, SCMI-SP, MHU3)

### DIFF
--- a/module/mhu3/doc/mhu3.md
+++ b/module/mhu3/doc/mhu3.md
@@ -1,10 +1,10 @@
 \ingroup GroupModules Modules
-\defgroup GroupMHU3 MHU Hardware version 3 driver.
+\defgroup GroupMHUv3 Message Handling Unit (MHU) v3 Driver
 
 # MHU Hardware version 3 driver
 
 
-Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
 
 ## Overview
 

--- a/module/scmi_system_power_req/include/mod_scmi_system_power_req.h
+++ b/module/scmi_system_power_req/include/mod_scmi_system_power_req.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -14,6 +14,16 @@
 
 #include <stddef.h>
 #include <stdint.h>
+
+/*!
+ * \addtogroup GroupModules Modules
+ * \{
+ */
+
+/*!
+ * \defgroup GroupSCMISystemPowerRequester SCMI System Power Requester
+ * \{
+ */
 
 /*!
  * \brief Set state configurations
@@ -128,5 +138,13 @@ static const fwk_id_t system_power_requester_set_state_request =
     FWK_ID_EVENT_INIT(
         FWK_MODULE_IDX_SCMI_SYSTEM_POWER_REQ,
         MOD_SCMI_SPR_EVENT_IDX_SET_STATE);
+
+/*!
+ * \}
+ */
+
+/*!
+ * \}
+ */
 
 #endif /* MOD_SCMI_SYSTEM_POWER_REQ_H */

--- a/module/smcf/doc/smcf.md
+++ b/module/smcf/doc/smcf.md
@@ -1,5 +1,5 @@
 \ingroup GroupModules Modules
-\defgroup GroupAtu Smcf
+\defgroup GroupModuleSMCF SMCF Driver
 
 # System Monitoring Control Framework SMCF Architecture
 


### PR DESCRIPTION
Trivial fixes for doxygen for SMCF, SCMI System Power and MHUv3.