### PR TITLE
SMCF: Fix enablement of START and END sample identifiers in WRCFG

### DIFF
--- a/module/smcf/src/mgi.c
+++ b/module/smcf/src/mgi.c
@@ -514,6 +514,7 @@ void mgi_enable_group_id_write_to_ram(struct smcf_mgi_reg *smcf_mgi)
 
 void mgi_request_start_id_wirte_to_ram(struct smcf_mgi_reg *smcf_mgi)
 {
+    smcf_mgi->WRCFG &= ~(SMCF_MGI_WRCFG_NUM_SAMPLE_ID);
     smcf_mgi->WRCFG |=
         (SMCF_MGI_WRCFG_WRITE_START_SAMPLE_ID
          << SMCF_MGI_WRCFG_NUM_SAMPLE_ID_POS);
@@ -521,7 +522,8 @@ void mgi_request_start_id_wirte_to_ram(struct smcf_mgi_reg *smcf_mgi)
 
 void mgi_request_start_and_end_id_wirte_to_ram(struct smcf_mgi_reg *smcf_mgi)
 {
+    smcf_mgi->WRCFG &= ~(SMCF_MGI_WRCFG_NUM_SAMPLE_ID);
     smcf_mgi->WRCFG |=
         (SMCF_MGI_WRCFG_WRITE_START_AND_END_SAMPLE_ID
-         << SMCF_MGI_WRCFG_NUM_SAMPLE_ID_POS);
+         << (SMCF_MGI_WRCFG_NUM_SAMPLE_ID_POS));
 }

--- a/module/smcf/test/mgi/mgi_unit_test.c
+++ b/module/smcf/test/mgi/mgi_unit_test.c
@@ -753,10 +753,38 @@ void utest_mgi_request_start_id_write_to_ram(void)
     TEST_ASSERT_BITS(0b11 << 4, 0b01 << 4, mgi.WRCFG);
 }
 
+void utest_mgi_request_start_id_write_to_ram_on_start_end_id_enabled(void)
+{
+    /* WRCFG: START and END sample identifiers are already enabled */
+    struct smcf_mgi_reg mgi = {
+        .WRCFG =
+            (SMCF_MGI_WRCFG_WRITE_START_AND_END_SAMPLE_ID
+             << SMCF_MGI_WRCFG_NUM_SAMPLE_ID_POS),
+    };
+
+    mgi_request_start_id_wirte_to_ram(&mgi);
+
+    TEST_ASSERT_BITS(0b11 << 4, 0b01 << 4, mgi.WRCFG);
+}
+
 void utest_mgi_request_start_and_end_id_write_to_ram(void)
 {
     struct smcf_mgi_reg mgi = {
         .WRCFG = 0,
+    };
+
+    mgi_request_start_and_end_id_wirte_to_ram(&mgi);
+
+    TEST_ASSERT_BITS(0b11 << 4, 0b10 << 4, mgi.WRCFG);
+}
+
+void utest_mgi_request_start_and_end_id_write_to_ram_on_start_id_enabled(void)
+{
+    /* WRCFG: START sample identifier is already enabled */
+    struct smcf_mgi_reg mgi = {
+        .WRCFG =
+            (SMCF_MGI_WRCFG_WRITE_START_SAMPLE_ID
+             << SMCF_MGI_WRCFG_NUM_SAMPLE_ID_POS),
     };
 
     mgi_request_start_and_end_id_wirte_to_ram(&mgi);
@@ -812,7 +840,10 @@ int mgi_test_main(void)
     RUN_TEST(utest_mgi_enable_valid_bits_write_to_ram);
     RUN_TEST(utest_mgi_enable_group_id_write_to_ram);
     RUN_TEST(utest_mgi_request_start_id_write_to_ram);
+    RUN_TEST(utest_mgi_request_start_id_write_to_ram_on_start_end_id_enabled);
     RUN_TEST(utest_mgi_request_start_and_end_id_write_to_ram);
+    RUN_TEST(
+        utest_mgi_request_start_and_end_id_write_to_ram_on_start_id_enabled);
     return UNITY_END();
 }
 


### PR DESCRIPTION
This change fixes the enablement of start and end sample identifiers. Currently if start sample identifier is already enabled and then end identifier is also requested, it results in WRCFG.NUM_SAMPLE_ID to be written with an invalid value 0b11 whereas the expected value as per specification is 0b10 to enable both START and END sample identifiers in data header.