### PR TITLE
fwk_list: Add a watermark to monitor list max sizes

### DIFF
--- a/doc/cmake_readme.md
+++ b/doc/cmake_readme.md
@@ -122,6 +122,11 @@ few common options can be configured.
 - `SCP_ENABLE_ATU_DELEGATE`: Enable/disable ATU delegation support. This option
   should be enabled when the ATU is not managed directly by the firmware.
 
+- `SCP_ENABLE_FWK_EVENT_WATERMARK_TRACING`: Enable/disable tracing for event
+  queues.
+
+- `SCP_ENABLE_MARKED_LIST`: Enable/disable calculations of list max size.
+
 - `SCP_ENABLE_FAST_CHANNELS`: Enable/disable Fast Channels support. This
   option should be enabled/disabled by the use of a platform specific setting
   like `SCP_ENABLE_SCMI_PERF_FAST_CHANNELS`.

--- a/doc/framework.md
+++ b/doc/framework.md
@@ -616,6 +616,11 @@ The driver module can then access its log framework related configuration data
 at any time. It is expected that the driver module performs initialization using
 this configuration data in the fwk_log_driver_init() function.
 
+#### Enable marked list feature
+
+When `SCP_ENABLE_MARKED_LIST` is set, the maximum size of linked list will be
+traced and marked.
+
 #### Tracing
 To enable tracing functionality `FWK_TRACE_ENABLE` should be defined.
 There is an example configuration for CMake that should be included in

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -40,6 +40,15 @@ target_sources(
             "${CMAKE_CURRENT_SOURCE_DIR}/src/stdlib.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/src/fwk_core.c")
 
+if(SCP_ENABLE_FWK_EVENT_WATERMARK_TRACING)
+    target_compile_definitions(framework
+                                PUBLIC "FWK_EVENTS_WATERMARK_TRACE_ENABLE")
+    set(SCP_ENABLE_MARKED_LIST TRUE)
+endif()
+
+if(SCP_ENABLE_MARKED_LIST)
+    target_compile_definitions(framework PUBLIC "FWK_MARKED_LIST_ENABLE")
+endif()
 
 if(SCP_ENABLE_SUB_SYSTEM_MODE)
     target_compile_definitions(framework PUBLIC "BUILD_HAS_SUB_SYSTEM_MODE")

