### PR TITLE
Thermal management

### DIFF
--- a/module/thermal_mgmt/doc/thermal_mgmt.md
+++ b/module/thermal_mgmt/doc/thermal_mgmt.md
@@ -136,6 +136,9 @@ value as long as the power model can work with it.
 The temperature above which the Thermal Mgmt algorithm will run. The unit needs
 to be consistent with the value provided by the targeted temperature sensor.
 
+`cold_state_power`
+Power limit used in cold state - temperature is below the switch_on_temperature.
+
 `control_temperature`
 The control temperature for the platform. Above this temperature the Thermal
 Mgmt will limit the power/performance.

--- a/module/thermal_mgmt/include/mod_thermal_mgmt.h
+++ b/module/thermal_mgmt/include/mod_thermal_mgmt.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -125,6 +125,9 @@ struct mod_thermal_mgmt_dev_config {
 
     /*! The thermal design power (TDP) for all the devices being controlled */
     uint16_t tdp;
+
+    /*! The cold state power */
+    uint16_t cold_state_power;
 
     /*!
      * \brief Switch-on temperature threshold.

--- a/module/thermal_mgmt/src/mod_thermal_mgmt.c
+++ b/module/thermal_mgmt/src/mod_thermal_mgmt.c
@@ -46,7 +46,8 @@ static void pi_control(fwk_id_t id)
         dev_ctx->config->pi_controller.switch_on_temperature) {
         /* The PI loop is not activated */
         dev_ctx->integral_error = 0;
-        dev_ctx->thermal_allocatable_power = (uint32_t)dev_ctx->config->tdp;
+        dev_ctx->thermal_allocatable_power =
+            (uint32_t)dev_ctx->config->cold_state_power;
 
         return;
     }

--- a/module/thermal_mgmt/test/mod_thermal_mgmt_unit_test.c
+++ b/module/thermal_mgmt/test/mod_thermal_mgmt_unit_test.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -483,7 +483,8 @@ void test_thermal_mgmt_pi_control_switched_off(void)
     pi_control(element_id);
     TEST_ASSERT_EQUAL(dev_ctx->integral_error, 0);
     TEST_ASSERT_EQUAL(
-        dev_ctx->thermal_allocatable_power, (uint32_t)dev_ctx->config->tdp);
+        dev_ctx->thermal_allocatable_power,
+        (uint32_t)dev_ctx->config->cold_state_power);
 }
 
 void test_thermal_mgmt_pi_control_anti_windup(void)

--- a/product/totalcompute/tc2/scp_ramfw/config_thermal_mgmt.c
+++ b/product/totalcompute/tc2/scp_ramfw/config_thermal_mgmt.c
@@ -40,6 +40,7 @@ static const struct fwk_element thermal_mgmt_domains_elem_table[2] = {
         .data = &((struct mod_thermal_mgmt_dev_config){
             .slow_loop_mult = 25,
             .tdp = 10,
+            .cold_state_power = 11,
             .pi_controller = {
                 .switch_on_temperature = 50,
                 .control_temperature = 60,


### PR DESCRIPTION
Add cold_state_power configuration to be used instead of TDP when
temperature is below `switch_on_temperature`.
To accommodate the cases where it's possible not to limit or use
different limits than TDP for the distributable power when
the system is "cold."
Configure cold state power of thermal management in TC2.
