### PR TITLE
Halt SCP boot if DDR4 training fails for morello and n1sdp

### DIFF
--- a/product/morello/module/dmc_bing/src/mod_dmc_bing.c
+++ b/product/morello/module/dmc_bing/src/mod_dmc_bing.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2018-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -1427,7 +1427,8 @@ static int dmc_bing_config(struct mod_dmc_bing_reg *dmc, fwk_id_t ddr_id)
 #if !defined(PLAT_FVP)
     status = ddr_training(dmc, ddr_id, &ddr_info);
     if (status != FWK_SUCCESS) {
-        return status;
+        FWK_LOG_ERR("[DDR] DDR training failed on DMC ID %d!", dmc_id);
+        fwk_trap();
     }
 
     status = morello_ddr_phy_post_training_configure(ddr_id, &ddr_info);

--- a/product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c
+++ b/product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2019-2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2019-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -1177,7 +1177,8 @@ static int dmc620_config(struct mod_dmc620_reg *dmc, fwk_id_t ddr_id)
 
     status = ddr_training(dmc, ddr_id, &ddr_info);
     if (status != FWK_SUCCESS) {
-        return status;
+        FWK_LOG_ERR("[DDR] DDR training failed on DMC ID %d!", dmc_id);
+        fwk_trap();
     }
 
     status = ddr_phy_api->post_training_configure(ddr_id, &ddr_info);

--- a/tools/cppcheck_suppress_list.txt
+++ b/tools/cppcheck_suppress_list.txt
@@ -75,8 +75,8 @@ nullPointerRedundantCheck:*module/sds/src/mod_sds.c:279
 nullPointerRedundantCheck:*module/timer/src/mod_timer.c:541
 nullPointerRedundantCheck:*module/timer/src/mod_timer.c:551
 nullPointerRedundantCheck:*module/timer/src/mod_timer.c:546
-nullPointerRedundantCheck:*product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c:1275
 nullPointerRedundantCheck:*product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c:1276
+nullPointerRedundantCheck:*product/n1sdp/module/n1sdp_dmc620/src/mod_n1sdp_dmc620.c:1277
 nullPointerRedundantCheck:*module/dmc620/src/mod_dmc620.c:61
 nullPointerRedundantCheck:*product/synquacer/module/f_uart3/src/mod_f_uart3.c:111
 nullPointerRedundantCheck:*product/synquacer/module/f_uart3/src/mod_f_uart3.c:112


### PR DESCRIPTION
Currently, the SCP boot continues if the DDR4 training fails, the boot then later hangs when it reaches tf-a stage. These patches will halt the boot in SCP itself.