### PR TITLE
TCx: Fix Resource Permissions inclusion in build

### DIFF
--- a/product/totalcompute/tc1/scp_ramfw/CMakeLists.txt
+++ b/product/totalcompute/tc1/scp_ramfw/CMakeLists.txt
@@ -46,6 +46,8 @@ target_sources(
 
 if(SCP_ENABLE_RESOURCE_PERMISSIONS)
     target_sources(tc1-bl2 PRIVATE "config_resource_perms.c")
+
+    list(APPEND SCP_MODULES "resource-perms")
 endif()
 
 #
@@ -62,3 +64,6 @@ target_link_libraries(tc1-bl2 PUBLIC cmsis::core-m)
 
 target_include_directories(tc1-bl2
     PUBLIC $<TARGET_PROPERTY:cmsis::core-m,INTERFACE_INCLUDE_DIRECTORIES>)
+
+set(SCP_MODULES ${SCP_MODULES} PARENT_SCOPE)
+set(SCP_MODULE_PATHS ${SCP_MODULE_PATHS} PARENT_SCOPE)

--- a/product/totalcompute/tc1/scp_ramfw/Firmware.cmake
+++ b/product/totalcompute/tc1/scp_ramfw/Firmware.cmake
@@ -54,7 +54,3 @@ list(APPEND SCP_MODULES "timer")
 list(APPEND SCP_MODULES "mock-psu")
 list(APPEND SCP_MODULES "psu")
 list(APPEND SCP_MODULES "tc-system")
-
-if(SCP_ENABLE_RESOURCE_PERMISSIONS)
-    list(APPEND SCP_MODULES,"resource-perms")
-endif()

--- a/product/totalcompute/tc2/scp_ramfw/CMakeLists.txt
+++ b/product/totalcompute/tc2/scp_ramfw/CMakeLists.txt
@@ -60,6 +60,10 @@ else()
         PUBLIC -DPLATFORM_VARIANT=TC2_VARIANT_STD)
 endif()
 
+if(SCP_ENABLE_RESOURCE_PERMISSIONS)
+    list(APPEND SCP_MODULES "resource-perms")
+endif()
+
 target_include_directories(
     tc2-bl2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include"
                    "${CMAKE_CURRENT_SOURCE_DIR}/../../common/include"

--- a/product/totalcompute/tc2/scp_ramfw/Firmware.cmake
+++ b/product/totalcompute/tc2/scp_ramfw/Firmware.cmake
@@ -60,7 +60,3 @@ list(APPEND SCP_MODULES "scmi-perf")
 list(APPEND SCP_MODULES "mock-psu")
 list(APPEND SCP_MODULES "psu")
 list(APPEND SCP_MODULES "tc-system")
-
-if(SCP_ENABLE_RESOURCE_PERMISSIONS)
-    list(APPEND SCP_MODULES,"resource-perms")
-endif()


### PR DESCRIPTION
Fix the CMake scripts to correctly include the Resource Permissions module in the ramfw target.
For both TC1 & TC2.