### PR TITLE
Fix/amu mmap allocation

### DIFF
--- a/module/amu_mmap/src/mod_amu_mmap.c
+++ b/module/amu_mmap/src/mod_amu_mmap.c
@@ -113,7 +113,8 @@ static int amu_mmap_element_init(
         (struct mod_core_element_config *)data;
     amu_mmap.core[core_idx].num_counters = sub_element_count;
 
-    if (amu_mmap.core[core_idx].core_config->counters_base_addr == NULL) {
+    if (amu_mmap.core[core_idx].core_config->counters_base_addr == NULL ||
+        amu_mmap.core[core_idx].core_config->counters_offsets == NULL) {
         return FWK_E_ACCESS;
     }
 

--- a/module/amu_mmap/src/mod_amu_mmap.c
+++ b/module/amu_mmap/src/mod_amu_mmap.c
@@ -91,7 +91,7 @@ static int amu_mmap_init(
     }
 
     amu_mmap.core =
-        fwk_mm_calloc(core_count, sizeof(struct mod_core_amu_counters *));
+        fwk_mm_calloc(core_count, sizeof(struct mod_core_amu_counters));
     amu_mmap.core_count = core_count;
 
     return FWK_SUCCESS;

--- a/module/amu_mmap/test/mod_amu_mmap_unit_test.c
+++ b/module/amu_mmap/test/mod_amu_mmap_unit_test.c
@@ -77,6 +77,7 @@ void test_amu_mmap_element_init_bad_params_fail(void)
     int status = FWK_E_PANIC;
     fwk_id_t element_id;
 
+    /* Invalid element ID */
     fwk_module_is_valid_element_id_ExpectAnyArgsAndReturn(false);
     status = amu_mmap_element_init(element_id, 0, NULL);
     TEST_ASSERT_EQUAL(FWK_E_PARAM, status);
@@ -85,6 +86,22 @@ void test_amu_mmap_element_init_bad_params_fail(void)
     fwk_module_is_valid_element_id_ExpectAnyArgsAndReturn(true);
     status = amu_mmap_element_init(element_id, 0, NULL);
     TEST_ASSERT_EQUAL(FWK_E_PARAM, status);
+}
+
+void test_amu_mmap_element_init_null_counters_offsets_fail(void)
+{
+    int status = FWK_E_PANIC;
+    fwk_id_t element_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_AMU_MMAP, CORE0_IDX);
+    struct mod_core_element_config core_config;
+
+    /* counters_offsets is NULL*/
+    core_config.counters_base_addr = amu_counters[CORE0_IDX];
+    core_config.counters_offsets = NULL;
+    fwk_module_is_valid_element_id_ExpectAnyArgsAndReturn(true);
+    fwk_id_get_element_idx_ExpectAndReturn(element_id, CORE0_IDX);
+    status =
+        amu_mmap_element_init(element_id, NUM_OF_COREA_COUNTERS, &core_config);
+    TEST_ASSERT_EQUAL(FWK_E_ACCESS, status);
 }
 
 void test_amu_mmap_element_init_success(void)
@@ -234,6 +251,7 @@ int amu_mmap_test_main(void)
     RUN_TEST(test_amu_mmap_init_zero_cores_fail);
     RUN_TEST(test_amu_mmap_init_success);
     RUN_TEST(test_amu_mmap_element_init_bad_params_fail);
+    RUN_TEST(test_amu_mmap_element_init_null_counters_offsets_fail);
     RUN_TEST(test_amu_mmap_element_init_success);
     RUN_TEST(test_amu_mmap_bind_request_amu_api_bad_params_fail);
     RUN_TEST(test_amu_mmap_bind_request_amu_api_success);

--- a/module/amu_mmap/test/mod_amu_mmap_unit_test.c
+++ b/module/amu_mmap/test/mod_amu_mmap_unit_test.c
@@ -88,6 +88,22 @@ void test_amu_mmap_element_init_bad_params_fail(void)
     TEST_ASSERT_EQUAL(FWK_E_PARAM, status);
 }
 
+void test_amu_mmap_element_init_null_counters_base_addr_fail(void)
+{
+    int status = FWK_E_PANIC;
+    fwk_id_t element_id = FWK_ID_ELEMENT(FWK_MODULE_IDX_AMU_MMAP, CORE0_IDX);
+    struct mod_core_element_config core_config;
+
+    /* counters_base_addr is NULL*/
+    core_config.counters_base_addr = NULL;
+    core_config.counters_offsets = core_a_layout;
+    fwk_module_is_valid_element_id_ExpectAnyArgsAndReturn(true);
+    fwk_id_get_element_idx_ExpectAndReturn(element_id, CORE0_IDX);
+    status =
+        amu_mmap_element_init(element_id, NUM_OF_COREA_COUNTERS, &core_config);
+    TEST_ASSERT_EQUAL(FWK_E_ACCESS, status);
+}
+
 void test_amu_mmap_element_init_null_counters_offsets_fail(void)
 {
     int status = FWK_E_PANIC;
@@ -251,6 +267,7 @@ int amu_mmap_test_main(void)
     RUN_TEST(test_amu_mmap_init_zero_cores_fail);
     RUN_TEST(test_amu_mmap_init_success);
     RUN_TEST(test_amu_mmap_element_init_bad_params_fail);
+    RUN_TEST(test_amu_mmap_element_init_null_counters_base_addr_fail);
     RUN_TEST(test_amu_mmap_element_init_null_counters_offsets_fail);
     RUN_TEST(test_amu_mmap_element_init_success);
     RUN_TEST(test_amu_mmap_bind_request_amu_api_bad_params_fail);

--- a/module/amu_mmap/test/mod_amu_mmap_unit_test.c
+++ b/module/amu_mmap/test/mod_amu_mmap_unit_test.c
@@ -62,7 +62,7 @@ void test_amu_mmap_init_success(void)
     int status = FWK_E_PANIC;
     memset(&amu_mmap, 0, sizeof(amu_mmap));
     fwk_mm_calloc_ExpectAndReturn(
-        CORE_COUNT, sizeof(struct mod_core_amu_counters *), core);
+        CORE_COUNT, sizeof(struct mod_core_amu_counters), core);
 
     status =
         amu_mmap_init(FWK_ID_MODULE(FWK_MODULE_IDX_AMU_MMAP), CORE_COUNT, NULL);


### PR DESCRIPTION
This change is to fix the following bug:
During amu_mmap_init, struct mod_core_amu_counters array with size
equal to the number of cores that should be allocated.
Instead, an array of struct mod_core_amu_counters pointers
are allocated.
Along with unit tests for AMU `counters_base_addr`  and `counters_offsets`