### PR TITLE
interface/cmn: Add a interface for CMN drivers

### DIFF
--- a/interface/cmn/doc/cmn.md
+++ b/interface/cmn/doc/cmn.md
@@ -1,0 +1,25 @@
+# CMN Interface
+Copyright (c) 2023, Arm Limited. All rights reserved.
+## Overview
+The CMN interface provides a standard API to be implemented by multiple
+modules (CMN drivers).
+
+This will allow multiple modules to have the same interface.
+but having different internal implementations.
+i.e. It abstracts the knowledge of the API user from the implementation,
+    which makes it more flexible and platform-agnostic
+## Use
+    To use the CMN interface it requires to add the include path in the
+    respective module `CMakeLists.txt` file.
+    ``` CMAKE
+    target_include_directories(${SCP_MODULE_TARGET} PUBLIC
+                                      "${CMAKE_SOURCE_DIR}/interface/cmn/")
+    ```
+    Then simply include `interface_cmn.h` file to use all CMN interface
+    definitions.
+
+### Example
+    ```C
+        /* `api` holds the concrete implementation of the interface. */
+       api->map_io_region(uint64_t base, size_t size, uint32_t node_id);
+       ```

--- a/interface/cmn/interface_cmn.h
+++ b/interface/cmn/interface_cmn.h
@@ -1,0 +1,58 @@
+/*
+ * Arm SCP/MCP Software
+ * Copyright (c) 2023, Arm Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef INTERFACE_CMN_H
+#define INTERFACE_CMN_H
+
+#include <fwk_id.h>
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*!
+ * \addtogroup GroupInterfaces Interfaces
+ * @{
+ */
+
+/*!
+ * \defgroup GroupCmn CMN module interface
+ *
+ * \brief Interface definition for CMN drivers.
+ *
+ * \details This provides an generic interface for the modules to bind to a
+ *          platform specific CMN module.
+ * @{
+ */
+
+/*!
+ * \brief CMN interface to manage mappings in RN-SAM
+ */
+struct interface_cmn_memmap_rnsam_api {
+    /*!
+     * \brief Program or update the given IO memory carveout in the RN-SAM of
+     *        all the nodes
+     * \param base Base address of the carveout to be mapped
+     * \param size Size of the carveout
+     * \param node_id Target node id to which carveout will be mapped
+     *
+     * \retval ::FWK_SUCCESS on successfully mapping the region
+     * \retval ::FWK_E_DATA if mapping region is invalid
+     * \return One of the standard framework status codes
+     */
+    int (*map_io_region)(uint64_t base, size_t size, uint32_t node_id);
+};
+
+/*!
+ * @}
+ */
+
+/*!
+ * @}
+ */
+
+#endif /* INTERFACE_CMN_H */

--- a/module/cmn700/CMakeLists.txt
+++ b/module/cmn700/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Arm SCP/MCP Software
-# Copyright (c) 2021, Arm Limited and Contributors. All rights reserved.
+# Copyright (c) 2021-2023, Arm Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -8,6 +8,7 @@ add_library(${SCP_MODULE_TARGET} SCP_MODULE)
 
 target_include_directories(${SCP_MODULE_TARGET}
                            PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include"
+                           PUBLIC "${CMAKE_SOURCE_DIR}/interface/cmn"
                            PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 target_sources(

--- a/module/cmn700/include/mod_cmn700.h
+++ b/module/cmn700/include/mod_cmn700.h
@@ -416,23 +416,6 @@ enum mod_cmn700_api_idx {
 };
 
 /*!
- * \brief Module interface to manage mappings in RN-SAM
- */
-struct mod_cmn700_memmap_rnsam_api {
-    /*!
-     * \brief Program or update the given IO memory carveout in the RN-SAM of
-     *        all the nodes
-     * \param base Base address of the carveout to be mapped
-     * \param size Size of the carveout
-     * \param node_id Target node id to which carveout will be mapped
-     *
-     * \return FWK_SUCCESS on successfully mapping the region
-     * \return FWK_E_DATA if mapping region is invalid
-     */
-    int (*map_io_region)(uint64_t base, size_t size, uint32_t node_id);
-};
-
-/*!
  * @}
  */
 

--- a/module/cmn700/src/mod_cmn700.c
+++ b/module/cmn700/src/mod_cmn700.c
@@ -7,13 +7,14 @@
 
 #include <cmn700.h>
 #include <cmn700_ccg.h>
-
 #include <internal/cmn700_ctx.h>
 
 #include <mod_clock.h>
 #include <mod_cmn700.h>
 #include <mod_system_info.h>
 #include <mod_timer.h>
+
+#include <interface_cmn.h>
 
 #include <fwk_assert.h>
 #include <fwk_event.h>
@@ -1233,7 +1234,7 @@ static int cmn700_process_notification(
     return FWK_SUCCESS;
 }
 
-static struct mod_cmn700_memmap_rnsam_api memmap_rnsam_api = {
+static struct interface_cmn_memmap_rnsam_api memmap_rnsam_api = {
     .map_io_region = map_io_region,
 };
 


### PR DESCRIPTION
CMN module drivers can change between platforms; this makes it challenging to write a generic module that uses CMN APIs to map regions during runtime.
Add a generic API interface that CMN modules use to define their APIs and use the module ID provided by the platform configuration to bind to the correct CMN module.
