### PR TITLE
increment nest counter inside critical section

### DIFF
--- a/arch/arm/arm-m/include/arch_helpers.h
+++ b/arch/arm/arm-m/include/arch_helpers.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -43,12 +43,8 @@ inline static void arch_interrupts_enable(unsigned int not_used)
  */
 inline static unsigned int arch_interrupts_disable(void)
 {
+    __disable_irq();
     critical_section_nest_level++;
-
-    /* If now in outer-most critical section, disable interrupts globally */
-    if (critical_section_nest_level == 1) {
-        __disable_irq();
-    }
 
     return 0;
 }

--- a/arch/arm/armv8-a/include/arch_helpers.h
+++ b/arch/arm/armv8-a/include/arch_helpers.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2013-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -582,12 +582,8 @@ inline static void arch_interrupts_enable(unsigned int not_used)
  */
 inline static unsigned int arch_interrupts_disable()
 {
+    disable_irq();
     critical_section_nest_level++;
-
-    /* If now in outer-most critical section, disable interrupts globally */
-    if (critical_section_nest_level == 1) {
-        disable_irq();
-    }
 
     return 0;
 }


### PR DESCRIPTION
The implementation for arch_interrupts_disable is incrementing the nest counter outside the critical section. This can lead to unexpected behavior because there is no guarantee the counter will be incremented atomically.

This change first aquires the critical section (by disabling irqs) then increments the counter thus guarantees the counter will be incremented atomically.