--- a/framework/include/fwk_dlist.h
+++ b/framework/include/fwk_dlist.h
@@ -24,11 +24,25 @@
  */
 
 /*!
+ * \brief marks used for marked slist.
+ *
+ * \internal
+ * \note This structure used in case of needed to mark dlist
+ */
+struct fwk_dlist_marks {
+    /*! Current numbers of dlist elements */
+    unsigned int current_count;
+
+    /*! Maximum marked elements in dlist */
+    unsigned int max_count;
+};
+
+/*!
  * \brief Doubly-linked list.
  *
  * \internal
- * \note This structure can be safely used in the place of ::fwk_slist,
- *      ::fwk_slist_node, or ::fwk_dlist_node.
+ * \note This structure can be safely used in the place of ::fwk_dlist,
+ *      ::fwk_dlist_node, or ::fwk_dlist_node.
  */
 struct fwk_dlist {
     /*! Pointer to the list head */
@@ -36,13 +50,18 @@ struct fwk_dlist {
 
     /*! Pointer to the list tail */
     struct fwk_dlist_node *tail;
+
+#ifdef FWK_MARKED_LIST_ENABLE
+    /*! save the mark for maximum usage of dlist */
+    struct fwk_dlist_marks marks;
+#endif
 };
 
 /*!
  * \brief Doubly-linked list node.
  *
  * \internal
- * \note This structure can be safely used in the place of ::fwk_slist_node.
+ * \note This structure can be safely used in the place of ::fwk_dlist_node.
  */
 struct fwk_dlist_node {
     /*! Pointer to the next node in the list */
@@ -106,6 +125,17 @@ void __fwk_dlist_insert(
     struct fwk_dlist_node *restrict new,
     struct fwk_dlist_node *restrict node) FWK_LEAF FWK_NOTHROW FWK_NONNULL(1)
     FWK_NONNULL(2) FWK_READ_WRITE1(1) FWK_READ_WRITE1(2) FWK_READ_WRITE1(3);
+
+#ifdef FWK_MARKED_LIST_ENABLE
+/*
+ * Return max size of dlist.
+ *
+ * For internal use only.
+ * See __fwk_dlist_get_max(list) for the public interface.
+ */
+int __fwk_dlist_get_max(const struct fwk_dlist *list) FWK_LEAF FWK_NOTHROW
+    FWK_NONNULL(1) FWK_READ_ONLY1(1);
+#endif
 
 /*!
  * @endcond

--- a/framework/include/fwk_list.h
+++ b/framework/include/fwk_list.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2015-2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -218,6 +218,23 @@
         node != NULL; \
         node = fwk_list_next(list, node), \
         elem = FWK_LIST_GET(node, type, member))
+
+/*!
+ * \brief Get maximum size of list.
+ *
+ * \param list Pointer to the list to get max list size. Must not be \c NULL.
+ *
+ * \retval Zero The list was never used.
+ * \return The maximum number of elements as a mark for the maximum size.
+ */
+#ifdef FWK_MARKED_LIST_ENABLE
+#    define fwk_list_get_max(list) \
+        _Generic((list), struct fwk_slist * \
+                 : __fwk_slist_get_max, struct fwk_dlist * \
+                 : __fwk_dlist_get_max)(list)
+#else
+#    define fwk_list_get_max(list) 0
+#endif
 
 /*!
  * \}

--- a/framework/include/fwk_slist.h
+++ b/framework/include/fwk_slist.h
@@ -26,6 +26,21 @@
  */
 
 /*!
+ * \brief marks used for marked slist.
+ *
+ * \internal
+ * \note This structure is used in case of needed to mark slist in case of
+ * FWK_MARKED_LIST_ENABLE is defined.
+ */
+struct fwk_slist_marks {
+    /*! Current numbers of slist elements */
+    unsigned int current_count;
+
+    /*! Maximum marked elements in slist */
+    unsigned int max_count;
+};
+
+/*!
  * \brief Singly-linked list.
  *
  * \internal
@@ -37,6 +52,11 @@ struct fwk_slist {
 
     /*! Pointer to the list tail */
     struct fwk_slist_node *tail;
+
+#ifdef FWK_MARKED_LIST_ENABLE
+    /*! save the mark for maximum usage of slist */
+    struct fwk_slist_marks marks;
+#endif
 };
 
 /*!
@@ -138,6 +158,17 @@ bool __fwk_slist_contains(
     const struct fwk_slist *list,
     const struct fwk_slist_node *node) FWK_PURE FWK_LEAF FWK_NOTHROW
     FWK_NONNULL(1) FWK_NONNULL(2) FWK_READ_ONLY1(1) FWK_READ_ONLY1(2);
+
+#ifdef FWK_MARKED_LIST_ENABLE
+/*
+ * Return max size of slist.
+ *
+ * For internal use only.
+ * See __fwk_slist_get_max(list) for the public interface.
+ */
+int __fwk_slist_get_max(const struct fwk_slist *list) FWK_LEAF FWK_NOTHROW
+    FWK_NONNULL(1) FWK_READ_ONLY1(1);
+#endif
 
 /*!
  * @endcond

--- a/framework/src/fwk_core.c
+++ b/framework/src/fwk_core.c
@@ -19,6 +19,11 @@
 #include <fwk_id.h>
 #include <fwk_interrupt.h>
 #include <fwk_list.h>
+
+#ifdef FWK_EVENTS_WATERMARK_TRACE_ENABLE
+#    define FWK_TRACE_ENABLE
+#endif
+
 #include <fwk_log.h>
 #include <fwk_mm.h>
 #include <fwk_module.h>
@@ -147,8 +152,16 @@ static int put_event(
     }
     if (intr_state == NOT_INTERRUPT_STATE) {
         fwk_list_push_tail(&ctx.event_queue, &allocated_event->slist_node);
+
+        FWK_TRACE(
+            "[FWK] event_queue peak: %d", fwk_list_get_max(&ctx.event_queue));
+
     } else {
         fwk_list_push_tail(&ctx.isr_event_queue, &allocated_event->slist_node);
+
+        FWK_TRACE(
+            "[FWK] isr_event_queue peak: %d",
+            fwk_list_get_max(&ctx.isr_event_queue));
     }
 
 #if FWK_LOG_LEVEL <= FWK_LOG_LEVEL_DEBUG
@@ -263,6 +276,8 @@ static bool process_isr(void)
 #endif
 
     fwk_list_push_tail(&ctx.event_queue, &isr_event->slist_node);
+
+    FWK_TRACE("[FWK] event_queue peak: %d", fwk_list_get_max(&ctx.event_queue));
 
     return true;
 }

--- a/framework/src/fwk_dlist.c
+++ b/framework/src/fwk_dlist.c
@@ -114,6 +114,13 @@ void __fwk_dlist_insert(
     node->prev = new;
 }
 
+#ifdef FWK_MARKED_LIST_ENABLE
+int __fwk_dlist_get_max(const struct fwk_dlist *list)
+{
+    return list->marks.max_count;
+}
+#endif
+
 static_assert(offsetof(struct fwk_dlist, head) ==
     offsetof(struct fwk_slist, head),
     "fwk_dlist::head not aligned with fwk_slist::head");

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -95,7 +95,7 @@ zerodivcond:*product/juno/module/juno_cdcel937/src/mod_juno_cdcel937.c:414
 syntaxError:*arch/arm/armv8-a/include/arch_system.h:19
 
 // Cppcheck is not able to parse returned boolean values inside if conditions
-internalAstError:*framework/src/fwk_core.c:297
+internalAstError:*framework/src/fwk_core.c:312
 
 // These assignments are used for testing
 constArgument:*framework/test/test_fwk_macros.c


### PR DESCRIPTION
Enable queue monitors and tracing the maximum queue elements as a watermark for both isr and event queues.

To enable queue monitor and watermark for tracing, `SCP_ENABLE_FWK_EVENT_WATERMARK_TRACING` shall be true.