### PR TITLE
morello: print the temperature sensor values during boot

### DIFF
--- a/product/morello/module/morello_system/CMakeLists.txt
+++ b/product/morello/module/morello_system/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021-2022, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -27,5 +27,7 @@ target_link_libraries(
             module-dmc-bing)
 
 if(NOT SCP_ENABLE_PLAT_FVP)
-target_link_libraries(${SCP_MODULE_TARGET} PRIVATE module-morello-scp2pcc)
+target_link_libraries(
+        ${SCP_MODULE_TARGET} PRIVATE module-morello-scp2pcc
+                                     module-morello-sensor module-sensor)
 endif()

--- a/product/morello/module/morello_system/include/mod_morello_system.h
+++ b/product/morello/module/morello_system/include/mod_morello_system.h
@@ -75,6 +75,22 @@ struct mod_morello_system_ap_memory_access_api {
     void (*disable_ap_memory_access)(void);
 };
 
+#if !defined(PLAT_FVP)
+enum mod_morello_system_temperature_sensor_idx {
+    /*! Index for morello system cluster 0 temperature sensor */
+    MOD_MORELLO_SYSTEM_CLUSTER0_SENSOR,
+
+    /*! Index for morello system cluster 1 temperature sensor */
+    MOD_MORELLO_SYSTEM_CLUSTER1_SENSOR,
+
+    /*! Index for morello system system temperature sensor */
+    MOD_MORELLO_SYSTEM_SENSOR,
+
+    /*! Number of temperature sensors */
+    MOD_MORELLO_SYSTEM_SENSOR_COUNT,
+};
+#endif
+
 /*!
  * \}
  */


### PR DESCRIPTION
Currently, on SCP, there is no way for users to get CPU temperature values during or after boot. This change will show reference temperature values during boot, so that the alarm or shutdown threshold does not come as a surprise.


Change-Id: I6079a750d4aeaa7768784aee640919cf2faa76b0