### PR TITLE
cmn700: fix address and size alignment check.

### DIFF
--- a/module/cmn700/src/cmn700.c
+++ b/module/cmn700/src/cmn700.c
@@ -242,7 +242,7 @@ bool is_region_aligned(
     uint64_t lsb_addr_mask;
 
     lsb_addr_mask = get_rnsam_lsb_addr_mask(rnsam, sam_type);
-    return ((mmap->base & ~lsb_addr_mask) & (mmap->size & ~lsb_addr_mask)) == 0;
+    return ((mmap->base & lsb_addr_mask) | (mmap->size & lsb_addr_mask)) == 0;
 }
 
 bool is_non_hash_region_mapped(


### PR DESCRIPTION
Fix the logical error in the cmn700 address alignment check. Due to the logical error, the check only failed if the address and size were unaligned.

Updated the logic to allow it to fail if either value is unaligned. Also fixed the wrong address mask calculation.
