### PR TITLE
morello: Add firmware version information to SDS

### DIFF
--- a/product/morello/include/morello_sds.h
+++ b/product/morello/include/morello_sds.h
@@ -38,7 +38,11 @@ enum morello_sds_region_idx {
  * Structure sizes.
  */
 #define MORELLO_SDS_CPU_INFO_SIZE 4
-#define MORELLO_SDS_FIRMWARE_VERSION_SIZE     8
+#if defined(PLAT_FVP)
+#    define MORELLO_SDS_FIRMWARE_VERSION_SIZE 8
+#else
+#    define MORELLO_SDS_FIRMWARE_VERSION_SIZE 16
+#endif
 #define MORELLO_SDS_PLATFORM_ID_SIZE 8
 #define MORELLO_SDS_RESET_SYNDROME_SIZE 4
 #define MORELLO_SDS_FEATURE_AVAILABILITY_SIZE 4
@@ -55,6 +59,17 @@ enum morello_sds_region_idx {
  */
 #define MORELLO_SILICON_REVISION_R_POS 16
 #define MORELLO_SILICON_REVISION_P_POS 0
+
+/*
+ * Field offsets for PCC and MCC firmware versions
+ */
+#define MORELLO_PCC_FIRMWARE_VERSION_UPPER_POS 16
+#define MORELLO_PCC_FIRMWARE_VERSION_MID_POS   8
+#define MORELLO_PCC_FIRMWARE_VERSION_LOWER_POS 0
+
+#define MORELLO_MCC_FIRMWARE_VERSION_UPPER_POS 16
+#define MORELLO_MCC_FIRMWARE_VERSION_MID_POS   8
+#define MORELLO_MCC_FIRMWARE_VERSION_LOWER_POS 0
 
 /*
  * Field masks and offsets for the MORELLO_SDS_AP_CPU_INFO structure.

--- a/product/morello/include/morello_sds.h
+++ b/product/morello/include/morello_sds.h
@@ -38,7 +38,7 @@ enum morello_sds_region_idx {
  * Structure sizes.
  */
 #define MORELLO_SDS_CPU_INFO_SIZE 4
-#define MORELLO_SDS_FIRMWARE_VERSION_SIZE 4
+#define MORELLO_SDS_FIRMWARE_VERSION_SIZE     8
 #define MORELLO_SDS_PLATFORM_ID_SIZE 8
 #define MORELLO_SDS_RESET_SYNDROME_SIZE 4
 #define MORELLO_SDS_FEATURE_AVAILABILITY_SIZE 4
@@ -61,6 +61,12 @@ enum morello_sds_region_idx {
  */
 #define MORELLO_SDS_CPU_INFO_PRIMARY_MASK 0xFFFFFFFF
 #define MORELLO_SDS_CPU_INFO_PRIMARY_POS 0
+
+/*
+ * Field sizes for SCP firmware version information.
+ */
+
+#define MORELLO_SDS_FIRMWARE_COMMIT_ID_LEN 8
 
 /*
  * Platform information
@@ -86,6 +92,7 @@ struct morello_sds_platid {
 /*
  * Element identifiers for SDS structures
  */
+#define SDS_ELEMENT_IDX_FIRMWARE_VERSION     1
 #define SDS_ELEMENT_IDX_FEATURE_AVAILABILITY 3
 #define SDS_ELEMENT_IDX_PLATFORM_INFO 4
 #endif /* MORELLO_SDS_H */

--- a/product/morello/module/morello_scp2pcc/include/mod_morello_scp2pcc.h
+++ b/product/morello/module/morello_scp2pcc/include/mod_morello_scp2pcc.h
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -28,8 +28,15 @@
  * \{
  */
 
-#define MORELLO_SCP2PCC_PCC_FW_VERSION_LEN (3)
-#define MORELLO_SCP2PCC_MCC_FW_VERSION_LEN (3)
+#define MORELLO_SCP2PCC_PCC_FW_VERSION_LEN         (3)
+#define MORELLO_SCP2PCC_PCC_FW_VERSION_UPPER_INDEX (2)
+#define MORELLO_SCP2PCC_PCC_FW_VERSION_MID_INDEX   (1)
+#define MORELLO_SCP2PCC_PCC_FW_VERSION_LOWER_INDEX (0)
+
+#define MORELLO_SCP2PCC_MCC_FW_VERSION_LEN         (3)
+#define MORELLO_SCP2PCC_MCC_FW_VERSION_UPPER_INDEX (2)
+#define MORELLO_SCP2PCC_MCC_FW_VERSION_MID_INDEX   (1)
+#define MORELLO_SCP2PCC_MCC_FW_VERSION_LOWER_INDEX (0)
 
 #define MORELLO_SCP2PCC_BOARD_SERIAL_NUM_LEN (16)
 

--- a/product/morello/scp_ramfw_soc/config_sds.c
+++ b/product/morello/scp_ramfw_soc/config_sds.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -21,7 +21,6 @@
 
 #include <stdbool.h>
 
-static const uint32_t version_packed = FWK_BUILD_VERSION;
 static const uint32_t feature_flags = 0x00000000;
 
 static const struct mod_sds_region_desc
@@ -64,7 +63,6 @@ static struct fwk_element sds_element_table[8] = {
         .data = &((struct mod_sds_structure_desc){
             .id = MORELLO_SDS_FIRMWARE_VERSION,
             .size = MORELLO_SDS_FIRMWARE_VERSION_SIZE,
-            .payload = &version_packed,
             .finalize = true,
         }),
     },

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -132,6 +132,9 @@ shadowVariable:*framework/test/test_fwk_notification.c:120
 AssignmentAddressToInteger:*product/rdv1/module/platform_system/src/mod_platform_system.c:143
 AssignmentAddressToInteger:*product/rdv1mc/module/platform_system/src/mod_platform_system.c:146
 
+// Cppcheck seems to get confused with macro substitution
+syntaxError:*product/morello/module/morello_system/src/mod_morello_system.c:296
+
 // TODO
 arrayIndexOutOfBoundsCond:*module/cmn600/src/mod_cmn600.c:447
 arrayIndexOutOfBoundsCond:*module/cmn600/src/mod_cmn600.c:461

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -133,7 +133,7 @@ AssignmentAddressToInteger:*product/rdv1/module/platform_system/src/mod_platform
 AssignmentAddressToInteger:*product/rdv1mc/module/platform_system/src/mod_platform_system.c:146
 
 // Cppcheck seems to get confused with macro substitution
-syntaxError:*product/morello/module/morello_system/src/mod_morello_system.c:296
+syntaxError:*product/morello/module/morello_system/src/mod_morello_system.c:300
 
 // TODO
 arrayIndexOutOfBoundsCond:*module/cmn600/src/mod_cmn600.c:447


### PR DESCRIPTION
Adds a firmware information structure to the SDS region on Morello, containing Morello-specific SCP, PCC, and MCC version information. This is to provide access to this versioning in further firmware stages. Additional commit resolves I2C issues where multiple SCP2PCC requests are made in succession, such as when fetching the PCC and MCC versions.