### PR TITLE
requirements.txt: update python module requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-clang-format==9.0.0
+clang-format==14.0.0
 cmake-format==0.6.13
 colorama==0.4.3
 docker==4.3.1
 pycodestyle==2.6.0
 ruamel.yaml==0.16.12
 yamllint==1.25.0
-dataclasses==0.7; python_version < '3.7'


### PR DESCRIPTION
This patch updates `requirements.txt` file since dataclasses are now part of all non-deprecated `python3` versions. `clang-format` is also updated to a newer version.


Change-Id: I51bbe8fd5c3399aab9fcbb37eab48d2f7243f64c