### PR TITLE
Allow a selected list of PID/CID registers to compare

### DIFF
--- a/module/pcid/include/mod_pcid.h
+++ b/module/pcid/include/mod_pcid.h
@@ -75,6 +75,19 @@ enum mod_pcid_register_id {
  * \param registers Pointer to set of PCID registers to check.
  * \param expected Pointer to set of PCID Registers that denote the expected
  *     values.
+ * \param valid_pcid_registers Bitmap of valid PID/CID registers.
+ *     Bit0  - Set if PID4 is valid.
+ *     Bit1  - Set if PID5 is valid.
+ *     Bit2  - Set if PID6 is valid.
+ *     Bit3  - Set if PID7 is valid.
+ *     Bit4  - Set if PID0 is valid.
+ *     Bit5  - Set if PID1 is valid.
+ *     Bit6  - Set if PID2 is valid.
+ *     Bit7  - Set if PID3 is valid.
+ *     Bit8  - Set if CID0 is valid.
+ *     Bit9  - Set if CID1 is valid.
+ *     Bit10 - Set if CID2 is valid.
+ *     Bit11 - Set if CID3 is valid.
  *
  * \pre \p registers must not be NULL
  * \pre \p expected must not be NULL
@@ -82,8 +95,10 @@ enum mod_pcid_register_id {
  * \retval true All the registers have the expected values.
  * \retval false One or more registers do not have the expected values.
  */
-bool mod_pcid_check_registers(const struct mod_pcid_registers *registers,
-                              const struct mod_pcid_registers *expected);
+bool mod_pcid_check_registers(
+    const struct mod_pcid_registers *registers,
+    const struct mod_pcid_registers *expected,
+    uint32_t valid_pcid_registers);
 
 /*!
  * \}

--- a/module/pcid/include/mod_pcid.h
+++ b/module/pcid/include/mod_pcid.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -27,6 +27,11 @@
  */
 
 /*!
+ * Value indicating that a PCID register is valid.
+ */
+#define PCID_REG_VALID (1u)
+
+/*!
  * \brief PID and CID registers.
  */
 struct mod_pcid_registers {
@@ -42,6 +47,26 @@ struct mod_pcid_registers {
     FWK_R uint32_t CID1; /*!< Component ID 1 */
     FWK_R uint32_t CID2; /*!< Component ID 2 */
     FWK_R uint32_t CID3; /*!< Component ID 3 */
+};
+
+/*!
+ * \brief PID/CID register identifier in address order.
+ */
+enum mod_pcid_register_id {
+    MOD_PCID_REGISTER_NONE = 0x000,
+    MOD_PCID_REGISTER_PID4 = (PCID_REG_VALID << 0),
+    MOD_PCID_REGISTER_PID5 = (PCID_REG_VALID << 1),
+    MOD_PCID_REGISTER_PID6 = (PCID_REG_VALID << 2),
+    MOD_PCID_REGISTER_PID7 = (PCID_REG_VALID << 3),
+    MOD_PCID_REGISTER_PID0 = (PCID_REG_VALID << 4),
+    MOD_PCID_REGISTER_PID1 = (PCID_REG_VALID << 5),
+    MOD_PCID_REGISTER_PID2 = (PCID_REG_VALID << 6),
+    MOD_PCID_REGISTER_PID3 = (PCID_REG_VALID << 7),
+    MOD_PCID_REGISTER_CID0 = (PCID_REG_VALID << 8),
+    MOD_PCID_REGISTER_CID1 = (PCID_REG_VALID << 9),
+    MOD_PCID_REGISTER_CID2 = (PCID_REG_VALID << 10),
+    MOD_PCID_REGISTER_CID3 = (PCID_REG_VALID << 11),
+    MOD_PCID_REGISTER_ALL = 0xFFF,
 };
 
 /*!

--- a/module/pcid/src/mod_pcid.c
+++ b/module/pcid/src/mod_pcid.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -9,19 +9,42 @@
 
 #include <fwk_assert.h>
 #include <fwk_id.h>
+#include <fwk_log.h>
+#include <fwk_macros.h>
 #include <fwk_module.h>
 #include <fwk_status.h>
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
 
-bool mod_pcid_check_registers(const struct mod_pcid_registers *registers,
-                              const struct mod_pcid_registers *expected)
+bool mod_pcid_check_registers(
+    const struct mod_pcid_registers *registers,
+    const struct mod_pcid_registers *expected,
+    uint32_t valid_pcid_registers)
 {
+    FWK_R uint32_t *pcid_reg, *pcid_expt;
+
     fwk_assert(registers != NULL);
     fwk_assert(expected != NULL);
 
-    return !memcmp(registers, expected, sizeof(*registers));
+    if (valid_pcid_registers == MOD_PCID_REGISTER_ALL) {
+        return !memcmp(registers, expected, sizeof(*registers));
+    } else {
+        valid_pcid_registers = valid_pcid_registers & MOD_PCID_REGISTER_ALL;
+        pcid_reg = &registers->PID4;
+        pcid_expt = &expected->PID4;
+
+        while (valid_pcid_registers) {
+            if ((valid_pcid_registers & 1) == PCID_REG_VALID) {
+                if (*pcid_reg++ != *pcid_expt++) {
+                    return false;
+                }
+            }
+            valid_pcid_registers >>= 1;
+        }
+        return true;
+    }
 }
 
 static int pcid_init(fwk_id_t module_id,

--- a/module/sid/include/mod_sid.h
+++ b/module/sid/include/mod_sid.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -83,6 +83,9 @@ struct mod_sid_config {
 
     /*! Expected values of the PID and CID registers */
     struct mod_pcid_registers pcid_expected;
+
+    /*! Bitmap representing valid PID and CID registers */
+    uint32_t valid_pcid_registers;
 };
 
 /*!

--- a/module/sid/src/mod_sid.c
+++ b/module/sid/src/mod_sid.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -67,8 +67,8 @@ static int sid_init(
 
     sid_reg = (struct sid_reg *)config->sid_base;
 
-    fwk_assert(
-        mod_pcid_check_registers(&sid_reg->pcid, &config->pcid_expected));
+    fwk_assert(mod_pcid_check_registers(
+        &sid_reg->pcid, &config->pcid_expected, config->valid_pcid_registers));
 
     info.system_major_revision =
         (sid_reg->SYSTEM_ID & SID_SYS_SOC_ID_MAJOR_REVISION_MASK)

--- a/product/rdn1e1/src/config_sid.c
+++ b/product/rdn1e1/src/config_sid.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -37,6 +37,16 @@ static const struct fwk_element *get_subsystem_table(fwk_id_t id)
 const struct fwk_module_config config_sid = {
     .data = &(struct mod_sid_config) {
         .sid_base = SCP_SID_BASE,
+        .valid_pcid_registers =
+            MOD_PCID_REGISTER_PID0 |
+            MOD_PCID_REGISTER_PID1 |
+            MOD_PCID_REGISTER_PID2 |
+            MOD_PCID_REGISTER_PID3 |
+            MOD_PCID_REGISTER_PID4 |
+            MOD_PCID_REGISTER_CID0 |
+            MOD_PCID_REGISTER_CID1 |
+            MOD_PCID_REGISTER_CID2 |
+            MOD_PCID_REGISTER_CID3,
         .pcid_expected = {
             .PID0 = 0xD2,
             .PID1 = 0xB0,

--- a/product/rdn2/src/config_sid.c
+++ b/product/rdn2/src/config_sid.c
@@ -41,6 +41,16 @@ static const struct fwk_element *get_subsystem_table(fwk_id_t id)
 const struct fwk_module_config config_sid = {
     .data = &(struct mod_sid_config) {
         .sid_base = SCP_SID_BASE,
+        .valid_pcid_registers =
+            MOD_PCID_REGISTER_PID0 |
+            MOD_PCID_REGISTER_PID1 |
+            MOD_PCID_REGISTER_PID2 |
+            MOD_PCID_REGISTER_PID3 |
+            MOD_PCID_REGISTER_PID4 |
+            MOD_PCID_REGISTER_CID0 |
+            MOD_PCID_REGISTER_CID1 |
+            MOD_PCID_REGISTER_CID2 |
+            MOD_PCID_REGISTER_CID3,
         .pcid_expected = {
             .PID0 = 0xBC,
             .PID1 = 0xB0,

--- a/product/rdn2/src/config_sid.c
+++ b/product/rdn2/src/config_sid.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -42,7 +42,7 @@ const struct fwk_module_config config_sid = {
     .data = &(struct mod_sid_config) {
         .sid_base = SCP_SID_BASE,
         .pcid_expected = {
-            .PID0 = 0xD2,
+            .PID0 = 0xBC,
             .PID1 = 0xB0,
             .PID2 = 0x0B,
             .PID3 = 0x00,

--- a/product/rdv1/src/config_sid.c
+++ b/product/rdv1/src/config_sid.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -30,6 +30,16 @@ static const struct fwk_element *get_subsystem_table(fwk_id_t id)
 const struct fwk_module_config config_sid = {
     .data = &(struct mod_sid_config) {
         .sid_base = SCP_SID_BASE,
+        .valid_pcid_registers =
+            MOD_PCID_REGISTER_PID0 |
+            MOD_PCID_REGISTER_PID1 |
+            MOD_PCID_REGISTER_PID2 |
+            MOD_PCID_REGISTER_PID3 |
+            MOD_PCID_REGISTER_PID4 |
+            MOD_PCID_REGISTER_CID0 |
+            MOD_PCID_REGISTER_CID1 |
+            MOD_PCID_REGISTER_CID2 |
+            MOD_PCID_REGISTER_CID3,
         .pcid_expected = {
             .PID0 = 0xD2,
             .PID1 = 0xB0,

--- a/product/rdv1mc/src/config_sid.c
+++ b/product/rdv1mc/src/config_sid.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2020-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2020-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -30,6 +30,16 @@ static const struct fwk_element *get_subsystem_table(fwk_id_t id)
 const struct fwk_module_config config_sid = {
     .data = &(struct mod_sid_config) {
         .sid_base = SCP_SID_BASE,
+        .valid_pcid_registers =
+            MOD_PCID_REGISTER_PID0 |
+            MOD_PCID_REGISTER_PID1 |
+            MOD_PCID_REGISTER_PID2 |
+            MOD_PCID_REGISTER_PID3 |
+            MOD_PCID_REGISTER_PID4 |
+            MOD_PCID_REGISTER_CID0 |
+            MOD_PCID_REGISTER_CID1 |
+            MOD_PCID_REGISTER_CID2 |
+            MOD_PCID_REGISTER_CID3,
         .pcid_expected = {
             .PID0 = 0xD2,
             .PID1 = 0xB0,

--- a/product/sgm775/src/config_sid.c
+++ b/product/sgm775/src/config_sid.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -32,6 +32,7 @@ static const struct fwk_element *get_subsystem_table(fwk_id_t id)
 struct fwk_module_config config_sid = {
     .data = &(struct mod_sid_config) {
         .sid_base = SSC_BASE,
+        .valid_pcid_registers = MOD_PCID_REGISTER_ALL,
         .pcid_expected = {
             .PID0 = 0x44,
             .PID1 = 0xB8,

--- a/product/sgm776/src/config_sid.c
+++ b/product/sgm776/src/config_sid.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2017-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -38,6 +38,7 @@ static const struct fwk_element *get_subsystem_table(fwk_id_t id)
 struct fwk_module_config config_sid = {
     .data = &(struct mod_sid_config) {
         .sid_base = SID_BASE,
+        .valid_pcid_registers = MOD_PCID_REGISTER_ALL,
         .pcid_expected = {
             .PID0 = 0xB9,
             .PID1 = 0xB0,


### PR DESCRIPTION
Certain peripherals have only a partial set of valid PID and CID
identification registers. On such peripherals, the PID and CID
register address offsets remain the same even though only a partial
set of registers are valid. Reading the invalid PID/CID registers
lead to a implementation specific behaviour. For example, such
reads could cause bus aborts.

For the supported platforms, allow the module configuration data to
specify the valid set of PID/CID registers to be compared. The valid
set of registers are represented as a bitmap.

Peripherals could implement a smaller set of PID/CID registers for its
identification and reading unimplemented registers could cause aborts.
So allow modules to specify a valid set of PID/CID register values
that have to be examined against a set of expected values.