### PR TITLE
smcf_utils: Utility for helping with the configuration.

### DIFF
--- a/module/smcf/CMakeLists.txt
+++ b/module/smcf/CMakeLists.txt
@@ -13,4 +13,5 @@ target_include_directories(${SCP_MODULE_TARGET}
 target_sources(
     ${SCP_MODULE_TARGET} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/mod_smcf.c"
                                  "${CMAKE_CURRENT_SOURCE_DIR}/src/smcf_data.c"
+                                 "${CMAKE_CURRENT_SOURCE_DIR}/src/smcf_utils.c"
                                  "${CMAKE_CURRENT_SOURCE_DIR}/src/mgi.c")

--- a/module/smcf/include/smcf_utils.h
+++ b/module/smcf/include/smcf_utils.h
@@ -1,0 +1,18 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef __SMCF_UTIL_H
+#define __SMCF_UTIL_H
+
+#include <stdint.h>
+
+uint32_t get_next_smcf_ram_offset(
+    uint32_t this_offset,
+    uint32_t header_format,
+    uint32_t data_size,
+    uint32_t tag_len_in_bits);
+
+#endif

--- a/module/smcf/src/smcf_utils.c
+++ b/module/smcf/src/smcf_utils.c
@@ -1,0 +1,70 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "smcf_data.h"
+#include "smcf_utils.h"
+
+#include <stddef.h>
+
+#define SMCF_UTILS_ALIGNMENT UINT32_C(4)
+#define WORD_SIZE            UINT32_C(4)
+#define DOUBLE_WORD_SIZE     UINT32_C(8)
+
+#define NUM_OF_BYTES(x) (x / 8)
+
+static uint32_t memory_align(uint32_t address, size_t alignment)
+{
+    uint32_t compensation = 0;
+
+    if ((address % alignment) != 0) {
+        compensation = alignment - (address % alignment);
+    }
+
+    address = address + compensation;
+
+    return address;
+}
+
+uint32_t get_next_smcf_ram_offset(
+    uint32_t this_offset,
+    uint32_t header_format,
+    uint32_t data_size,
+    uint32_t tag_len_in_bits)
+{
+    uint32_t header_size = 0;
+    uint32_t next_offset = 0;
+
+    if ((header_format & SMCF_SAMPLE_HEADER_FORMAT_GROUP_ID) != 0) {
+        header_size += WORD_SIZE;
+    }
+
+    if ((header_format & SMCF_SAMPLE_HEADER_FORMAT_DATA_VALID_BITS) != 0) {
+        header_size += WORD_SIZE;
+    }
+
+    if ((header_format & SMCF_SAMPLE_HEADER_FORMAT_COUNT_ID) != 0) {
+        header_size += WORD_SIZE;
+
+        if ((header_format & SMCF_SAMPLE_HEADER_FORMAT_END_ID) != 0) {
+            header_size += WORD_SIZE;
+        }
+    }
+
+    if ((header_format & SMCF_SAMPLE_HEADER_FORMAT_TAG_ID) != 0) {
+        uint32_t tag_lenght_in_bytes = NUM_OF_BYTES(tag_len_in_bits);
+        header_size += WORD_SIZE + tag_lenght_in_bytes;
+
+        if ((header_format & SMCF_SAMPLE_HEADER_FORMAT_END_ID) != 0) {
+            header_size += WORD_SIZE + tag_lenght_in_bytes;
+        }
+    }
+
+    next_offset = this_offset + header_size + data_size;
+    next_offset = memory_align(next_offset, SMCF_UTILS_ALIGNMENT);
+
+    return next_offset;
+}

--- a/module/smcf/test/CMakeLists.txt
+++ b/module/smcf/test/CMakeLists.txt
@@ -13,3 +13,6 @@ include(${SCP_ROOT}/module/smcf/test/module/mod_smcf.cmake)
 
 set(TEST_MODULE smcf)
 include(${SCP_ROOT}/module/smcf/test/smcf_data/mod_smcf_data.cmake)
+
+set(TEST_MODULE smcf)
+include(${SCP_ROOT}/module/smcf/test/smcf_utils/mod_smcf_utils.cmake)

--- a/module/smcf/test/smcf_utils/fwk_module_idx.h
+++ b/module/smcf/test/smcf_utils/fwk_module_idx.h
@@ -1,0 +1,18 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef TEST_FWK_MODULE_MODULE_IDX_H
+#define TEST_FWK_MODULE_MODULE_IDX_H
+
+#include <fwk_id.h>
+
+enum fwk_module_idx {
+    FWK_MODULE_IDX_SMCF,
+    FWK_MODULE_IDX_COUNT,
+};
+
+#endif /* TEST_FWK_MODULE_MODULE_IDX_H */

--- a/module/smcf/test/smcf_utils/mod_smcf_utils.cmake
+++ b/module/smcf/test/smcf_utils/mod_smcf_utils.cmake
@@ -1,0 +1,31 @@
+#
+# Arm SCP/MCP Software
+# Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set(TEST_SRC smcf_utils)
+set(TEST_FILE smcf_utils)
+
+if(TEST_ON_TARGET)
+    set(TEST_MODULE smcf)
+    set(MODULE_ROOT ${CMAKE_SOURCE_DIR}/module)
+else()
+    set(TEST_FILE smcf_utils)
+    set(UNIT_TEST_TARGET ${TEST_FILE}_unit_test)
+endif()
+
+set(MODULE_SRC ${MODULE_ROOT}/${TEST_MODULE}/src)
+set(MODULE_INC ${MODULE_ROOT}/${TEST_MODULE}/include)
+set(MODULE_UT_SRC ${CMAKE_CURRENT_LIST_DIR})
+set(MODULE_UT_INC ${CMAKE_CURRENT_LIST_DIR})
+
+list(APPEND MOCK_REPLACEMENTS fwk_module)
+
+if(NOT TEST_ON_TARGET)
+    set(TEST_FILE smcf_utils)
+    set(UNIT_TEST_TARGET ${TEST_FILE}_unit_test)
+endif()
+
+Include(${SCP_ROOT}/unit_test/module_common.cmake)

--- a/module/smcf/test/smcf_utils/smcf_utils_unit_test.c
+++ b/module/smcf/test/smcf_utils/smcf_utils_unit_test.c
@@ -1,0 +1,161 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "mod_smcf_data.h"
+#include "scp_unity.h"
+#include "smcf_utils.h"
+#include "stdint.h"
+#include "unity.h"
+
+#include <strings.h>
+
+#define SMCF_RAM_START_ADDRESS UINT32_C(0x51000000)
+#define SMCF_TAG_LENGTH        UINT32_C(64)
+
+/* MGI_COUNTER_SIZE: the current size of counter in bytes */
+#define MGI_COUNTER_SIZE UINT32_C(8)
+
+/* MGI_NUMBER_OF_COUNTER: the current number of counters */
+#define MGI_NUMBER_OF_COUNTER UINT32_C(7)
+
+/* MGI_PADDING: spacing between Archi and Aux counters */
+#define MGI_PADDING UINT32_C(224)
+
+#define MGI_COUNTER_DATA_SIZE \
+    ((MGI_COUNTER_SIZE * MGI_NUMBER_OF_COUNTER) + MGI_PADDING)
+#define MGI_SENSOR_DATA_SIZE UINT32_C(4)
+
+#include UNIT_TEST_SRC
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void calculate_mgi_sesnsor_next_ram_offset(void)
+{
+    uint32_t header = SMCF_SAMPLE_HEADER_FORMAT_GROUP_ID |
+        SMCF_SAMPLE_HEADER_FORMAT_DATA_VALID_BITS |
+        SMCF_SAMPLE_HEADER_FORMAT_COUNT_ID | SMCF_SAMPLE_HEADER_FORMAT_TAG_ID |
+        SMCF_SAMPLE_HEADER_FORMAT_END_ID;
+
+    uint32_t next_ram_offces;
+
+    next_ram_offces = get_next_smcf_ram_offset(
+        SMCF_RAM_START_ADDRESS, header, MGI_SENSOR_DATA_SIZE, SMCF_TAG_LENGTH);
+
+    TEST_ASSERT_EQUAL(next_ram_offces, (SMCF_RAM_START_ADDRESS + 0x2C));
+}
+
+void calculate_mgi_sesnsor_next_ram_offset_header_zero(void)
+{
+    uint32_t header = 0;
+
+    uint32_t next_ram_offces;
+
+    next_ram_offces = get_next_smcf_ram_offset(
+        SMCF_RAM_START_ADDRESS, header, MGI_SENSOR_DATA_SIZE, SMCF_TAG_LENGTH);
+
+    TEST_ASSERT_EQUAL(next_ram_offces, (SMCF_RAM_START_ADDRESS + 0x04));
+}
+
+void calculate_mgi_amu_next_ram_offset(void)
+{
+    uint32_t header = SMCF_SAMPLE_HEADER_FORMAT_GROUP_ID |
+        SMCF_SAMPLE_HEADER_FORMAT_DATA_VALID_BITS |
+        SMCF_SAMPLE_HEADER_FORMAT_COUNT_ID | SMCF_SAMPLE_HEADER_FORMAT_TAG_ID |
+        SMCF_SAMPLE_HEADER_FORMAT_END_ID;
+
+    uint32_t next_ram_offces;
+
+    next_ram_offces = get_next_smcf_ram_offset(
+        SMCF_RAM_START_ADDRESS, header, MGI_COUNTER_DATA_SIZE, SMCF_TAG_LENGTH);
+
+    TEST_ASSERT_EQUAL(next_ram_offces, (SMCF_RAM_START_ADDRESS + 0x140));
+}
+
+void calculate_mgi_amu_next_ram_offset_header_zero(void)
+{
+    uint32_t header = 0;
+
+    uint32_t next_ram_offces;
+
+    next_ram_offces = get_next_smcf_ram_offset(
+        SMCF_RAM_START_ADDRESS, header, MGI_COUNTER_DATA_SIZE, SMCF_TAG_LENGTH);
+
+    TEST_ASSERT_EQUAL(next_ram_offces, (SMCF_RAM_START_ADDRESS + 0x118));
+}
+
+void calculate_overall_memory_consumption(void)
+{
+    uint32_t header = SMCF_SAMPLE_HEADER_FORMAT_GROUP_ID |
+        SMCF_SAMPLE_HEADER_FORMAT_DATA_VALID_BITS |
+        SMCF_SAMPLE_HEADER_FORMAT_COUNT_ID | SMCF_SAMPLE_HEADER_FORMAT_TAG_ID |
+        SMCF_SAMPLE_HEADER_FORMAT_END_ID;
+
+    uint32_t next_ram_offces = SMCF_RAM_START_ADDRESS;
+
+    for (uint8_t index = 0; index < 16; index++) {
+        next_ram_offces = get_next_smcf_ram_offset(
+            next_ram_offces, header, MGI_SENSOR_DATA_SIZE, SMCF_TAG_LENGTH);
+    }
+
+    for (uint8_t index = 0; index < 16; index++) {
+        next_ram_offces = get_next_smcf_ram_offset(
+            next_ram_offces, header, MGI_COUNTER_DATA_SIZE, SMCF_TAG_LENGTH);
+    }
+
+    TEST_ASSERT_EQUAL(next_ram_offces, (SMCF_RAM_START_ADDRESS + 0x16C0));
+}
+
+void utest_memory_align_sending_not_alligned_address_with_32bit(void)
+{
+    int address = 30;
+    int allignement = 4;
+
+    int result = memory_align(address, allignement);
+
+    TEST_ASSERT_EQUAL(32, result);
+}
+
+void utest_memory_align_sending_alligned_address_with_32bit(void)
+{
+    int address = 20;
+    int allignement = 4;
+
+    int result = memory_align(address, allignement);
+
+    TEST_ASSERT_EQUAL(20, result);
+}
+
+int smcf_data_test_main(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(calculate_mgi_sesnsor_next_ram_offset);
+    RUN_TEST(calculate_mgi_sesnsor_next_ram_offset_header_zero);
+
+    RUN_TEST(calculate_mgi_amu_next_ram_offset);
+    RUN_TEST(calculate_mgi_amu_next_ram_offset_header_zero);
+
+    RUN_TEST(calculate_overall_memory_consumption);
+
+    RUN_TEST(utest_memory_align_sending_not_alligned_address_with_32bit);
+    RUN_TEST(utest_memory_align_sending_alligned_address_with_32bit);
+
+    return UNITY_END();
+}
+
+#if !defined(TEST_ON_TARGET)
+int main(void)
+{
+    return smcf_data_test_main();
+}
+#endif


### PR DESCRIPTION
Add a helper function to configure SMCF RAM based on SMCF header configuration and data size.