### PR TITLE
interface: `AMU`

### DIFF
--- a/interface/amu/doc/amu.md
+++ b/interface/amu/doc/amu.md
@@ -1,0 +1,32 @@
+
+# AMU Interface
+Copyright (c) 2023, Arm Limited. All rights reserved.
+## Overview
+The `AMU` interface provides an API to be implemented by multiple modules
+(`AMU` drivers).
+
+
+This will allow multiple modules to have the same interface while the
+implementation is different.
+i.e. It abstracts the knowledge of the API user from the implementation,
+which makes it more flexible and platform-agnostic.
+
+The `AMU` API retrieves the AMU data from the hardware.
+The implementation will copy any number of the available counters into the
+buffer provided by the caller. It's the caller's responsibility to ensure
+the buffer (memory) is valid and not overridden during the API call.
+## Use
+To use the AMU interface it requires to add the include path in the
+respective module `CMakeLists.txt` file.
+``` CMAKE
+target_include_directories(${SCP_MODULE_TARGET} PUBLIC
+                          "${CMAKE_SOURCE_DIR}/interface/amu/")
+```
+Then simply include `interface_amu.h` file to use all AMU interface
+definitions.
+
+### Example
+```C
+    /* `api` holds the concrete implementation of the interface. */
+   api->get_counters(start_counter_id, amu_buff, num_counters);
+```

--- a/interface/amu/interface_amu.h
+++ b/interface/amu/interface_amu.h
@@ -1,0 +1,74 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Description:
+ *     AMU interface
+ */
+
+#ifndef INTERFACE_AMU_H
+#define INTERFACE_AMU_H
+
+#include <fwk_id.h>
+
+#include <stddef.h>
+
+/*!
+ * \addtogroup GroupInterfaces Interfaces
+ * \{
+ */
+
+/*!
+ * \defgroup GroupAmu Activity Monitor Unit counters interface
+ *
+ * \brief Interface definition for AMU drivers.
+ *
+ * \details This interface should be implemented by drivers to access
+ *          AMU counters.
+ * \{
+ */
+
+/*!
+ * \defgroup GroupAmuApis APIs
+ * \{
+ */
+
+/*!
+ * \brief AMU API to retrieve the AMU counters.
+ */
+struct amu_api {
+    /*!
+     * \brief Get the AMU counters value starting from the given counter ID
+     *
+     * \param start_counter_id ID of the counter to start from.
+     * \param[out] counter_buff Pointer to a buffer to be filled with the
+     *                          counters values.
+     * \param num_counter The number of the counters requested.
+     *
+     * \note \b counter_buff must have space for \b num_counter elements.
+     * \retval ::FWK_E_PARAM One or more parameters were invalid.
+     * \retval ::FWK_E_RANGE Number of counters requested is out of range.
+     * \retval ::FWK_SUCCESS The request was successfully completed.
+     * \return One of the standard framework status codes.
+     */
+    int (*get_counters)(
+        fwk_id_t start_counter_id,
+        uint64_t *counter_buff,
+        size_t num_counter);
+};
+
+/*!
+ * \}
+ */
+
+/*!
+ * \}
+ */
+
+/*!
+ * \}
+ */
+
+#endif /* INTERFACE_AMU_H */


### PR DESCRIPTION
Add AMU interface definition.

The interface introduces an API to get the `AMU` counters of CPUs.

The definition of `AMU` interface to be implemented by multiple
drivers as counters access from SCP differs across platforms.
    

