### PR TITLE
ppu power status

### DIFF
--- a/module/ppu_v0/src/mod_ppu_v0.c
+++ b/module/ppu_v0/src/mod_ppu_v0.c
@@ -89,7 +89,7 @@ static int get_state(struct ppu_v0_reg *ppu, unsigned int *state)
 
     *state = ppu_mode_to_power_state[ppu_mode];
     if (*state == MODE_UNSUPPORTED) {
-        FWK_LOG_ERR("[PD] Unexpected PPU mode (%i).", ppu_mode);
+        FWK_LOG_ERR("[PPU] Unexpected PPU mode (%i).", ppu_mode);
         return FWK_E_DEVICE;
     }
 
@@ -143,7 +143,8 @@ static int pd_set_state(fwk_id_t pd_id, unsigned int state)
         break;
 
     default:
-        FWK_LOG_ERR("[PD] Requested power state (%i) is not supported.", state);
+        FWK_LOG_ERR(
+            "[PPU] Requested power state (%i) is not supported.", state);
         return FWK_E_PARAM;
     }
 

--- a/module/ppu_v1/src/mod_ppu_v1.c
+++ b/module/ppu_v1/src/mod_ppu_v1.c
@@ -169,7 +169,8 @@ static int ppu_v1_pd_set_state(fwk_id_t pd_id, unsigned int state)
         break;
 
     default:
-        FWK_LOG_ERR("[PD] Requested power state (%i) is not supported.", state);
+        FWK_LOG_ERR(
+            "[PPU] Requested power state (%i) is not supported.", state);
         return FWK_E_PARAM;
     }
 

--- a/module/ppu_v1/src/mod_ppu_v1.c
+++ b/module/ppu_v1/src/mod_ppu_v1.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -134,22 +134,37 @@ static int get_state(struct ppu_v1_reg *ppu, unsigned int *state)
 static int ppu_v1_pd_set_state(fwk_id_t pd_id, unsigned int state)
 {
     int status;
+    unsigned int pd_mod_state;
     struct ppu_v1_pd_ctx *pd_ctx;
 
     pd_ctx = ppu_v1_ctx.pd_ctx_table + fwk_id_get_element_idx(pd_id);
 
     switch (state) {
     case MOD_PD_STATE_ON:
-        ppu_v1_set_power_mode(pd_ctx->ppu, PPU_V1_MODE_ON, pd_ctx->timer_ctx);
+        status = ppu_v1_set_power_mode(
+            pd_ctx->ppu, PPU_V1_MODE_ON, pd_ctx->timer_ctx);
+        if (status == FWK_SUCCESS) {
+            pd_mod_state = state;
+        } else {
+            get_state(pd_ctx->ppu, &pd_mod_state);
+        }
+
         status = pd_ctx->pd_driver_input_api->report_power_state_transition(
-            pd_ctx->bound_id, MOD_PD_STATE_ON);
+            pd_ctx->bound_id, pd_mod_state);
         fwk_assert(status == FWK_SUCCESS);
         break;
 
     case MOD_PD_STATE_OFF:
-        ppu_v1_set_power_mode(pd_ctx->ppu, PPU_V1_MODE_OFF, pd_ctx->timer_ctx);
+        status = ppu_v1_set_power_mode(
+            pd_ctx->ppu, PPU_V1_MODE_OFF, pd_ctx->timer_ctx);
+        if (status == FWK_SUCCESS) {
+            pd_mod_state = state;
+        } else {
+            get_state(pd_ctx->ppu, &pd_mod_state);
+        }
+
         status = pd_ctx->pd_driver_input_api->report_power_state_transition(
-            pd_ctx->bound_id, MOD_PD_STATE_OFF);
+            pd_ctx->bound_id, pd_mod_state);
         fwk_assert(status == FWK_SUCCESS);
         break;
 

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -65,10 +65,10 @@ nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:65
 nullPointerRedundantCheck:*module/mhu2/src/mod_mhu2.c:90
 nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:135
 nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:136
-nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:624
-nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:634
-nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:957
+nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:625
+nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:635
 nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:958
+nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:959
 nullPointerRedundantCheck:*module/reg_sensor/src/mod_reg_sensor.c:52
 nullPointerRedundantCheck:*module/sds/src/mod_sds.c:273
 nullPointerRedundantCheck:*module/sds/src/mod_sds.c:279

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -65,11 +65,10 @@ nullPointerRedundantCheck:*module/dmc500/src/mod_dmc500.c:65
 nullPointerRedundantCheck:*module/mhu2/src/mod_mhu2.c:90
 nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:135
 nullPointerRedundantCheck:*module/pl011/src/mod_pl011.c:136
-nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:609
-nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:620
-nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:642
-nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:942
-nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:943
+nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:624
+nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:634
+nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:957
+nullPointerRedundantCheck:*module/ppu_v1/src/mod_ppu_v1.c:958
 nullPointerRedundantCheck:*module/reg_sensor/src/mod_reg_sensor.c:52
 nullPointerRedundantCheck:*module/sds/src/mod_sds.c:273
 nullPointerRedundantCheck:*module/sds/src/mod_sds.c:279


### PR DESCRIPTION
After set power received, PPU report the current power state hardcoded without
any check the HW state.

Return the current power status if the set power return in successful
state otherwise get the current power status from direct reading HW.

Fix error messages logs by replacing [PD] by [PPU].