### PR TITLE
scmi_perf: Correct the return status of scmi_perf_process_event

### DIFF
--- a/module/scmi_perf/src/mod_scmi_perf.c
+++ b/module/scmi_perf/src/mod_scmi_perf.c
@@ -622,18 +622,12 @@ static int scmi_perf_process_event(
     struct fwk_event *resp_event)
 {
 #ifdef BUILD_HAS_SCMI_PERF_PROTOCOL_OPS
-    int status;
-
     if ((fwk_id_get_module_idx(event->source_id) ==
          fwk_id_get_module_idx(fwk_module_id_scmi)) ||
         (fwk_id_get_module_idx(event->source_id) ==
          fwk_id_get_module_idx(fwk_module_id_dvfs))) {
         /* Handle requests from SCMi and responses from DVFS */
-        status = perf_prot_ops_process_events(event, resp_event);
-
-        if (status != FWK_SUCCESS) {
-            return status;
-        }
+        return perf_prot_ops_process_events(event, resp_event);
     }
 #endif
 


### PR DESCRIPTION
Currently, when perf_prot_ops_process_events function returns successfully the scmi_perf_process_event function returns an error condition. Correct this behaviour so that the function does not return an error condition during successful case.
