### PR TITLE
fix/unit-test: add variable initialization

### DIFF
--- a/module/scmi_sensor_req/test/mod_scmi_sensor_req_unit_test.c
+++ b/module/scmi_sensor_req/test/mod_scmi_sensor_req_unit_test.c
@@ -1,6 +1,6 @@
 /*
  * Arm SCP/MCP Software
- * Copyright (c) 2022, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2022-2023, Arm Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -201,7 +201,7 @@ void test_function_scmi_sensor_req_ret_reading_handler(void)
             ->service_id;
 
     fwk_id_t error_service_id = { .value = 0xFFFF };
-    struct mod_sensor_driver_resp_params expected_resp_params;
+    struct mod_sensor_driver_resp_params expected_resp_params = { 0 };
     uint32_t payload[10] = { 0 };
 
     expected_resp_params = (struct mod_sensor_driver_resp_params){

--- a/module/smcf/test/smcf_data/smcf_data_unit_test.c
+++ b/module/smcf/test/smcf_data/smcf_data_unit_test.c
@@ -1460,7 +1460,7 @@ void utest_smcf_data_get_data_success_copy_data(void)
     int status = FWK_E_STATE;
     uint32_t mli_index = 0;
     uint32_t data[2] = { 0xAA, 0x55 };
-    uint32_t buffer[2];
+    uint32_t buffer[2] = { 0 };
     uint32_t tag;
     struct smcf_data_attr data_attr = {
         .data_addr = data,


### PR DESCRIPTION
There are some variables unitilialized for testing resulting in unexpected behaviour.
This patch fixes that giving them a default `0` value to ensure that all bytes are zeroed.


Change-Id: I29265f415bd9f9b1462884da7bc97ef83f1581a0